### PR TITLE
docs: add stability hardening plan and refactor plan v4

### DIFF
--- a/qcut/docs/task/large-files-refactor-plan-v4.md
+++ b/qcut/docs/task/large-files-refactor-plan-v4.md
@@ -1,0 +1,229 @@
+# Large Files Refactoring Plan v4 — Next 5 Medium-Risk Files
+
+> Generated: 2026-02-24 | Continues from: large-files-refactor-plan-v3.md (10 files DONE total)
+> **STATUS: PENDING**
+
+---
+
+## Selection Criteria
+
+Previous rounds targeted low-risk files (pure data, types, utilities). This round tackles **medium-risk** files — handlers, generators, and UI components with clear internal boundaries. Files were chosen for:
+- High splittability (clear section boundaries)
+- Low consumer count (1–8 files)
+- Independent sections with minimal cross-dependencies
+
+---
+
+## 1. `electron/screen-recording-handler.ts` (1,075 lines)
+
+### Analysis
+- **Layered handler** with clear separation: types → utilities → file I/O → transcoding → IPC setup.
+- Sections:
+  - **Types & Constants** (lines 1-132): `SCREEN_SOURCE_TYPE`, `SCREEN_RECORDING_STATE`, `OUTPUT_FORMAT`, interfaces (~132 lines)
+  - **Path Utilities** (lines 137-307): `sanitizeFilename()`, `ensureExtension()`, `resolveOutputFormat()`, `getRecordingsDir()`, `buildDefaultRecordingPath()`, `resolveOutputPath()` (~170 lines)
+  - **File Operations** (lines 309-580): `buildCaptureFilePath()`, `ensureParentDirectory()`, `listCaptureSources()`, `pickSource()`, `waitForStreamOpen()`, `writeChunk()`, `closeStream()`, `moveFile()` (~270 lines)
+  - **Transcoding & Output** (lines 581-704): `transcodeWebmToMp4()`, `finalizeRecordingOutput()`, `cleanupSessionFiles()` (~125 lines)
+  - **Session State** (lines 705-825): `buildStatus()`, `resolveSourceForDisplayRequest()`, `ensureDisplayMediaHandlerConfigured()` (~120 lines)
+  - **IPC Setup** (lines 827-1076): `setupScreenRecordingIPC()` — registers 5 handlers (~250 lines)
+- **Consumers (2 files):** `utility-bridge.ts`, documentation
+
+### Plan: Split by layer
+```text
+electron/screen-recording-handler/
+  types.ts               → Constants (SCREEN_SOURCE_TYPE, SCREEN_RECORDING_STATE, OUTPUT_FORMAT),
+                            all interfaces (~132 lines)
+  path-utils.ts          → sanitizeFilename, ensureExtension, getPathExtension,
+                            resolveOutputFormat, replaceExtension, normalizeOutputPathExtension,
+                            getRecordingsDir, formatDateSegment, buildDefaultRecordingPath,
+                            assertPathWithinAllowedDir, resolveOutputPath (~170 lines)
+  file-ops.ts            → buildCaptureFilePath, ensureParentDirectory, mapSourceType,
+                            listCaptureSources, getCurrentWindowSourceId, pickSource,
+                            waitForStreamOpen, writeChunk, appendChunkToSession,
+                            closeStream, removeFileIfExists, moveFile, getFileSize (~270 lines)
+  transcoder.ts          → transcodeWebmToMp4, finalizeRecordingOutput,
+                            cleanupSessionFiles (~125 lines)
+  session.ts             → buildStatus, resolveSourceForDisplayRequest,
+                            ensureDisplayMediaHandlerConfigured, session state (~120 lines)
+  ipc.ts                 → setupScreenRecordingIPC (imports from above) (~250 lines)
+  index.ts               → re-exports setupScreenRecordingIPC + types
+```
+
+- `from "./screen-recording-handler"` resolves to directory `index.ts` — **zero import changes**.
+- **Internal dependencies:** `ipc.ts` → `session.ts` → `transcoder.ts` → `file-ops.ts` → `path-utils.ts` → `types.ts`. Clean one-directional dependency chain.
+- **Risk: Low** — 2 consumers, layered architecture, barrel preserves API.
+
+---
+
+## 2. `apps/web/src/lib/ai-video/generators/text-to-video.ts` (866 lines)
+
+### Analysis
+- **Generator module** with one function per AI model, plus a shared payload builder.
+- Sections:
+  - **Imports & Docs** (lines 1-53): Type/validator imports (~53 lines)
+  - **`generateVideo()`** (lines 73-283): Main entry point with queue polling (~210 lines)
+  - **`generateVideoFromText()`** (lines 292-373): Hailuo 2.3 text-to-video (~80 lines)
+  - **`generateLTXV2Video()`** (lines 380-468): LTX Video 2.0 with audio (~90 lines)
+  - **`generateWAN26TextVideo()`** (lines 480-633): WAN v2.6 with multi-shot (~155 lines)
+  - **`generateViduQ3TextVideo()`** (lines 645-776): Vidu Q3 with multi-resolution (~130 lines)
+  - **`buildTextToVideoPayload()`** (lines 785-866): Payload construction helper (~80 lines)
+- **Consumers (4 code files):** `ai-video/index.ts`, `model-handlers.ts`, `model-handler-implementations.ts`, + tests
+
+### Plan: Split by model family
+```text
+apps/web/src/lib/ai-video/generators/text-to-video/
+  shared.ts              → buildTextToVideoPayload(), shared types/imports (~100 lines)
+  generate-video.ts      → generateVideo() main entry with queue polling (~230 lines)
+  hailuo-generator.ts    → generateVideoFromText() for Hailuo 2.3 (~100 lines)
+  ltxv2-generator.ts     → generateLTXV2Video() for LTX Video 2.0 (~110 lines)
+  wan26-generator.ts     → generateWAN26TextVideo() for WAN v2.6 (~175 lines)
+  vidu-generator.ts      → generateViduQ3TextVideo() for Vidu Q3 (~150 lines)
+  index.ts               → re-exports all public functions
+```
+
+- `from "../generators/text-to-video"` resolves to directory `index.ts` — **zero import changes**.
+- **Internal dependencies:** Each model generator imports from `shared.ts`. `generate-video.ts` calls individual generators by model type. No cross-model dependencies.
+- **Risk: Low** — 4 code consumers, function-per-model is natural split, barrel preserves API.
+
+---
+
+## 3. `electron/native-pipeline/cli/vimax-cli-handlers.ts` (830 lines)
+
+### Analysis
+- **10 independent handler functions** with zero inter-dependencies. Each handler follows the same pattern: validate input → import dependencies → process → return result.
+- Sections:
+  - `handleVimaxExtractCharacters()` (lines 25-88, ~64 lines)
+  - `handleVimaxGenerateScript()` (lines 91-148, ~58 lines)
+  - `handleVimaxGenerateStoryboard()` (lines 151-253, ~103 lines)
+  - `handleVimaxGeneratePortraits()` (lines 256-402, ~147 lines)
+  - `handleVimaxCreateRegistry()` (lines 405-483, ~79 lines)
+  - `handleVimaxShowRegistry()` (lines 486-543, ~58 lines)
+  - `handleVimaxIdea2Video()` (lines 546-629, ~84 lines)
+  - `handleVimaxScript2Video()` (lines 632-710, ~79 lines)
+  - `handleVimaxNovel2Movie()` (lines 713-778, ~66 lines)
+  - `handleVimaxListModels()` (lines 781-829, ~49 lines)
+- **Consumers (3 code files):** `cli-runner/runner.ts`, `manager.ts`, self-reference
+
+### Plan: Group by domain
+```text
+electron/native-pipeline/cli/vimax-cli-handlers/
+  character-handlers.ts  → handleVimaxExtractCharacters,
+                            handleVimaxGeneratePortraits (~211 lines)
+  script-handlers.ts     → handleVimaxGenerateScript,
+                            handleVimaxGenerateStoryboard (~161 lines)
+  registry-handlers.ts   → handleVimaxCreateRegistry,
+                            handleVimaxShowRegistry (~137 lines)
+  pipeline-handlers.ts   → handleVimaxIdea2Video, handleVimaxScript2Video,
+                            handleVimaxNovel2Movie (~229 lines)
+  model-handlers.ts      → handleVimaxListModels (~49 lines)
+  index.ts               → re-exports all 10 handler functions
+```
+
+- `from "./vimax-cli-handlers"` resolves to directory `index.ts` — **zero import changes**.
+- **Internal dependencies:** None. All 10 handlers are fully independent.
+- **Risk: Very low** — independent functions, 3 consumers, barrel preserves API. This is effectively already modular — just needs file separation.
+
+---
+
+## 4. `apps/web/src/components/editor/media-panel/views/media.tsx` (868 lines)
+
+### Analysis
+- **Large UI component** with mixed callbacks, rendering logic, and JSX. Single consumer makes it safe to refactor.
+- Sections:
+  - **Imports** (lines 1-68)
+  - **State & hooks** (lines 71-101): Local state, store hooks
+  - **Callbacks** (lines 107-362): `processFiles()`, `handleSync()`, `handleFileSelect()`, selection helpers, `handleAddSelectedToTimeline()`, `handleDeleteSelected()`, `handleDownloadSelected()`, `handleEdit()`, `formatDuration()` (~255 lines)
+  - **`renderPreview()`** (lines 389-481): Preview rendering with type switching (~93 lines)
+  - **Main JSX** (lines 483-867): File input, toolbar, media grid (~385 lines)
+- **Consumers (1 file):** `media-panel/index.tsx`
+
+### Plan: Extract sub-components and hooks
+```text
+apps/web/src/components/editor/media-panel/views/media/
+  use-media-actions.ts   → Custom hook: processFiles, handleSync, handleFileSelect,
+                            handleAddSelectedToTimeline, handleDeleteSelected,
+                            handleDownloadSelected, handleEdit, selection helpers (~280 lines)
+  media-preview.tsx      → renderPreview extracted as <MediaPreview> component (~110 lines)
+  media-item-card.tsx    → Individual media item with context menu, extracted from
+                            the media grid JSX loop (~150 lines)
+  media.tsx              → Main component — uses hook + renders sub-components (~330 lines)
+  index.ts               → re-exports default from media.tsx
+```
+
+- `from "../views/media"` resolves to directory `index.ts` — **zero import changes**.
+- **Internal dependencies:** `media.tsx` imports from `use-media-actions.ts`, `media-preview.tsx`, `media-item-card.tsx`. No circular dependencies.
+- **Risk: Low** — 1 consumer, UI extraction is safe, barrel preserves API.
+
+---
+
+## 5. `apps/web/src/components/export-dialog.tsx` (816 lines)
+
+### Analysis
+- **Dialog component** where JSX dominates (585 lines / 72%). Contains independent setting "card" sections that are natural extraction targets.
+- Sections:
+  - **Imports** (lines 1-50)
+  - **State & hooks** (lines 52-116)
+  - **`handleExport()`** (lines 129-215): Export business logic (~87 lines)
+  - **Main JSX** (lines 230-814): 8 independent card sections:
+    - Presets grid (lines 338-386, ~50 lines)
+    - File name card (lines 389-413, ~25 lines)
+    - Quality card (lines 415-447, ~33 lines)
+    - Engine card (lines 449-526, ~78 lines)
+    - Format card (lines 528-558, ~30 lines)
+    - Details card (lines 560-609, ~50 lines)
+    - Caption export card (lines 612-686, ~75 lines)
+    - Audio export card (lines 689-720, ~32 lines)
+    - Warnings section (lines 724-809, ~86 lines)
+- **Consumers (1 file):** `export-panel-content.tsx`
+
+### Plan: Extract setting cards
+```text
+apps/web/src/components/export-dialog/
+  export-settings-cards.tsx → PresetGrid, QualityCard, EngineCard, FormatCard,
+                               DetailsCard sub-components (~270 lines)
+  export-media-cards.tsx    → CaptionExportCard, AudioExportCard
+                               sub-components (~120 lines)
+  export-warnings.tsx       → ExportWarnings component (~100 lines)
+  export-dialog.tsx         → Main dialog: state, handleExport, layout,
+                               composes sub-components (~330 lines)
+  index.ts                  → re-exports default from export-dialog.tsx
+```
+
+- `from "../export-dialog"` / `from "./export-dialog"` resolves to directory `index.ts` — **zero import changes**.
+- **Internal dependencies:** `export-dialog.tsx` imports from the three sub-component files. Sub-components receive props from parent (no store access needed).
+- **Risk: Low** — 1 consumer, UI card extraction is mechanical, barrel preserves API.
+
+---
+
+## Execution Order (recommended)
+
+1. **Split** `vimax-cli-handlers.ts` — independent functions, zero cross-deps, very low risk
+2. **Split** `screen-recording-handler.ts` — 2 consumers, clean layered architecture
+3. **Split** `text-to-video.ts` — model-per-file, natural boundaries
+4. **Split** `export-dialog.tsx` — 1 consumer, UI card extraction
+5. **Split** `media.tsx` — 1 consumer, hook + component extraction
+
+**Total lines affected:** ~4,455 lines reorganized into focused modules.
+
+---
+
+## Files NOT selected (and why)
+
+| File | Lines | Reason skipped |
+|------|-------|----------------|
+| `timeline-store-operations.ts` | 1,427 | Core state logic — high risk, many consumers |
+| `claude-timeline-bridge.ts` | 1,417 | Core bridge logic — high risk |
+| `timeline-track.tsx` | 1,324 | Complex UI component — high risk |
+| `preview-panel.tsx` | 1,296 | Complex UI component — high risk |
+| `ffmpeg-export-handler.ts` | 1,219 | Core export logic — high risk |
+| `export-engine-cli.ts` | 1,128 | Core export class — `exportWithCLI()` is 540-line monolith, medium-high risk |
+| `word-timeline-view.tsx` | 1,166 | Complex UI component — high risk |
+| `media-store.ts` | 1,157 | Core store — high risk, many consumers |
+| `claude-timeline-handler.ts` | 1,143 | Core handler — high risk |
+| `drawing-canvas.tsx` | 1,132 | Complex canvas component — high risk |
+| `timeline-store.ts` | 1,087 | Core store — high risk |
+| `use-ai-generation.ts` | 1,082 | Core hook — medium-high risk |
+| `ffmpeg-utils.ts` | 903 | `initFFmpeg()` is 280-line monolith with complex fallback logic — risky to split |
+| `remotion-store.ts` | 919 | 12 consumers — medium risk, candidate for v5 |
+| `effects-store.ts` | 852 | 23 consumers + tight internal coupling — not worth splitting |
+| `use-canvas-objects.ts` | 830 | 1 consumer — candidate for v5 |
+| Test files (5) | 825–1,187 | Low value to split |

--- a/qcut/docs/task/stability-hardening-plan.md
+++ b/qcut/docs/task/stability-hardening-plan.md
@@ -1,0 +1,164 @@
+# Stability Hardening Plan
+
+Three focused improvements to reduce runtime fragility and improve long-term maintainability.
+
+---
+
+## Task 1: Fix Circular Dependencies (29 detected)
+
+**Status**: Detected by `bun run check:circular` (madge v8.0.0) in CI — warns but does not block merges.
+
+### Problem
+
+29 circular dependency cycles exist across `apps/web/src/` and `electron/`. Most are type-only re-exports through barrel files, so they don't break at runtime today. But they degrade tree-shaking, slow bundling, and will eventually cause initialization order bugs as the codebase grows.
+
+### High-Risk Barrel Files
+
+| Barrel File | Exports | Risk |
+|---|---|---|
+| `apps/web/src/lib/ai-video/index.ts` | 100+ items across 14 submodules | High |
+| `apps/web/src/lib/remotion/index.ts` | 190+ lines, deep export tree | High |
+| `apps/web/src/stores/timeline/index.ts` | 30+ exports, interdependent submodules | Medium |
+| `apps/web/src/lib/export/index.ts` | 16 export engine variants | Medium |
+| `apps/web/src/lib/ai-clients/ai-video-client.ts` | `export * from "../ai-video"` re-export chain | Medium |
+| `apps/web/src/lib/ai-models/text2image-models.ts` | Cross-barrel re-export to `../text2image-models/` | Medium |
+
+### Subtasks
+
+#### 1.1 Audit and categorize all 29 cycles
+
+- Run `npx madge --circular --extensions ts,tsx apps/web/src electron/ --json` and capture output
+- Classify each cycle: **type-only** (safe to fix with `import type`) vs **value import** (needs refactoring)
+- File: `.github/workflows/ci.yml` (lines 40-41) — current CI check
+
+#### 1.2 Fix type-only cycles with `import type`
+
+- For cycles caused by type re-exports, switch to `import type { ... }` / `export type { ... }`
+- Primary targets: `ai-video/index.ts`, `ai-models/text2image-models.ts`, `timeline/index.ts`
+- Files: all barrel `index.ts` files listed above
+
+#### 1.3 Break value-import cycles by extracting shared types
+
+- For true value-import cycles, extract shared interfaces into a dedicated `types.ts` at the module boundary
+- Example: if `ai-video` and `ai-clients` both import values from each other, move shared types to `lib/ai-video/types.ts`
+- Files: determined by audit in 1.1
+
+#### 1.4 Make CI check blocking
+
+- Change `bun run check:circular` to fail the build when cycles exceed 0
+- Add `--warning` threshold if gradual reduction is preferred
+- File: `.github/workflows/ci.yml`
+
+### Tests
+
+- `bun run check:circular` should exit 0 with no cycles
+- `bun run build` should still succeed
+- `bun check-types` should pass (type-only import changes can surface errors)
+
+---
+
+## Task 2: Replace spawnSync with Async Spawn for FFmpeg Binary Validation
+
+### Problem
+
+`isBinaryExecutable()` in `electron/ffmpeg/paths.ts:91-102` uses `spawnSync` with a 2.5s timeout to validate FFmpeg/FFprobe binaries. This blocks the Electron main process during startup while `getFFmpegPath()` and `getFFprobePath()` each call it (potentially multiple times across search candidates).
+
+The health check in `electron/ffmpeg/health.ts` already uses async `spawn` — the sync validation in `paths.ts` is the only blocker.
+
+### Relevant Files
+
+| File | Lines | Purpose |
+|---|---|---|
+| `electron/ffmpeg/paths.ts` | 91-102 | `isBinaryExecutable()` — **the sync call to fix** |
+| `electron/ffmpeg/paths.ts` | 237-279 | `getFFmpegPath()` — calls `isBinaryExecutable` |
+| `electron/ffmpeg/paths.ts` | 289-359 | `getFFprobePath()` — calls `isBinaryExecutable` |
+| `electron/ffmpeg/health.ts` | 20-81 | `checkBinaryVersion()` — already async, reference impl |
+| `electron/ffmpeg-handler.ts` | 40-67 | Cached health check orchestrator |
+| `electron/main.ts` | 653, 683 | Startup registration + health check init |
+
+### Subtasks
+
+#### 2.1 Convert `isBinaryExecutable` to async
+
+- Replace `spawnSync` with `spawn` wrapped in a `Promise`
+- Keep the 2.5s timeout
+- Return `Promise<boolean>` instead of `boolean`
+- File: `electron/ffmpeg/paths.ts:91-102`
+
+#### 2.2 Make `getFFmpegPath` and `getFFprobePath` async
+
+- Change return type from `string` to `Promise<string>`
+- `await` the `isBinaryExecutable` calls inside the search loop
+- Files: `electron/ffmpeg/paths.ts:237-279`, `electron/ffmpeg/paths.ts:289-359`
+
+#### 2.3 Update all callers
+
+- Update `electron/ffmpeg-handler.ts` and any IPC handlers that call `getFFmpegPath`/`getFFprobePath` to `await` the result
+- Ensure `initFFmpegHealthCheck()` in `electron/main.ts:683` still fires non-blocking
+- Files: `electron/ffmpeg-handler.ts`, `electron/main.ts`
+
+### Tests
+
+- Existing test: `electron/__tests__/sticker-export-real.test.ts` (uses `spawnSync` to locate FFmpeg — keep as-is since it's a test utility, not production code)
+- Add unit test for `isBinaryExecutable`: mock `spawn` to verify timeout and success/failure paths
+- Test file: `electron/__tests__/ffmpeg-paths.test.ts` (new)
+- Manual: verify `bun run electron:dev` starts without blocking, FFmpeg paths resolve correctly
+
+---
+
+## Task 3: Add React Error Boundaries Around Core Editor Panels
+
+### Problem
+
+If the Timeline, Preview, Media, or Properties panel throws a runtime error, the entire editor white-screens. The app already has:
+
+- A global `<ErrorBoundary>` in `apps/web/src/routes/__root.tsx:46`
+- An isolated `<ErrorBoundary isolate>` around `<Outlet />` in `__root.tsx:50`
+- A reusable `ErrorBoundary` component at `apps/web/src/components/error-boundary.tsx`
+
+But no Error Boundary wraps the individual panels inside the editor layout. An error in the Timeline crashes the Preview, Media, and Properties panels too.
+
+### Relevant Files
+
+| File | Lines | Purpose |
+|---|---|---|
+| `apps/web/src/components/error-boundary.tsx` | 180-251 | Existing `ErrorBoundary` component (supports `isolate` prop) |
+| `apps/web/src/components/editor/panel-layouts.tsx` | 22-411 | All 4 editor layouts (`Default`, `Media`, `Inspector`, `VerticalPreview`) |
+| `apps/web/src/components/editor/media-panel/index.tsx` | 34-94 | MediaPanel component |
+| `apps/web/src/components/editor/properties-panel/index.tsx` | 39-150+ | PropertiesPanel component |
+| `apps/web/src/components/editor/timeline/index.tsx` | 45-150+ | Timeline component |
+| `apps/web/src/components/editor/preview-panel.tsx` | 498-1296 | PreviewPanel component |
+
+### Subtasks
+
+#### 3.1 Create a lightweight `PanelErrorFallback` component
+
+- Smaller than the existing `DefaultErrorFallback` — just shows panel name, "Something went wrong", and a Retry button
+- Should fit inside a resizable panel without layout overflow
+- File: `apps/web/src/components/editor/panel-error-fallback.tsx` (new)
+
+#### 3.2 Wrap each panel in `<ErrorBoundary isolate>` in all 4 layouts
+
+- Wrap `<MediaPanel />`, `<PreviewPanel />`, `<PropertiesPanel />`, and `<Timeline />` with `<ErrorBoundary isolate fallback={<PanelErrorFallback name="..." />}>`
+- Apply in all 4 layout components: `DefaultLayout`, `MediaLayout`, `InspectorLayout`, `VerticalPreviewLayout`
+- File: `apps/web/src/components/editor/panel-layouts.tsx`
+
+#### 3.3 Add tests
+
+- Unit test: render `PanelErrorFallback`, verify it shows the panel name and retry button
+- Unit test: wrap a component that throws in `<ErrorBoundary isolate>`, verify the fallback renders instead of propagating
+- Test file: `apps/web/src/components/editor/__tests__/panel-error-boundary.test.tsx` (new)
+
+### Implementation Notes
+
+- The existing `ErrorBoundary` already supports `isolate` mode (line 32 in `error-boundary.tsx`) which prevents the error from propagating to parent boundaries
+- The existing `componentDidCatch` (line 204) logs to the centralized error handler at `lib/debug/error-handler.ts`
+- No changes needed to the `ErrorBoundary` component itself — just use it
+
+---
+
+## Priority Order
+
+1. **Error Boundaries** (Task 3) — highest user-facing impact, prevents full white-screen crashes
+2. **Async FFmpeg** (Task 2) — removes main-process blocking, small surface area
+3. **Circular Dependencies** (Task 1) — largest scope, lowest immediate risk, best done incrementally


### PR DESCRIPTION
Add two planning documents:

- **stability-hardening-plan.md** — Plan for improving app stability (error boundaries, crash recovery, etc.)
- **large-files-refactor-plan-v4.md** — Next round of large file refactoring targets

Docs only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Large Files Refactoring Plan v4 outlining a modularization strategy for restructuring large files into smaller, focused, maintainable units
  * Added Stability Hardening Plan detailing proposed improvements for runtime stability, dependency management, error handling, and overall maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->