### PR TITLE
fix: resolve TypeScript errors in remotion-bundler.ts for Windows build

### DIFF
--- a/qcut/electron/remotion-bundler.ts
+++ b/qcut/electron/remotion-bundler.ts
@@ -107,7 +107,7 @@ const EXTERNAL_PACKAGES = [
 /**
  * Get esbuild dynamically to avoid bundling issues.
  */
-async function getEsbuild(): Promise<typeof import("esbuild")> {
+async function getEsbuild(): Promise<any> {
   try {
     // Try to require esbuild
     return require("esbuild");
@@ -295,7 +295,7 @@ export async function bundleComposition(
 
     // Extract output
     const outputFile = result.outputFiles?.find(
-      (f) => f.path.endsWith(".js") || f.path === "<stdout>"
+      (f: any) => f.path.endsWith(".js") || f.path === "<stdout>"
     );
 
     if (!outputFile) {


### PR DESCRIPTION
## Changes
- Fixed \emotion-bundler.ts\ TypeScript compilation errors:
  - Changed \getEsbuild()\ return type from \	ypeof import('esbuild')\ to \ny\ (esbuild types not installed)
  - Added explicit \ny\ type annotation for \\ parameter in \outputFiles.find()\`n
## Context
- These errors blocked \un run build\ on Windows
- Web build (vite/turbo) passes fine, only electron tsc step was failing
- Minimal fix to unblock builds without adding new dependencies