### PR TITLE
fix: add missing aria-label to editor zoom slider

### DIFF
--- a/qcut/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
+++ b/qcut/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
@@ -581,6 +581,7 @@ export function TimelineToolbar({
 						min={0.05}
 						max={4}
 						step={0.05}
+						aria-label="Timeline zoom"
 						data-zoom-level={zoomLevel}
 					/>
 					<Button


### PR DESCRIPTION
## Summary
- Adds `aria-label="Timeline zoom"` to the zoom slider in `timeline-toolbar.tsx` for screen reader accessibility

Closes #232

## Test plan
- [x] `bun run lint:clean` passes
- [x] `bun run check-types` passes
- [ ] Verify slider is announced as "Timeline zoom" by screen readers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the timeline zoom slider with enhanced labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->