### PR TITLE
fix(ci): fix release workflow artifact uploads

### DIFF
--- a/qcut/.github/workflows/release.yml
+++ b/qcut/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           name: windows-build
           path: |
             dist-electron/QCut*Setup*.exe
-            dist-electron/*.yml
+            dist-electron/latest.yml
           if-no-files-found: error
 
   # macOS build
@@ -135,7 +135,7 @@ jobs:
           path: |
             dist-electron/*.dmg
             dist-electron/*.zip
-            dist-electron/*.yml
+            dist-electron/latest-mac.yml
           if-no-files-found: error
 
   # Linux build
@@ -184,7 +184,7 @@ jobs:
           path: |
             dist-electron/*.AppImage
             dist-electron/*.deb
-            dist-electron/*.yml
+            dist-electron/latest-linux.yml
           if-no-files-found: error
 
   # Create release with all artifacts


### PR DESCRIPTION
## Summary
- Exclude `builder-debug.yml` from artifact uploads (use specific filenames instead of `*.yml`)
- Combined with `--publish never` from previous merge, fixes the 404 race condition where electron-builder and softprops/action-gh-release both tried to manage the same release assets

## Test plan
- [ ] CI checks pass
- [ ] Trigger a release after merge and verify all assets upload successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release artifact publishing process to ensure platform-specific release files are correctly uploaded and made available in GitHub Releases for Windows, macOS, and Linux builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->