### PR TITLE
chore: bump version to 0.2.5 and clean up debug logs

### DIFF
--- a/qcut/apps/web/src/hooks/use-selection-box.ts
+++ b/qcut/apps/web/src/hooks/use-selection-box.ts
@@ -161,17 +161,13 @@ export function useSelectionBox({
     };
 
     const handleMouseUp = () => {
-      console.log(
-        JSON.stringify({ mouseUp: { wasActive: selectionBox?.isActive } })
-      );
+      // Debug logging removed for production
 
       // If we had an active selection, mark that we just finished selecting
       if (selectionBox?.isActive) {
-        console.log(JSON.stringify({ settingJustFinishedSelecting: true }));
         setJustFinishedSelecting(true);
         // Clear the flag after a short delay to allow click events to check it
         setTimeout(() => {
-          console.log(JSON.stringify({ clearingJustFinishedSelecting: true }));
           setJustFinishedSelecting(false);
         }, 50);
       }

--- a/qcut/apps/web/src/hooks/use-timeline-playhead.ts
+++ b/qcut/apps/web/src/hooks/use-timeline-playhead.ts
@@ -58,24 +58,7 @@ export function useTimelinePlayhead({
       const projectFps = projectStore.activeProject?.fps || 30;
       const time = snapTimeToFrame(rawTime, projectFps);
 
-      // Debug logging
-      if (rawX < 0 || x !== rawX) {
-        console.log(
-          "PLAYHEAD DEBUG:",
-          JSON.stringify({
-            mouseX: e.clientX,
-            rulerLeft: rect.left,
-            rawX,
-            constrainedX: x,
-            timelineContentWidth,
-            rawTime,
-            finalTime: time,
-            duration,
-            zoomLevel,
-            playheadPx: time * 50 * zoomLevel,
-          })
-        );
-      }
+      // Debug logging removed for production
 
       setScrubTime(time);
       seek(time); // update video preview in real time

--- a/qcut/package.json
+++ b/qcut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qcut",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "QCut - Open-source video editor",
   "author": "QCut Team",
   "main": "electron/main.js",


### PR DESCRIPTION
## Summary
- Bumped version from 0.2.4 to 0.2.5
- Cleaned up debug console.log statements in hooks

## Changes
- Updated package.json version to 0.2.5
- Removed unnecessary console.log statements from use-selection-box.ts
- Removed debug logging from use-timeline-playhead.ts

## Test plan
- [x] Version bump applied correctly
- [x] No functional changes, only cleanup
- [x] Application builds and runs without errors