### PR TITLE
fix: correct toast Tailwind syntax errors and improve close button contrast

### DIFF
--- a/qcut/apps/web/src/components/ui/toast.tsx
+++ b/qcut/apps/web/src/components/ui/toast.tsx
@@ -62,7 +62,7 @@ const ToastAction = React.forwardRef<
 	<ToastPrimitives.Action
 		ref={ref}
 		className={cn(
-			"inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus-visible:outline-hidden focus-visible:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 hover:group-[.destructive]:border-destructive/30 hover:group-[.destructive]:bg-destructive hover:group-[.destructive]:text-destructive-foreground group-[.destructive]:focus-visible::ring-destructive",
+			"inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus-visible:outline-hidden focus-visible:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 hover:group-[.destructive]:border-destructive/30 hover:group-[.destructive]:bg-destructive hover:group-[.destructive]:text-destructive-foreground group-[.destructive]:focus-visible:ring-destructive",
 			className
 		)}
 		{...props}
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
 	<ToastPrimitives.Close
 		ref={ref}
 		className={cn(
-			"absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-hidden focus-visible::ring-1 group-hover:opacity-100 group-[.destructive]:text-muted-foreground hover:group-[.destructive]:text-red-50 focus-visible:group-[.destructive]:ring-red-400 focus-visible:group-[.destructive]:ring-offset-red-600",
+			"absolute right-1 top-1 rounded-md p-1 text-foreground/70 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-hidden focus-visible:ring-1 group-hover:opacity-100 group-[.destructive]:text-muted-foreground hover:group-[.destructive]:text-red-50 focus-visible:group-[.destructive]:ring-red-400 focus-visible:group-[.destructive]:ring-offset-red-600",
 			className
 		)}
 		toast-close=""


### PR DESCRIPTION
## Summary
- Fix double-colon `::` → single colon `:` in `ToastAction` (`focus-visible::ring-destructive`)
- Fix double-colon `::` → single colon `:` in `ToastClose` (`focus-visible::ring-1`)
- Increase `ToastClose` text opacity from `text-foreground/50` to `text-foreground/70` for better contrast

Closes #226

## Test plan
- [x] `bun run lint:clean` passes
- [x] `bun run check-types` passes
- [ ] Visual check: toast close button has adequate contrast
- [ ] Visual check: focus rings appear correctly on toast action and close buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected styling inconsistencies in toast notifications to ensure proper visual rendering of interactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->