### PR TITLE
feat: add AI proxy server and beta tester invite system

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/ai/hooks/generation/__tests__/model-handlers-routing.test.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/ai/hooks/generation/__tests__/model-handlers-routing.test.ts
@@ -162,17 +162,27 @@ describe("model handler routing regression", () => {
 	});
 
 	// GMI T2V routing
+	const t2vHandlerMap: Record<string, ReturnType<typeof vi.fn>> = {
+		handleGmiVeoLiteT2V: textToVideoHandlers.handleGmiVeoLiteT2V as ReturnType<
+			typeof vi.fn
+		>,
+		handleSkyreelsV4T2V: textToVideoHandlers.handleSkyreelsV4T2V as ReturnType<
+			typeof vi.fn
+		>,
+		handleGmiKlingV3T2V: textToVideoHandlers.handleGmiKlingV3T2V as ReturnType<
+			typeof vi.fn
+		>,
+		handleGmiKlingOmniT2V:
+			textToVideoHandlers.handleGmiKlingOmniT2V as ReturnType<typeof vi.fn>,
+	};
+
 	it.each([
 		["gmi_veo31_lite_t2v", "handleGmiVeoLiteT2V"],
 		["gmi_skyreels_v4_t2v", "handleSkyreelsV4T2V"],
 		["gmi_kling_v3_t2v", "handleGmiKlingV3T2V"],
 		["gmi_kling_v3_omni_t2v", "handleGmiKlingOmniT2V"],
 	] as const)("routeTextToVideoHandler maps %s to %s", async (modelId, handlerName) => {
-		const mock = vi.mocked(
-			textToVideoHandlers[
-				handlerName as keyof typeof textToVideoHandlers
-			] as ReturnType<typeof vi.fn>
-		);
+		const mock = vi.mocked(t2vHandlerMap[handlerName]);
 		await routeTextToVideoHandler(
 			createContext({ modelId }),
 			{} as TextToVideoSettings
@@ -181,6 +191,21 @@ describe("model handler routing regression", () => {
 	});
 
 	// GMI I2V routing
+	const i2vHandlerMap: Record<string, ReturnType<typeof vi.fn>> = {
+		handleGmiVeoLiteI2V:
+			imageToVideoHandlersGmi.handleGmiVeoLiteI2V as ReturnType<typeof vi.fn>,
+		handleSkyreelsV4I2V:
+			imageToVideoHandlersGmi.handleSkyreelsV4I2V as ReturnType<typeof vi.fn>,
+		handleGmiKlingV3I2V:
+			imageToVideoHandlersGmi.handleGmiKlingV3I2V as ReturnType<typeof vi.fn>,
+		handleGmiKlingOmniI2V:
+			imageToVideoHandlersGmi.handleGmiKlingOmniI2V as ReturnType<typeof vi.fn>,
+		handleGmiKlingMotionControl:
+			imageToVideoHandlersGmi.handleGmiKlingMotionControl as ReturnType<
+				typeof vi.fn
+			>,
+	};
+
 	it.each([
 		["gmi_veo31_lite_i2v", "handleGmiVeoLiteI2V"],
 		["gmi_skyreels_v4_i2v", "handleSkyreelsV4I2V"],
@@ -188,11 +213,7 @@ describe("model handler routing regression", () => {
 		["gmi_kling_v3_omni_i2v", "handleGmiKlingOmniI2V"],
 		["gmi_kling_motion_control", "handleGmiKlingMotionControl"],
 	] as const)("routeImageToVideoHandler maps %s to %s", async (modelId, handlerName) => {
-		const mock = vi.mocked(
-			imageToVideoHandlersGmi[
-				handlerName as keyof typeof imageToVideoHandlersGmi
-			] as ReturnType<typeof vi.fn>
-		);
+		const mock = vi.mocked(i2vHandlerMap[handlerName]);
 		await routeImageToVideoHandler(createContext({ modelId }), {
 			selectedImage: new File(["test"], "test.jpg"),
 			uploadImageToFal: vi.fn().mockResolvedValue("https://fal.ai/img"),

--- a/qcut/apps/web/src/lib/ai-video/core/__tests__/fal-request-proxy.test.ts
+++ b/qcut/apps/web/src/lib/ai-video/core/__tests__/fal-request-proxy.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Mock platform
+const mockGetAuthToken = vi.fn();
+vi.mock("@qcut/platform-core", () => ({
+	platform: () => ({
+		license: {
+			getAuthToken: mockGetAuthToken,
+		},
+		apiKeys: undefined,
+	}),
+}));
+
+// Mock error handler
+vi.mock("@/lib/debug/error-handler", () => ({
+	handleAIServiceError: vi.fn(),
+}));
+
+// Mock global fetch
+const originalFetch = globalThis.fetch;
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", mockFetch);
+	mockFetch.mockReset();
+	mockGetAuthToken.mockReset();
+	// Clear env to ensure no local API key
+	vi.stubEnv("VITE_FAL_API_KEY", "");
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+// Import after mocks
+const { makeFalRequest, clearFalApiKeyCache } = await import("../fal-request");
+
+describe("makeFalRequest proxy mode", () => {
+	beforeEach(() => {
+		clearFalApiKeyCache();
+	});
+
+	it("routes through license server proxy when no local API key", async () => {
+		mockGetAuthToken.mockResolvedValue("session-token-123");
+		mockFetch.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+		await makeFalRequest("fal-ai/test-model", { prompt: "test" });
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const [url, init] = mockFetch.mock.calls[0];
+		expect(url).toContain("/api/ai/proxy");
+		expect(init.method).toBe("POST");
+		expect(init.headers.Authorization).toBe("Bearer session-token-123");
+
+		const body = JSON.parse(init.body);
+		expect(body.provider).toBe("fal");
+		expect(body.endpoint).toBe("https://fal.run/fal-ai/test-model");
+		expect(body.method).toBe("POST");
+		expect(body.body).toEqual({ prompt: "test" });
+	});
+
+	it("uses queue base URL in queue mode", async () => {
+		mockGetAuthToken.mockResolvedValue("session-token-123");
+		mockFetch.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+		await makeFalRequest(
+			"fal-ai/test-model",
+			{ prompt: "test" },
+			{ queueMode: true }
+		);
+
+		const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+		expect(body.endpoint).toBe("https://queue.fal.run/fal-ai/test-model");
+	});
+
+	it("passes through full URLs without prefixing base", async () => {
+		mockGetAuthToken.mockResolvedValue("token");
+		mockFetch.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+		await makeFalRequest("https://custom.fal.run/endpoint", { prompt: "test" });
+
+		const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+		expect(body.endpoint).toBe("https://custom.fal.run/endpoint");
+	});
+
+	it("throws when no API key and no session token", async () => {
+		mockGetAuthToken.mockResolvedValue("");
+
+		await expect(
+			makeFalRequest("fal-ai/test", { prompt: "test" })
+		).rejects.toThrow("FAL API key not configured");
+	});
+
+	it("forwards abort signal to proxy request", async () => {
+		mockGetAuthToken.mockResolvedValue("token");
+		const controller = new AbortController();
+		mockFetch.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+		await makeFalRequest(
+			"fal-ai/test",
+			{ prompt: "test" },
+			{ signal: controller.signal }
+		);
+
+		expect(mockFetch.mock.calls[0][1].signal).toBe(controller.signal);
+	});
+});
+
+describe("getSessionToken error handling", () => {
+	it("falls through to error when getAuthToken throws", async () => {
+		clearFalApiKeyCache();
+		mockGetAuthToken.mockRejectedValue(new Error("auth failed"));
+
+		await expect(
+			makeFalRequest("fal-ai/test", { prompt: "test" })
+		).rejects.toThrow("FAL API key not configured");
+	});
+});

--- a/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
+++ b/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
@@ -147,8 +147,8 @@ async function getSessionToken(): Promise<string> {
 			).getAuthToken();
 			return token ?? "";
 		}
-	} catch {
-		// No license API or not authenticated
+	} catch (error) {
+		console.warn("[getSessionToken] Failed to get session token:", error);
 	}
 	return "";
 }

--- a/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
+++ b/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
@@ -127,15 +127,66 @@ export interface FalRequestOptions {
  * @returns Raw Response object for flexible handling
  * @throws Error with user-friendly message if API key is missing
  */
+/**
+ * License server URL for proxy mode.
+ * Falls back to production URL if env var is not set.
+ */
+const LICENSE_SERVER_URL =
+	import.meta.env.VITE_LICENSE_SERVER_URL ||
+	"https://qcut-license-server.zdhpeter.workers.dev";
+
+/** Try to get a session token from the license store (if available). */
+async function getSessionToken(): Promise<string> {
+	try {
+		const licenseApi = platform().license;
+		if (!licenseApi) return "";
+		// The license API exposes the auth token via getAuthToken if available
+		if ("getAuthToken" in licenseApi) {
+			const token = await (
+				licenseApi as { getAuthToken: () => Promise<string> }
+			).getAuthToken();
+			return token ?? "";
+		}
+	} catch {
+		// No license API or not authenticated
+	}
+	return "";
+}
+
 export async function makeFalRequest(
 	endpoint: string,
 	payload: Record<string, unknown>,
 	options?: FalRequestOptions
 ): Promise<Response> {
 	const apiKey = await getFalApiKeyAsync();
+
+	// If no local key, try proxy mode
 	if (!apiKey) {
+		const sessionToken = await getSessionToken();
+		if (sessionToken) {
+			const base = options?.queueMode ? FAL_QUEUE_BASE : FAL_API_BASE;
+			const targetUrl = endpoint.startsWith("https://")
+				? endpoint
+				: `${base}/${endpoint}`;
+
+			return fetch(`${LICENSE_SERVER_URL}/api/ai/proxy`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${sessionToken}`,
+				},
+				body: JSON.stringify({
+					provider: "fal",
+					endpoint: targetUrl,
+					method: "POST",
+					body: payload,
+				}),
+				signal: options?.signal,
+			});
+		}
+
 		const error = new Error(
-			"FAL API key not configured. Please set VITE_FAL_API_KEY environment variable or configure it in Settings."
+			"FAL API key not configured. Please sign in to your QCut account or set VITE_FAL_API_KEY."
 		);
 		handleAIServiceError(error, "FAL API Request", {
 			configRequired: "VITE_FAL_API_KEY",

--- a/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
+++ b/qcut/apps/web/src/lib/ai-video/core/fal-request.ts
@@ -119,15 +119,6 @@ export interface FalRequestOptions {
 }
 
 /**
- * Makes an authenticated request to FAL AI API.
- *
- * @param endpoint - FAL endpoint path (e.g., "fal-ai/kling-video/v2.6/pro/text-to-video")
- * @param payload - Request payload
- * @param options - Optional request configuration
- * @returns Raw Response object for flexible handling
- * @throws Error with user-friendly message if API key is missing
- */
-/**
  * License server URL for proxy mode.
  * Falls back to production URL if env var is not set.
  */
@@ -153,6 +144,10 @@ async function getSessionToken(): Promise<string> {
 	return "";
 }
 
+/**
+ * Makes an authenticated request to FAL AI API.
+ * Uses proxy mode via the license server when no local API key is available.
+ */
 export async function makeFalRequest(
 	endpoint: string,
 	payload: Record<string, unknown>,

--- a/qcut/apps/web/src/lib/license/credit-guard.ts
+++ b/qcut/apps/web/src/lib/license/credit-guard.ts
@@ -75,6 +75,15 @@ export async function enforceCreditRequirement({
 
 		const falApiKey = await getFalApiKeyAsync();
 		if (typeof falApiKey === "string" && falApiKey.length > 0) {
+			// BYOK: user has their own key, no credit deduction needed
+			return { allowed: true, requiredCredits: 0 };
+		}
+
+		// Proxy mode: when no local key but user is authenticated, the server
+		// proxy handles credit deduction. Skip client-side deduction to avoid
+		// double-charging.
+		const currentLicense = useLicenseStore.getState().license;
+		if (currentLicense && currentLicense.status === "active") {
 			return { allowed: true, requiredCredits: 0 };
 		}
 

--- a/qcut/docs/task/invite-test/api-key-proxy-plan.md
+++ b/qcut/docs/task/invite-test/api-key-proxy-plan.md
@@ -310,12 +310,16 @@ wrangler secret put ADMIN_API_KEY
 | Tests (41 new, 78 total) | Done | `provider-keys.test.ts`, `ai-proxy.test.ts`, `rate-limit.test.ts` |
 | **Deploy** | **TODO** | `wrangler secret put` + `wrangler deploy` |
 
-### Phase 2 — Client migration (TODO)
+### Phase 2 — Client migration (DONE)
 
 | Subtask | Status | Files |
 |---------|--------|-------|
-| Electron client switch to proxy | TODO | `electron/native-pipeline/infra/api-caller.ts`, `key-manager.ts` |
-| Web client switch to proxy | TODO | `apps/web/src/lib/ai-video/core/fal-request.ts`, `credit-guard.ts` |
+| Shared provider URL/utils module | Done | `electron/native-pipeline/infra/api-provider-urls.ts` (new) |
+| Proxy client module | Done | `electron/native-pipeline/infra/proxy-client.ts` (new) |
+| Electron api-caller proxy mode | Done | `electron/native-pipeline/infra/api-caller.ts` (modified, 789 lines) |
+| FAL upload handlers proxy mode | Done | `electron/main-ipc/fal-upload-handlers.ts` (modified) |
+| Web client fal-request proxy mode | Done | `apps/web/src/lib/ai-video/core/fal-request.ts` (modified) |
+| Credit guard skip for proxy mode | Done | `apps/web/src/lib/license/credit-guard.ts` (modified) |
 | Remove local key storage | TODO | `api-keys-view.tsx`, `api-key-handler.ts` |
 
 ### Phase 3 — Hardening (TODO)

--- a/qcut/docs/task/invite-test/api-key-proxy-plan.md
+++ b/qcut/docs/task/invite-test/api-key-proxy-plan.md
@@ -1,0 +1,338 @@
+# API Key Proxy — Implementation Plan
+
+## Problem
+
+Company API keys (FAL, Gemini, ElevenLabs, etc.) are stored on user machines.
+Even with Electron safeStorage encryption, a determined user can extract them from
+memory, network traffic, or the running process. One leaked key = entire company bill.
+
+## Current Architecture
+
+```
+Electron App  ──(API key in header)──→  FAL / Gemini / etc.
+     ↑
+Keys stored locally:
+  - Electron safeStorage (encrypted)
+  - ~/.qcut/.env (plaintext)
+  - process.env
+```
+
+## Target Architecture
+
+```
+Electron App  ──(session token)──→  License Server  ──(API key)──→  Provider
+                                         ↑
+                                   Keys in Wrangler
+                                   secrets (never
+                                   leaves server)
+```
+
+### Hybrid Strategy
+
+| Request type | Route | Why |
+|---|---|---|
+| Small JSON (text gen, transcription, image gen) | Full proxy through license server | Low bandwidth, full control |
+| Large binary upload (video to FAL CDN) | Server vends signed upload URL, client uploads direct | Avoids proxying GB-scale video through CF Worker |
+| Async polling (FAL queue, GMI queue) | Client polls proxy, proxy polls provider | Keeps provider key server-side |
+
+---
+
+## Subtasks
+
+### 1. AI Proxy Route on License Server
+
+**Goal**: Add `/api/ai/proxy` route that accepts provider requests, injects the real API key, and forwards to the provider.
+
+**Estimated time**: ~30 min
+
+**Files to create/modify**:
+- `packages/license-server/src/routes/ai-proxy.ts` — new route file
+- `packages/license-server/src/services/provider-keys.ts` — new service: reads provider keys from env
+- `packages/license-server/src/index.ts` — register the new route
+
+**Design**:
+```
+POST /api/ai/proxy
+Headers: Authorization: Bearer <session-token>
+Body: {
+  provider: "fal" | "gemini" | "openrouter" | "elevenlabs" | "gmi" | "runway",
+  endpoint: "/fal-ai/kling-video/v2/master/text-to-video",
+  method: "POST",
+  body: { ...provider-specific payload }
+}
+```
+
+**Server does**:
+1. Authenticate user via session token (existing `authMiddleware`)
+2. Check + deduct credits (atomic, before calling provider)
+3. Look up provider API key from Wrangler secrets (`FAL_API_KEY`, `GEMINI_API_KEY`, etc.)
+4. Build provider request with correct auth header format per provider
+5. Forward request, return response to client
+
+**Provider auth header mapping** (in `provider-keys.ts`):
+| Provider | Env var | Header format |
+|---|---|---|
+| fal | `FAL_API_KEY` | `Authorization: Key {key}` |
+| gemini | `GEMINI_API_KEY` | `x-goog-api-key: {key}` |
+| openrouter | `OPENROUTER_API_KEY` | `Authorization: Bearer {key}` |
+| elevenlabs | `ELEVENLABS_API_KEY` | `xi-api-key: {key}` |
+| gmi | `GMI_API_KEY` | `Authorization: Bearer {key}` |
+| runway | `RUNWAY_API_KEY` | `Authorization: Bearer {key}` + `X-Runway-Version: 2024-11-06` |
+
+**Allowed endpoint prefixes** (whitelist to prevent SSRF):
+- fal: `https://queue.fal.run/`, `https://fal.run/`
+- gemini: `https://generativelanguage.googleapis.com/`
+- openrouter: `https://openrouter.ai/api/`
+- elevenlabs: `https://api.elevenlabs.io/`
+- gmi: `https://console.gmicloud.ai/api/`
+- runway: `https://api.runwayml.com/`
+
+**Test file**: `packages/license-server/src/routes/ai-proxy.test.ts`
+- Test auth rejection (no token → 401)
+- Test unknown provider → 400
+- Test endpoint whitelist rejection → 403
+- Test credit deduction before forward
+- Test correct header injection per provider
+
+---
+
+### 2. FAL Upload URL Vending Endpoint
+
+**Goal**: Instead of giving the client the FAL key to upload files, the server initiates the upload and returns only the signed URL.
+
+**Estimated time**: ~20 min
+
+**Files to create/modify**:
+- `packages/license-server/src/routes/ai-proxy.ts` — add `POST /api/ai/upload-url` endpoint
+
+**Design**:
+```
+POST /api/ai/upload-url
+Headers: Authorization: Bearer <session-token>
+Body: {
+  provider: "fal",
+  fileName: "input.mp4",
+  contentType: "video/mp4",
+  fileSize: 52428800
+}
+Response: {
+  uploadUrl: "https://storage.fal.ai/signed/...",  (client PUTs file here)
+  fileUrl: "https://cdn.fal.ai/..."                 (use this in subsequent API calls)
+}
+```
+
+**Server does**:
+1. Authenticate user
+2. Call `POST https://rest.alpha.fal.ai/storage/upload/initiate` with the real FAL key
+3. Return `{ uploadUrl, fileUrl }` — client never sees the key
+
+**Test file**: `packages/license-server/src/routes/ai-proxy.test.ts` (extend)
+- Test upload URL generation with mocked FAL response
+- Test auth required
+- Test file size limits
+
+---
+
+### 3. Async Polling Proxy
+
+**Goal**: Proxy FAL/GMI queue status polling so the client never needs the API key for polling.
+
+**Estimated time**: ~20 min
+
+**Files to create/modify**:
+- `packages/license-server/src/routes/ai-proxy.ts` — add `GET /api/ai/status` endpoint
+
+**Design**:
+```
+GET /api/ai/status?provider=fal&endpoint=/fal-ai/kling-video/...&requestId=abc123
+Headers: Authorization: Bearer <session-token>
+Response: { status: "COMPLETED", response: {...} }
+```
+
+**Server does**:
+1. Authenticate user
+2. Build status URL from provider + endpoint + requestId
+3. Call provider with real API key
+4. Return status/result to client
+
+**Test file**: `packages/license-server/src/routes/ai-proxy.test.ts` (extend)
+- Test status polling with mocked provider response
+- Test request ID validation (no path traversal)
+
+---
+
+### 4. Electron Client — Switch to Proxy
+
+**Goal**: Update the Electron API caller to route through the license server proxy instead of calling providers directly.
+
+**Estimated time**: ~40 min
+
+**Files to modify**:
+- `electron/native-pipeline/infra/api-caller.ts` — main change: route through proxy
+- `electron/native-pipeline/infra/key-manager.ts` — add proxy mode (skip local key lookup)
+- `electron/main-ipc/fal-upload-handlers.ts` — use upload URL vending instead of direct FAL upload
+- `electron/api-key-handler.ts` — add `getProxyConfig()` returning server URL + session token
+
+**Design for api-caller.ts**:
+```typescript
+// Before (direct)
+const headers = { Authorization: `Key ${apiKey}` };
+const response = await fetch(`https://queue.fal.run/${endpoint}`, { headers, body });
+
+// After (proxied)
+const response = await fetch(`${LICENSE_SERVER}/api/ai/proxy`, {
+  headers: { Authorization: `Bearer ${sessionToken}` },
+  body: JSON.stringify({
+    provider: "fal",
+    endpoint: `https://queue.fal.run/${endpoint}`,
+    method: "POST",
+    body: payload,
+  }),
+});
+```
+
+**Fallback**: If proxy is unreachable or user has their own key (BYOK), fall back to direct mode. This keeps the app functional for power users who prefer their own keys.
+
+**Key change in key-manager.ts**:
+```typescript
+export type KeyMode = "proxy" | "local";
+
+export function getKeyMode(): KeyMode {
+  // If user has a session token and no local key override → proxy
+  // If user set their own key in settings → local (BYOK)
+}
+```
+
+**Test file**: `electron/native-pipeline/infra/__tests__/api-caller.test.ts`
+- Test proxy mode routes through license server
+- Test BYOK fallback to direct mode
+- Test proxy failure falls back to local key
+
+---
+
+### 5. Web Client — Switch to Proxy
+
+**Goal**: Update browser-side AI clients to use the proxy.
+
+**Estimated time**: ~30 min
+
+**Files to modify**:
+- `apps/web/src/lib/ai-video/core/fal-request.ts` — route through proxy
+- `apps/web/src/lib/ai-clients/fal-ai-client.ts` — proxy mode
+- `apps/web/src/lib/gemini/gemini-utils.ts` — proxy mode
+- `apps/web/src/lib/license/credit-guard.ts` — credit deduction now happens server-side, remove client-side deduction to avoid double-charging
+
+**Key change in credit-guard.ts**:
+```typescript
+// Before: client deducts credits, then calls provider
+// After: proxy deducts credits server-side, client just sends request
+// Remove enforceCreditRequirement() calls from AI request flows
+// Keep it only for BYOK mode where calls go direct
+```
+
+**Test considerations**:
+- Existing credit-guard tests may need updating
+- Verify no double-deduction (proxy deducts + client deducts)
+
+---
+
+### 6. Wrangler Secrets Setup
+
+**Goal**: Store all provider API keys as Cloudflare Worker secrets.
+
+**Estimated time**: ~5 min
+
+**Files to modify**:
+- `packages/license-server/wrangler.toml` — document expected secrets (as comments)
+- `packages/license-server/.env.example` — add all provider key vars
+
+**Commands to run**:
+```bash
+cd packages/license-server
+wrangler secret put FAL_API_KEY
+wrangler secret put GEMINI_API_KEY
+wrangler secret put OPENROUTER_API_KEY
+wrangler secret put ELEVENLABS_API_KEY
+wrangler secret put GMI_API_KEY
+wrangler secret put RUNWAY_API_KEY
+wrangler secret put FREESOUND_API_KEY
+wrangler secret put ADMIN_API_KEY
+```
+
+---
+
+### 7. Remove Local Key Storage for Company Keys
+
+**Goal**: Stop shipping/storing company keys on user machines. Keep BYOK path for power users.
+
+**Estimated time**: ~20 min
+
+**Files to modify**:
+- `apps/web/src/components/editor/properties-panel/api-keys-view.tsx` — change UI: show "Connected via QCut account" when proxied, only show key input fields for BYOK users
+- `electron/api-key-handler.ts` — remove auto-sync of company keys from AICP/CLI stores; keep user-provided keys
+- `apps/web/.env.example` — remove `VITE_FAL_API_KEY` etc. (no longer needed in client builds)
+
+---
+
+### 8. Rate Limiting & Abuse Prevention
+
+**Goal**: Prevent proxy abuse (one user flooding the API).
+
+**Estimated time**: ~20 min
+
+**Files to create/modify**:
+- `packages/license-server/src/middleware/rate-limit.ts` — new middleware
+- `packages/license-server/src/routes/ai-proxy.ts` — apply rate limit middleware
+
+**Design**:
+- Per-user rate limit: 60 requests/minute (configurable via env var)
+- Use CF Worker's built-in `cf.cacheApi` or a simple in-memory counter with TTL
+- Return `429 Too Many Requests` with `Retry-After` header
+- Credit system already limits spend, but rate limiting prevents rapid-fire abuse
+
+**Test file**: `packages/license-server/src/middleware/rate-limit.test.ts`
+
+---
+
+## Implementation Order
+
+```
+Phase 1 — Server (no client changes, no user impact):
+  1. Provider keys service
+  2. AI proxy route
+  3. Upload URL vending
+  4. Async polling proxy
+  5. Wrangler secrets setup
+  6. Deploy & test with curl
+
+Phase 2 — Client migration (feature-flagged):
+  4. Electron client switch
+  5. Web client switch
+  7. Remove local key storage
+
+Phase 3 — Hardening:
+  8. Rate limiting
+  Monitoring & alerting on proxy usage
+```
+
+## Environment Variables (New)
+
+| Variable | Where | Purpose |
+|---|---|---|
+| `FAL_API_KEY` | Wrangler secret | FAL provider key |
+| `GEMINI_API_KEY` | Wrangler secret | Google Gemini key |
+| `OPENROUTER_API_KEY` | Wrangler secret | OpenRouter key |
+| `ELEVENLABS_API_KEY` | Wrangler secret | ElevenLabs key |
+| `GMI_API_KEY` | Wrangler secret | GMI Cloud key |
+| `RUNWAY_API_KEY` | Wrangler secret | Runway key |
+| `FREESOUND_API_KEY` | Wrangler secret | Freesound key |
+| `ADMIN_API_KEY` | Wrangler secret | Admin API auth |
+| `AI_PROXY_RATE_LIMIT` | wrangler.toml var | Requests/min per user (default: 60) |
+
+## Security Considerations
+
+- **SSRF prevention**: Whitelist allowed endpoint prefixes per provider. Reject any URL not matching.
+- **Request size limits**: Cap proxy request body at 10MB (JSON payloads only; binary goes through signed URLs).
+- **No key leakage in errors**: Never include the provider API key in error messages returned to client.
+- **Audit log**: Log provider, endpoint, userId, creditsCost per proxy request for debugging.
+- **BYOK escape hatch**: Users who prefer their own keys can still enter them in settings and bypass the proxy entirely.

--- a/qcut/docs/task/invite-test/api-key-proxy-plan.md
+++ b/qcut/docs/task/invite-test/api-key-proxy-plan.md
@@ -294,26 +294,35 @@ wrangler secret put ADMIN_API_KEY
 
 ---
 
-## Implementation Order
+## Implementation Status
 
-```
-Phase 1 — Server (no client changes, no user impact):
-  1. Provider keys service
-  2. AI proxy route
-  3. Upload URL vending
-  4. Async polling proxy
-  5. Wrangler secrets setup
-  6. Deploy & test with curl
+### Phase 1 — Server (DONE)
 
-Phase 2 — Client migration (feature-flagged):
-  4. Electron client switch
-  5. Web client switch
-  7. Remove local key storage
+| Subtask | Status | Files |
+|---------|--------|-------|
+| Provider keys service | Done | `packages/license-server/src/services/provider-keys.ts` |
+| AI proxy route (POST /proxy) | Done | `packages/license-server/src/routes/ai-proxy.ts` |
+| Upload URL vending (POST /upload-url) | Done | `packages/license-server/src/routes/ai-proxy.ts` |
+| Async polling proxy (GET /status, /result) | Done | `packages/license-server/src/routes/ai-proxy.ts` |
+| Rate limiting middleware | Done | `packages/license-server/src/middleware/rate-limit.ts` |
+| Wrangler config + .env.example | Done | `wrangler.toml`, `.env.example` |
+| Route wired into index.ts | Done | `packages/license-server/src/index.ts` |
+| Tests (41 new, 78 total) | Done | `provider-keys.test.ts`, `ai-proxy.test.ts`, `rate-limit.test.ts` |
+| **Deploy** | **TODO** | `wrangler secret put` + `wrangler deploy` |
 
-Phase 3 — Hardening:
-  8. Rate limiting
-  Monitoring & alerting on proxy usage
-```
+### Phase 2 — Client migration (TODO)
+
+| Subtask | Status | Files |
+|---------|--------|-------|
+| Electron client switch to proxy | TODO | `electron/native-pipeline/infra/api-caller.ts`, `key-manager.ts` |
+| Web client switch to proxy | TODO | `apps/web/src/lib/ai-video/core/fal-request.ts`, `credit-guard.ts` |
+| Remove local key storage | TODO | `api-keys-view.tsx`, `api-key-handler.ts` |
+
+### Phase 3 — Hardening (TODO)
+
+| Subtask | Status | Files |
+|---------|--------|-------|
+| Monitoring & alerting on proxy usage | TODO | — |
 
 ## Environment Variables (New)
 

--- a/qcut/docs/task/invite-test/testers.md
+++ b/qcut/docs/task/invite-test/testers.md
@@ -1,0 +1,29 @@
+# QCut Beta Tester Invites
+
+## How It Works
+
+QCut uses a **credit-based system** via the license server (`qcut-license-server.zdhpeter.workers.dev`).
+
+- Users sign up with **Google OAuth** (Gmail) or email/password
+- Each plan gets monthly credits: Free=50, Pro=500, Team=2000
+- AI operations (video gen, image gen, transcription) deduct credits per use
+- API keys are **app-level** (FAL, Gemini, etc.) — testers do NOT need their own keys
+
+## Onboarding a Tester
+
+1. Tester signs up in QCut using their Gmail (Google OAuth)
+2. They get a **Free plan** automatically (50 credits/month, 5 AI generations, 1 device)
+3. To give more credits: either upgrade their plan in the DB or grant top-up credits
+4. Payment canary mode (`PAYMENTS_CANARY_ONLY`) can restrict purchases to an allowlist
+
+## Actions Needed
+
+- [ ] Decide: grant extra credits via DB top-up, or upgrade plan to Pro/Team?
+- [ ] Decide: add testers to `PAYMENTS_EMAIL_ALLOWLIST` for self-service top-up?
+- [ ] Script or admin endpoint to bulk-grant credits by email
+
+## Tester List
+
+| Gmail | Plan | Credits Granted | Date Added | Status |
+|-------|------|-----------------|------------|--------|
+| | | | | |

--- a/qcut/docs/task/invite-test/testers.md
+++ b/qcut/docs/task/invite-test/testers.md
@@ -2,25 +2,190 @@
 
 ## How It Works
 
-QCut uses a **credit-based system** via the license server (`qcut-license-server.zdhpeter.workers.dev`).
+QCut uses a **credit-based licensing system** via the license server (`qcut-license-server.zdhpeter.workers.dev`).
 
-- Users sign up with **Google OAuth** (Gmail) or email/password
-- Each plan gets monthly credits: Free=50, Pro=500, Team=2000
-- AI operations (video gen, image gen, transcription) deduct credits per use
-- API keys are **app-level** (FAL, Gemini, etc.) — testers do NOT need their own keys
+- Users sign up with **Google OAuth** (primary) or **email/password**
+- Each plan gets monthly credits: **Free=50, Pro=500, Team=2000**
+- Credits reset monthly (auto-reset on first API call after reset timestamp)
+- Plan credits are consumed first, then top-up credits
+- API keys are **app-level** (FAL, Gemini, ElevenLabs, etc.) — testers do NOT need their own keys
+- Credit precision: `numeric(12,3)` — supports fractional credits (0.001 minimum)
+
+## Plans & Limits
+
+| Plan | Credits/Month | Devices | Stripe Required |
+|------|---------------|---------|-----------------|
+| Free | 50 | 1 | No |
+| Pro | 500 | 3 | Yes |
+| Team | 2000 | 10 | Yes |
+
+## Top-Up Credit Packs (Stripe)
+
+| Pack | Credits |
+|------|---------|
+| Starter | 50 |
+| Standard | 120 |
+| Pro | 350 |
+| Mega | 800 |
+
+## New User Signup Flow
+
+1. User signs up via Google OAuth or email/password (Better Auth)
+2. `users` table entry created automatically by Better Auth
+3. `licenses` table auto-created on first API call → **Free plan**, status=active, 1 device
+4. `creditBalances` auto-created on first credit API call → **50 plan credits**, 0 top-up, reset in 1 month
+5. A `plan_grant` transaction is recorded in `creditTransactions`
+
+No manual provisioning needed — Free tier is fully automatic.
+
+## Credit Deduction
+
+- Endpoint: `POST /api/credits/deduct` (or `/api/credits/use`)
+- Requires: `amount`, `modelKey`, `description`
+- Consumes **planCredits first**, then **topUpCredits**
+- Returns `402 Insufficient Credits` if balance too low
+- All operations use database transactions (atomic, no race conditions)
+
+## API Endpoints
+
+### License
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `GET /api/license/` | GET | Full license info with devices & credits |
+| `GET /api/license/status` | GET | Plan, status, device count, credits |
+| `GET /api/license/validate` | GET | Check if license is active/valid |
+| `POST /api/license/activate` | POST | Register new device |
+| `DELETE /api/license/deactivate` | DELETE | Unregister device |
+
+### Credits
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `GET /api/credits/` | GET | Current balance (planCredits + topUpCredits) |
+| `GET /api/credits/balance` | GET | Formatted balance with reset timestamp |
+| `POST /api/credits/deduct` | POST | Deduct credits |
+| `POST /api/credits/use` | POST | Alias for deduct |
+| `GET /api/credits/history` | GET | Transaction history (limit 1-200) |
+
+### Stripe / Payments
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `POST /api/stripe/checkout` | POST | Create subscription checkout |
+| `POST /api/stripe/topup` | POST | Create credit top-up checkout |
+| `POST /api/stripe/portal` | POST | Billing portal session |
+| `POST /api/stripe/webhook` | POST | Handle Stripe webhooks |
+
+### Admin (requires `x-admin-key` header)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `GET /api/admin/user?email=` | GET | Look up user by email (ID, plan, credits) |
+| `POST /api/admin/grant-credits` | POST | Bulk grant top-up credits by email |
+| `POST /api/admin/upgrade-plan` | POST | Upgrade user plan by email |
+
+### Auth
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `GET /api/auth/google/start` | GET | Start Google OAuth flow |
+| `GET /api/auth/callback/:provider` | GET | OAuth callback |
+| `GET /api/auth/oauth/token-bridge` | GET | Token bridge for static clients |
+| `GET /api/auth/oauth/desktop-bridge` | GET | Desktop activation (`qcut://activate?token=...`) |
+
+## Canary / Beta Gate
+
+Control who can make payments during beta testing.
+
+**Environment variables** (set on the Cloudflare Worker):
+
+```
+PAYMENTS_CANARY_ONLY=true              # Block payments for non-allowlisted users
+PAYMENTS_EMAIL_ALLOWLIST=a@b.com,c@d.com  # Comma-separated, case-insensitive
+```
+
+When enabled:
+- Checkout and top-up endpoints return **403** for users not in the allowlist
+- Error message: "Payments are currently restricted to internal tester accounts"
+- Free tier signup still works for everyone
+
+**Implementation**: `packages/license-server/src/services/payment-access.ts`
 
 ## Onboarding a Tester
 
-1. Tester signs up in QCut using their Gmail (Google OAuth)
-2. They get a **Free plan** automatically (50 credits/month, 5 AI generations, 1 device)
-3. To give more credits: either upgrade their plan in the DB or grant top-up credits
-4. Payment canary mode (`PAYMENTS_CANARY_ONLY`) can restrict purchases to an allowlist
+### Minimal (Free Tier — no manual steps)
+1. Tester opens QCut and signs in with their Gmail
+2. They automatically get Free plan: 50 credits/month, 1 device
+3. Done — they can start using AI features immediately
 
-## Actions Needed
+### Upgraded (More Credits)
 
-- [ ] Decide: grant extra credits via DB top-up, or upgrade plan to Pro/Team?
+Option A — **Admin API** (recommended):
+```bash
+# Look up a user
+curl -H "x-admin-key: $ADMIN_API_KEY" \
+  "https://qcut-license-server.zdhpeter.workers.dev/api/admin/user?email=tester@gmail.com"
+
+# Grant 500 top-up credits to one or more users
+curl -X POST -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"emails": ["tester1@gmail.com", "tester2@gmail.com"], "amount": 500, "description": "Beta tester grant"}' \
+  "https://qcut-license-server.zdhpeter.workers.dev/api/admin/grant-credits"
+
+# Upgrade a user's plan (also resets plan credits to match new tier)
+curl -X POST -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "tester@gmail.com", "plan": "pro"}' \
+  "https://qcut-license-server.zdhpeter.workers.dev/api/admin/upgrade-plan"
+```
+
+Option B — **Allow self-service payment**:
+1. Set `PAYMENTS_CANARY_ONLY=true` on the worker
+2. Add tester email to `PAYMENTS_EMAIL_ALLOWLIST`
+3. Tester can buy top-up packs or upgrade via Stripe checkout
+
+Option C — **Direct SQL** (if admin API not deployed yet):
+```sql
+UPDATE licenses SET plan = 'pro', max_devices = 3 WHERE user_id = '<id>';
+UPDATE credit_balances SET plan_credits = 500 WHERE user_id = '<id>';
+```
+
+## Database Schema (Key Tables)
+
+```
+users
+├─ id, email (unique), name, image, emailVerified, createdAt
+
+licenses
+├─ userId (unique FK → users)
+├─ plan: "free" | "pro" | "team"
+├─ status: "active" | "past_due" | "cancelled" | "expired"
+├─ maxDevices, stripeCustomerId, stripeSubscriptionId
+
+creditBalances
+├─ userId (unique FK → users)
+├─ planCredits, topUpCredits (numeric 12,3)
+├─ planCreditsResetAt
+
+creditTransactions
+├─ userId (FK → users)
+├─ type: "plan_grant" | "top_up" | "deduction" | "refund" | "expiry"
+├─ amount, balanceAfter, modelKey, description
+```
+
+## Setup Checklist
+
+- [x] Auth system (Google OAuth + email/password) — implemented
+- [x] Credit system (plans, deduction, monthly reset) — implemented
+- [x] Stripe payments (subscriptions + top-ups) — implemented
+- [x] Canary gate (`PAYMENTS_CANARY_ONLY` + email allowlist) — implemented
+- [x] Admin API for bulk credit grants & plan upgrades — implemented
+- [ ] Set `ADMIN_API_KEY` env var on Cloudflare Worker (via `wrangler secret put ADMIN_API_KEY`)
+- [ ] Deploy license server with admin routes (`wrangler deploy` from `packages/license-server/`)
+- [ ] Decide: grant extra credits via admin API, or upgrade plan to Pro/Team?
+- [ ] Decide: enable `PAYMENTS_CANARY_ONLY=true` for beta period?
 - [ ] Decide: add testers to `PAYMENTS_EMAIL_ALLOWLIST` for self-service top-up?
-- [ ] Script or admin endpoint to bulk-grant credits by email
 
 ## Tester List
 

--- a/qcut/docs/task/invite-test/testers.md
+++ b/qcut/docs/task/invite-test/testers.md
@@ -100,7 +100,7 @@ Control who can make payments during beta testing.
 
 **Environment variables** (set on the Cloudflare Worker):
 
-```
+```bash
 PAYMENTS_CANARY_ONLY=true              # Block payments for non-allowlisted users
 PAYMENTS_EMAIL_ALLOWLIST=a@b.com,c@d.com  # Comma-separated, case-insensitive
 ```
@@ -153,7 +153,7 @@ UPDATE credit_balances SET plan_credits = 500 WHERE user_id = '<id>';
 
 ## Database Schema (Key Tables)
 
-```
+```text
 users
 ├─ id, email (unique), name, image, emailVerified, createdAt
 

--- a/qcut/electron/__tests__/credit-estimator.test.ts
+++ b/qcut/electron/__tests__/credit-estimator.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { estimateProxyCredits } from "../native-pipeline/infra/credit-estimator.js";
+
+// Register models so the registry is populated
+import { registerTextToVideoModels } from "../native-pipeline/registry-data/text-to-video.js";
+import { registerTextToImageModels } from "../native-pipeline/registry-data/text-to-image.js";
+
+registerTextToVideoModels();
+registerTextToImageModels();
+
+describe("credit-estimator", () => {
+	it("returns positive credits for a registered model", () => {
+		const result = estimateProxyCredits("veo3", { duration: "8s" });
+		expect(result.amount).toBeGreaterThan(0);
+		expect(result.modelKey).toBe("veo3");
+		expect(result.description).toContain("generation");
+	});
+
+	it("falls back to 1 credit for unknown models", () => {
+		const result = estimateProxyCredits("nonexistent_model_xyz");
+		expect(result.amount).toBe(1);
+		expect(result.modelKey).toBe("nonexistent_model_xyz");
+	});
+
+	it("scales credits by duration for per-second models", () => {
+		const short = estimateProxyCredits("veo3", { duration: "5" });
+		const long = estimateProxyCredits("veo3", { duration: "10" });
+		expect(long.amount).toBeGreaterThan(short.amount);
+	});
+
+	it("returns correct format for proxy credits field", () => {
+		const result = estimateProxyCredits("hailuo_pro");
+		expect(result).toEqual({
+			amount: expect.any(Number),
+			modelKey: "hailuo_pro",
+			description: expect.stringContaining("generation"),
+		});
+		expect(result.amount).toBeGreaterThanOrEqual(0.1);
+	});
+});

--- a/qcut/electron/__tests__/proxy-credit-integration.test.ts
+++ b/qcut/electron/__tests__/proxy-credit-integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration test: verifies the full credit flow from callModelApi → proxy → server.
+ *
+ * Mocks fetch to capture the actual HTTP request body sent to the proxy,
+ * verifying that credits are included with the correct amount.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Register models
+import { registerTextToVideoModels } from "../native-pipeline/registry-data/text-to-video.js";
+registerTextToVideoModels();
+
+// Mock api-key-handler: return empty keys so proxy mode activates
+vi.mock("../api-key-handler.js", () => ({
+	getDecryptedApiKeys: vi.fn().mockResolvedValue({
+		falApiKey: "",
+		geminiApiKey: "",
+		openRouterApiKey: "",
+	}),
+}));
+
+// Mock session token provider
+vi.mock("../native-pipeline/infra/proxy-client.js", async (importOriginal) => {
+	const original = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...original,
+		getSessionToken: vi.fn().mockResolvedValue("test-session-token"),
+		isProxyAvailable: vi.fn().mockResolvedValue(true),
+	};
+});
+
+const { callModelApi } = await import("../native-pipeline/infra/api-caller.js");
+
+describe("proxy credit integration", () => {
+	const originalFetch = globalThis.fetch;
+	let capturedBody: Record<string, unknown> | null = null;
+
+	beforeEach(() => {
+		capturedBody = null;
+		delete process.env.FAL_KEY;
+		delete process.env.FAL_API_KEY;
+
+		// Intercept fetch to capture the request body sent to the proxy
+		globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+			const urlStr = typeof url === "string" ? url : url.toString();
+			if (urlStr.includes("/api/ai/proxy")) {
+				capturedBody = JSON.parse(init?.body as string);
+				return new Response(
+					JSON.stringify({ video: { url: "https://example.com/output.mp4" } }),
+					{ status: 200, headers: { "Content-Type": "application/json" } }
+				);
+			}
+			return new Response("Not found", { status: 404 });
+		}) as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("sends credits in the proxy request body for veo3 model", async () => {
+		const result = await callModelApi({
+			endpoint: "fal-ai/veo3",
+			modelKey: "veo3",
+			payload: { prompt: "a cat walking", duration: "8s" },
+			provider: "fal",
+			async: false,
+		});
+
+		expect(result.success).toBe(true);
+		expect(capturedBody).not.toBeNull();
+		expect(capturedBody!.credits).toBeDefined();
+
+		const credits = capturedBody!.credits as {
+			amount: number;
+			modelKey: string;
+			description: string;
+		};
+		expect(credits.modelKey).toBe("veo3");
+		expect(credits.amount).toBeGreaterThan(0);
+		expect(credits.description).toContain("generation");
+
+		// veo3 at 8s with audio: 8 * $0.75 = $6.00 → 60 credits
+		expect(credits.amount).toBe(60);
+	});
+
+	it("sends credits for hailuo_pro (per-video model)", async () => {
+		await callModelApi({
+			endpoint: "fal-ai/minimax/hailuo-02/pro/text-to-video",
+			modelKey: "hailuo_pro",
+			payload: { prompt: "test" },
+			provider: "fal",
+			async: false,
+		});
+
+		expect(capturedBody).not.toBeNull();
+		const credits = capturedBody!.credits as {
+			amount: number;
+			modelKey: string;
+		};
+		expect(credits.modelKey).toBe("hailuo_pro");
+		// hailuo_pro: $0.08 per video → 0.8 credits → rounds to 0.8
+		expect(credits.amount).toBeGreaterThanOrEqual(0.1);
+	});
+
+	it("does NOT send credits when modelKey is omitted", async () => {
+		await callModelApi({
+			endpoint: "fal-ai/veo3",
+			payload: { prompt: "test" },
+			provider: "fal",
+			async: false,
+		});
+
+		expect(capturedBody).not.toBeNull();
+		expect(capturedBody!.credits).toBeUndefined();
+	});
+});

--- a/qcut/electron/__tests__/proxy-credit-passthrough.test.ts
+++ b/qcut/electron/__tests__/proxy-credit-passthrough.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the api-key-handler so callModelApi can import
+vi.mock("../api-key-handler.js", () => ({
+	getDecryptedApiKeys: vi.fn().mockResolvedValue({
+		falApiKey: "",
+		geminiApiKey: "",
+		openRouterApiKey: "",
+	}),
+}));
+
+// Mock proxy-client to capture what gets passed
+const mockCallModelApiViaProxy = vi.fn().mockResolvedValue({
+	success: true,
+	data: {},
+	duration: 1,
+});
+
+vi.mock("../native-pipeline/infra/proxy-client.js", async (importOriginal) => {
+	const original = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...original,
+		isProxyAvailable: vi.fn().mockResolvedValue(true),
+		callModelApiViaProxy: mockCallModelApiViaProxy,
+	};
+});
+
+const { callModelApi } = await import("../native-pipeline/infra/api-caller.js");
+
+describe("proxy credit pass-through", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Ensure no local API keys so proxy mode is used
+		delete process.env.FAL_KEY;
+		delete process.env.FAL_API_KEY;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("passes credits when modelKey is provided", async () => {
+		await callModelApi({
+			endpoint: "fal-ai/ltx-video/v2",
+			modelKey: "some_model_key",
+			payload: { prompt: "test" },
+			provider: "fal",
+		});
+
+		expect(mockCallModelApiViaProxy).toHaveBeenCalledTimes(1);
+		const [options] = mockCallModelApiViaProxy.mock.calls[0];
+		expect(options.credits).toBeDefined();
+		expect(options.credits.amount).toBeGreaterThan(0);
+		expect(options.credits.modelKey).toBe("some_model_key");
+		expect(options.credits.description).toContain("generation");
+	});
+
+	it("does not pass credits when modelKey is omitted", async () => {
+		await callModelApi({
+			endpoint: "fal-ai/ltx-video/v2",
+			payload: { prompt: "test" },
+			provider: "fal",
+		});
+
+		expect(mockCallModelApiViaProxy).toHaveBeenCalledTimes(1);
+		const [options] = mockCallModelApiViaProxy.mock.calls[0];
+		expect(options.credits).toBeUndefined();
+	});
+});

--- a/qcut/electron/main-ipc/fal-upload-handlers.ts
+++ b/qcut/electron/main-ipc/fal-upload-handlers.ts
@@ -6,6 +6,10 @@
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
 import type { MainIpcDeps, Logger } from "./types.js";
 import { FAL_CONTENT_TYPES, FAL_DEFAULTS } from "./types.js";
+import {
+	isProxyAvailable,
+	proxyUploadUrl,
+} from "../native-pipeline/infra/proxy-client.js";
 
 /** Shared FAL 2-step upload: initiate signed URL, then PUT the file. */
 async function falUpload(
@@ -26,44 +30,60 @@ async function falUpload(
 			FAL_DEFAULTS[mediaType] ??
 			"application/octet-stream";
 
-		const initResponse = await fetch(
-			"https://rest.alpha.fal.ai/storage/upload/initiate?storage_type=fal-cdn-v3",
-			{
-				method: "POST",
-				headers: {
-					Authorization: `Key ${apiKey}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					file_name: filename,
-					content_type: contentType,
-				}),
-			}
-		);
+		let upload_url: string;
+		let file_url: string;
 
-		if (!initResponse.ok) {
-			const errorText = await initResponse.text();
-			logger.error(
-				`[FAL ${tag}] Initiate failed: ${initResponse.status} - ${errorText}`
+		const useProxy = await isProxyAvailable();
+
+		if (useProxy) {
+			logger.info(`[FAL ${tag}] Using proxy for upload URL`);
+			const urls = await proxyUploadUrl({
+				fileName: filename,
+				contentType,
+			});
+			upload_url = urls.uploadUrl;
+			file_url = urls.fileUrl;
+		} else {
+			const initResponse = await fetch(
+				"https://rest.alpha.fal.ai/storage/upload/initiate?storage_type=fal-cdn-v3",
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Key ${apiKey}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						file_name: filename,
+						content_type: contentType,
+					}),
+				}
 			);
-			return {
-				success: false,
-				error: `Upload initiate failed: ${initResponse.status} - ${errorText}`,
-			};
-		}
 
-		const initData = (await initResponse.json()) as {
-			upload_url?: string;
-			file_url?: string;
-		};
-		const { upload_url, file_url } = initData;
+			if (!initResponse.ok) {
+				const errorText = await initResponse.text();
+				logger.error(
+					`[FAL ${tag}] Initiate failed: ${initResponse.status} - ${errorText}`
+				);
+				return {
+					success: false,
+					error: `Upload initiate failed: ${initResponse.status} - ${errorText}`,
+				};
+			}
 
-		if (!upload_url || !file_url) {
-			logger.error(`[FAL ${tag}] Missing URLs in response`);
-			return {
-				success: false,
-				error: "FAL API did not return upload URLs",
+			const initData = (await initResponse.json()) as {
+				upload_url?: string;
+				file_url?: string;
 			};
+
+			if (!initData.upload_url || !initData.file_url) {
+				logger.error(`[FAL ${tag}] Missing URLs in response`);
+				return {
+					success: false,
+					error: "FAL API did not return upload URLs",
+				};
+			}
+			upload_url = initData.upload_url;
+			file_url = initData.file_url;
 		}
 
 		logger.info(`[FAL ${tag}] Step 2: Uploading to signed URL...`);

--- a/qcut/electron/main-ipc/fal-upload-handlers.ts
+++ b/qcut/electron/main-ipc/fal-upload-handlers.ts
@@ -114,6 +114,7 @@ async function falUpload(
 	}
 }
 
+/** Registers IPC handlers for uploading media files to FAL CDN storage. */
 export function registerFalUploadHandlers(deps: MainIpcDeps): void {
 	const { logger } = deps;
 

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -222,6 +222,7 @@ async function executeTextToImage(
 
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -261,6 +262,7 @@ async function executeTextToVideo(
 
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -288,6 +290,7 @@ async function executeImageToVideo(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -342,6 +345,7 @@ async function executeImageToImage(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -369,6 +373,7 @@ async function executeVideoToVideo(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -399,6 +404,7 @@ async function executeAvatar(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -437,6 +443,7 @@ async function executeTTS(
 
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -478,6 +485,7 @@ async function executeSTT(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -533,6 +541,7 @@ async function executeImageUnderstanding(
 	}
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
@@ -641,6 +650,7 @@ async function executeVolcengineVideoUnderstanding(
 
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload: apiPayload,
 		provider: "volcengine",
 		async: false,
@@ -703,6 +713,7 @@ async function executePromptGeneration(
 	payload.prompt = input.text || payload.prompt;
 	const result = await callModelApi({
 		endpoint: model.endpoint,
+		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -581,10 +581,9 @@ export async function callModelApi(
 
 	// ── Proxy mode: route through license server ──
 	if (useProxy) {
-		const credits =
-			options.modelKey
-				? estimateProxyCredits(options.modelKey, options.payload)
-				: undefined;
+		const credits = options.modelKey
+			? estimateProxyCredits(options.modelKey, options.payload)
+			: undefined;
 		return callModelApiViaProxy({ ...options, credits }, startTime);
 	}
 

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -11,15 +11,24 @@ import * as fs from "fs";
 import * as path from "path";
 import { pipeline } from "stream/promises";
 import { Readable } from "stream";
+import {
+	type ProviderName,
+	buildProviderUrl,
+	extractOutputUrl,
+	getAdaptivePollInterval,
+	FAL_BASE,
+	FAL_STATUS_BASE,
+	GEMINI_BASE,
+	OPENROUTER_BASE,
+	VOLCENGINE_BASE,
+} from "./api-provider-urls.js";
+import {
+	callModelApiViaProxy,
+	isProxyAvailable,
+	proxyUploadUrl,
+} from "./proxy-client.js";
 
-export type ProviderName =
-	| "fal"
-	| "elevenlabs"
-	| "google"
-	| "openrouter"
-	| "volcengine"
-	| "gmi"
-	| "runway";
+export type { ProviderName };
 export type ApiKeyProvider = (provider: ProviderName) => Promise<string>;
 
 export interface ApiCallOptions {
@@ -69,11 +78,7 @@ interface GmiStatusResponse {
 	error?: string;
 }
 
-const FAL_BASE = "https://queue.fal.run";
-const FAL_STATUS_BASE = "https://queue.fal.run";
 const FAL_TRUSTED_HOSTS = [".fal.run", ".fal.ai"];
-const GMI_BASE = "https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey";
-const RUNWAY_BASE = "https://api.runwayml.com/v1";
 
 /** Validate that a URL belongs to a trusted FAL domain before sending auth headers. */
 function isTrustedFalUrl(url: string): boolean {
@@ -107,41 +112,57 @@ export async function uploadToFalStorage(
 	filePath: string
 ): Promise<{ success: boolean; url?: string; error?: string }> {
 	try {
-		const apiKey = await getApiKey("fal");
-		if (!apiKey) {
-			return { success: false, error: "No FAL API key configured" };
-		}
-
 		const filename = path.basename(filePath);
 		const ext = path.extname(filePath).toLowerCase();
 		const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
-		// Step 1: Initiate upload to get signed URL
-		const initRes = await fetch(FAL_STORAGE_INITIATE, {
-			method: "POST",
-			headers: {
-				Authorization: `Key ${apiKey}`,
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				file_name: filename,
-				content_type: contentType,
-			}),
-		});
+		// Proxy mode: server vends the signed URL (key never leaves server)
+		const useProxy = await isProxyAvailable();
+		const apiKey = useProxy ? "" : await getApiKey("fal");
 
-		if (!initRes.ok) {
-			return {
-				success: false,
-				error: `FAL upload initiate failed: ${initRes.status}`,
-			};
+		if (!useProxy && !apiKey) {
+			return { success: false, error: "No FAL API key configured" };
 		}
 
-		const initData = (await initRes.json()) as {
-			upload_url?: string;
-			file_url?: string;
-		};
-		if (!initData.upload_url || !initData.file_url) {
-			return { success: false, error: "FAL API did not return upload URLs" };
+		let uploadUrl: string;
+		let fileUrl: string;
+
+		if (useProxy) {
+			const urls = await proxyUploadUrl({
+				fileName: filename,
+				contentType,
+			});
+			uploadUrl = urls.uploadUrl;
+			fileUrl = urls.fileUrl;
+		} else {
+			const initRes = await fetch(FAL_STORAGE_INITIATE, {
+				method: "POST",
+				headers: {
+					Authorization: `Key ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					file_name: filename,
+					content_type: contentType,
+				}),
+			});
+
+			if (!initRes.ok) {
+				return {
+					success: false,
+					error: `FAL upload initiate failed: ${initRes.status}`,
+				};
+			}
+
+			const initData = (await initRes.json()) as {
+				upload_url?: string;
+				file_url?: string;
+			};
+			if (!initData.upload_url || !initData.file_url) {
+				return { success: false, error: "FAL API did not return upload URLs" };
+			}
+			uploadUrl = initData.upload_url;
+			fileUrl = initData.file_url;
 		}
 
 		// Step 2: Read file and PUT to signed URL
@@ -155,7 +176,7 @@ export async function uploadToFalStorage(
 			};
 		}
 
-		const uploadRes = await fetch(initData.upload_url, {
+		const uploadRes = await fetch(uploadUrl, {
 			method: "PUT",
 			headers: { "Content-Type": contentType },
 			body: fileBuffer,
@@ -168,7 +189,7 @@ export async function uploadToFalStorage(
 			};
 		}
 
-		return { success: true, url: initData.file_url };
+		return { success: true, url: fileUrl };
 	} catch (err) {
 		return {
 			success: false,
@@ -177,28 +198,13 @@ export async function uploadToFalStorage(
 	}
 }
 
-const ELEVENLABS_BASE = "https://api.elevenlabs.io/v1";
-export const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta";
-export const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
-export const VOLCENGINE_BASE = "https://ark.cn-beijing.volces.com/api/v3";
+export { GEMINI_BASE, OPENROUTER_BASE, VOLCENGINE_BASE };
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const GMI_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_RETRIES = 2;
 
-/**
- * Adaptive polling interval based on elapsed time.
- * Starts aggressive (500ms) for quick jobs, backs off for longer ones.
- *
- * - 0–10s elapsed: 500ms intervals (catches quick completions)
- * - 10–30s elapsed: 2s intervals (typical image generation)
- * - 30s+ elapsed: 4s intervals (long-running jobs)
- */
-export function getAdaptivePollInterval(elapsedMs: number): number {
-	if (elapsedMs < 10_000) return 500;
-	if (elapsedMs < 30_000) return 2_000;
-	return 4_000;
-}
+export { getAdaptivePollInterval };
 
 /** Resolve API key from environment variables only (no Electron dependency). */
 export function envApiKeyProvider(provider: ProviderName): Promise<string> {
@@ -310,23 +316,7 @@ function buildUrl(
 	provider: ApiCallOptions["provider"],
 	endpoint: string
 ): string {
-	switch (provider) {
-		case "fal":
-			return `${FAL_BASE}/${endpoint}`;
-		case "elevenlabs":
-			return `${ELEVENLABS_BASE}/${endpoint}`;
-		case "google":
-			return `${GEMINI_BASE}/${endpoint}`;
-		case "openrouter":
-			return `${OPENROUTER_BASE}/${endpoint}`;
-		case "volcengine":
-			// Strip the "volcengine/" routing prefix from the endpoint
-			return `${VOLCENGINE_BASE}/${endpoint.replace(/^volcengine\//, "")}`;
-		case "gmi":
-			return `${GMI_BASE}/requests`;
-		case "runway":
-			return `${RUNWAY_BASE}/${endpoint}`;
-	}
+	return buildProviderUrl(provider, endpoint);
 }
 
 /**
@@ -483,7 +473,7 @@ async function pollGmiQueue(
 	const startTime = Date.now();
 	const apiKey = await getApiKey("gmi");
 	const headers = buildHeaders("gmi", apiKey);
-	const statusUrl = `${GMI_BASE}/requests/${requestId}`;
+	const statusUrl = `https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey/requests/${requestId}`;
 
 	const maxAttempts = 360;
 	let lastPercent = 0;
@@ -555,41 +545,7 @@ async function pollGmiQueue(
 	};
 }
 
-/** Extract a best-effort output URL from known provider response shapes. */
-function extractOutputUrl(data: unknown): string | undefined {
-	if (!data || typeof data !== "object") return;
-	const obj = data as Record<string, unknown>;
-
-	if (typeof obj.video === "object" && obj.video !== null) {
-		const video = obj.video as Record<string, unknown>;
-		if (typeof video.url === "string") return video.url;
-	}
-	if (typeof obj.image === "object" && obj.image !== null) {
-		const image = obj.image as Record<string, unknown>;
-		if (typeof image.url === "string") return image.url;
-	}
-	if (typeof obj.audio === "object" && obj.audio !== null) {
-		const audio = obj.audio as Record<string, unknown>;
-		if (typeof audio.url === "string") return audio.url;
-	}
-	if (Array.isArray(obj.images) && obj.images.length > 0) {
-		const first = obj.images[0] as Record<string, unknown>;
-		if (typeof first?.url === "string") return first.url;
-	}
-	if (Array.isArray(obj.videos) && obj.videos.length > 0) {
-		const first = obj.videos[0] as Record<string, unknown>;
-		if (typeof first?.url === "string") return first.url;
-	}
-	// GMI media_urls format (SkyReels, Gemini, Kling)
-	if (Array.isArray(obj.media_urls) && obj.media_urls.length > 0) {
-		const first = obj.media_urls[0] as Record<string, unknown>;
-		if (typeof first?.url === "string") return first.url;
-	}
-	if (typeof obj.output_url === "string") return obj.output_url;
-	if (typeof obj.url === "string") return obj.url;
-
-	return;
-}
+export { extractOutputUrl };
 
 /**
  * Call a provider endpoint and normalize the result payload.
@@ -610,12 +566,19 @@ export async function callModelApi(
 	} = options;
 
 	const apiKey = await getApiKey(provider);
-	if (!apiKey) {
+	const useProxy = !apiKey && (await isProxyAvailable());
+
+	if (!apiKey && !useProxy) {
 		return {
 			success: false,
 			error: `No API key configured for provider: ${provider}`,
 			duration: 0,
 		};
+	}
+
+	// ── Proxy mode: route through license server ──
+	if (useProxy) {
+		return callModelApiViaProxy(options, startTime);
 	}
 
 	const headers = buildHeaders(provider, apiKey);

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -27,6 +27,7 @@ import {
 	isProxyAvailable,
 	proxyUploadUrl,
 } from "./proxy-client.js";
+import { estimateProxyCredits } from "./credit-estimator.js";
 
 export type { ProviderName };
 export type ApiKeyProvider = (provider: ProviderName) => Promise<string>;
@@ -40,6 +41,8 @@ export interface ApiCallOptions {
 	timeoutMs?: number;
 	retries?: number;
 	signal?: AbortSignal;
+	/** Model registry key — used to calculate credit cost in proxy mode. */
+	modelKey?: string;
 }
 
 export interface ApiCallResult {
@@ -578,7 +581,11 @@ export async function callModelApi(
 
 	// ── Proxy mode: route through license server ──
 	if (useProxy) {
-		return callModelApiViaProxy(options, startTime);
+		const credits =
+			options.modelKey
+				? estimateProxyCredits(options.modelKey, options.payload)
+				: undefined;
+		return callModelApiViaProxy({ ...options, credits }, startTime);
 	}
 
 	const headers = buildHeaders(provider, apiKey);

--- a/qcut/electron/native-pipeline/infra/api-provider-urls.ts
+++ b/qcut/electron/native-pipeline/infra/api-provider-urls.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared provider URL constants and URL builder.
+ * Extracted to avoid circular dependencies between api-caller and proxy-client.
+ */
+
+export type ProviderName =
+	| "fal"
+	| "elevenlabs"
+	| "google"
+	| "openrouter"
+	| "volcengine"
+	| "gmi"
+	| "runway";
+
+export const FAL_BASE = "https://queue.fal.run";
+export const FAL_STATUS_BASE = "https://queue.fal.run";
+const ELEVENLABS_BASE = "https://api.elevenlabs.io/v1";
+export const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta";
+export const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+export const VOLCENGINE_BASE = "https://ark.cn-beijing.volces.com/api/v3";
+const GMI_BASE = "https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey";
+const RUNWAY_BASE = "https://api.runwayml.com/v1";
+
+/** Build a fully qualified provider URL from a logical endpoint path. */
+export function buildProviderUrl(
+	provider: ProviderName,
+	endpoint: string
+): string {
+	switch (provider) {
+		case "fal":
+			return `${FAL_BASE}/${endpoint}`;
+		case "elevenlabs":
+			return `${ELEVENLABS_BASE}/${endpoint}`;
+		case "google":
+			return `${GEMINI_BASE}/${endpoint}`;
+		case "openrouter":
+			return `${OPENROUTER_BASE}/${endpoint}`;
+		case "volcengine":
+			return `${VOLCENGINE_BASE}/${endpoint.replace(/^volcengine\//, "")}`;
+		case "gmi":
+			return `${GMI_BASE}/requests`;
+		case "runway":
+			return `${RUNWAY_BASE}/${endpoint}`;
+	}
+}
+
+/** Extract the first output URL from a provider response (video, image, audio). */
+export function extractOutputUrl(data: unknown): string | undefined {
+	if (!data || typeof data !== "object") return;
+	const obj = data as Record<string, unknown>;
+
+	if (typeof obj.video === "object" && obj.video !== null) {
+		const video = obj.video as Record<string, unknown>;
+		if (typeof video.url === "string") return video.url;
+	}
+	if (typeof obj.image === "object" && obj.image !== null) {
+		const image = obj.image as Record<string, unknown>;
+		if (typeof image.url === "string") return image.url;
+	}
+	if (typeof obj.audio === "object" && obj.audio !== null) {
+		const audio = obj.audio as Record<string, unknown>;
+		if (typeof audio.url === "string") return audio.url;
+	}
+	if (Array.isArray(obj.images) && obj.images.length > 0) {
+		const first = obj.images[0] as Record<string, unknown>;
+		if (typeof first?.url === "string") return first.url;
+	}
+	if (Array.isArray(obj.videos) && obj.videos.length > 0) {
+		const first = obj.videos[0] as Record<string, unknown>;
+		if (typeof first?.url === "string") return first.url;
+	}
+	if (Array.isArray(obj.media_urls) && obj.media_urls.length > 0) {
+		const first = obj.media_urls[0] as Record<string, unknown>;
+		if (typeof first?.url === "string") return first.url;
+	}
+	if (typeof obj.output_url === "string") return obj.output_url;
+	if (typeof obj.url === "string") return obj.url;
+
+	return;
+}
+
+/**
+ * Adaptive polling interval based on elapsed time.
+ * - 0–10s: 500ms, 10–30s: 2s, 30s+: 4s
+ */
+export function getAdaptivePollInterval(elapsedMs: number): number {
+	if (elapsedMs < 10_000) return 500;
+	if (elapsedMs < 30_000) return 2_000;
+	return 4_000;
+}

--- a/qcut/electron/native-pipeline/infra/credit-estimator.ts
+++ b/qcut/electron/native-pipeline/infra/credit-estimator.ts
@@ -1,0 +1,45 @@
+/**
+ * Credit cost estimator for proxy-mode API calls.
+ *
+ * Uses the cost-calculator (USD pricing from model registry) and converts
+ * to credits at 1 credit ≈ $0.10.
+ *
+ * @module electron/native-pipeline/infra/credit-estimator
+ */
+
+import { estimateCost } from "./cost-calculator.js";
+
+const USD_PER_CREDIT = 0.1;
+const DEFAULT_CREDITS = 1;
+
+/**
+ * Estimate the credit cost for an AI model call.
+ * Returns { amount, modelKey, description } ready for the proxy credits field.
+ *
+ * Falls back to a safe default (1 credit) if the model is not in the registry.
+ */
+export function estimateProxyCredits(
+	modelKey: string,
+	params?: Record<string, unknown>
+): { amount: number; modelKey: string; description: string } {
+	try {
+		const cost = estimateCost(modelKey, params ?? {});
+		const credits = Math.max(
+			0.1,
+			Math.round((cost.totalCost / USD_PER_CREDIT) * 10) / 10
+		);
+
+		return {
+			amount: credits,
+			modelKey,
+			description: `${cost.model} generation`,
+		};
+	} catch {
+		// Model not in registry — use safe default
+		return {
+			amount: DEFAULT_CREDITS,
+			modelKey,
+			description: `${modelKey} generation`,
+		};
+	}
+}

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -1,0 +1,403 @@
+/**
+ * Client for the QCut license-server AI proxy.
+ *
+ * Routes API requests through the server so provider keys never touch
+ * the user's machine. Falls back to direct calls when proxy is
+ * unavailable or user has their own key (BYOK).
+ *
+ * @module electron/native-pipeline/infra/proxy-client
+ */
+
+import {
+	type ProviderName,
+	buildProviderUrl,
+	extractOutputUrl,
+	getAdaptivePollInterval,
+} from "./api-provider-urls.js";
+
+const DEFAULT_LICENSE_SERVER =
+	"https://qcut-license-server.zdhpeter.workers.dev";
+
+/** Resolves the license-server base URL from env or default. */
+export function getLicenseServerUrl(): string {
+	return process.env.QCUT_LICENSE_SERVER_URL?.trim() || DEFAULT_LICENSE_SERVER;
+}
+
+/** Session token provider — injected at startup from license-handler. */
+let sessionTokenProvider: (() => Promise<string>) | null = null;
+
+export function setSessionTokenProvider(provider: () => Promise<string>): void {
+	sessionTokenProvider = provider;
+}
+
+/** Returns the current session token, or empty string if unavailable. */
+export async function getSessionToken(): Promise<string> {
+	if (!sessionTokenProvider) return "";
+	try {
+		return await sessionTokenProvider();
+	} catch {
+		return "";
+	}
+}
+
+/** Whether proxy mode is available (has session token, no override). */
+export async function isProxyAvailable(): Promise<boolean> {
+	const token = await getSessionToken();
+	return token.length > 0;
+}
+
+export interface ProxyRequestOptions {
+	provider: string;
+	endpoint: string;
+	method?: string;
+	body?: unknown;
+	credits?: {
+		amount: number;
+		modelKey: string;
+		description: string;
+	};
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+export interface ProxyResponse {
+	ok: boolean;
+	status: number;
+	data: unknown;
+}
+
+/**
+ * Forward a JSON request through the AI proxy.
+ * POST /api/ai/proxy
+ */
+export async function proxyRequest(
+	options: ProxyRequestOptions
+): Promise<ProxyResponse> {
+	const token = await getSessionToken();
+	const baseUrl = getLicenseServerUrl();
+
+	const response = await fetch(`${baseUrl}/api/ai/proxy`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({
+			provider: options.provider,
+			endpoint: options.endpoint,
+			method: options.method ?? "POST",
+			body: options.body,
+			credits: options.credits,
+		}),
+		signal: options.signal ?? AbortSignal.timeout(options.timeoutMs ?? 120_000),
+	});
+
+	const text = await response.text();
+	let data: unknown;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		data = text;
+	}
+
+	return { ok: response.ok, status: response.status, data };
+}
+
+/**
+ * Get a signed upload URL from the proxy.
+ * POST /api/ai/upload-url
+ */
+export async function proxyUploadUrl({
+	fileName,
+	contentType,
+	fileSize,
+}: {
+	fileName: string;
+	contentType: string;
+	fileSize?: number;
+}): Promise<{ uploadUrl: string; fileUrl: string }> {
+	const token = await getSessionToken();
+	const baseUrl = getLicenseServerUrl();
+
+	const response = await fetch(`${baseUrl}/api/ai/upload-url`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({
+			provider: "fal",
+			fileName,
+			contentType,
+			fileSize,
+		}),
+		signal: AbortSignal.timeout(15_000),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(
+			`Upload URL request failed (${response.status}): ${errorText}`
+		);
+	}
+
+	return response.json();
+}
+
+/**
+ * Poll async job status through the proxy.
+ * GET /api/ai/status
+ */
+export async function proxyPollStatus({
+	provider,
+	endpoint,
+	requestId,
+	signal,
+}: {
+	provider: string;
+	endpoint?: string;
+	requestId: string;
+	signal?: AbortSignal;
+}): Promise<{ status: number; data: unknown }> {
+	const token = await getSessionToken();
+	const baseUrl = getLicenseServerUrl();
+
+	const params = new URLSearchParams({ provider, requestId });
+	if (endpoint) params.set("endpoint", endpoint);
+
+	const response = await fetch(`${baseUrl}/api/ai/status?${params}`, {
+		method: "GET",
+		headers: { Authorization: `Bearer ${token}` },
+		signal: signal ?? AbortSignal.timeout(15_000),
+	});
+
+	const text = await response.text();
+	let data: unknown;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		data = text;
+	}
+
+	return { status: response.status, data };
+}
+/**
+ * Fetch completed async job result through the proxy.
+ * GET /api/ai/result
+ */
+export async function proxyFetchResult({
+	provider,
+	endpoint,
+	requestId,
+	signal,
+}: {
+	provider: string;
+	endpoint: string;
+	requestId: string;
+	signal?: AbortSignal;
+}): Promise<{ status: number; data: unknown }> {
+	const token = await getSessionToken();
+	const baseUrl = getLicenseServerUrl();
+
+	const params = new URLSearchParams({ provider, endpoint, requestId });
+
+	const response = await fetch(`${baseUrl}/api/ai/result?${params}`, {
+		method: "GET",
+		headers: { Authorization: `Bearer ${token}` },
+		signal: signal ?? AbortSignal.timeout(30_000),
+	});
+
+	const text = await response.text();
+	let data: unknown;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		data = text;
+	}
+
+	return { status: response.status, data };
+}
+
+// ── High-level proxy orchestration ──────────────────────────────────────────
+
+export interface ProxyApiCallOptions {
+	endpoint: string;
+	payload: Record<string, unknown>;
+	provider: ProviderName;
+	async?: boolean;
+	onProgress?: (percent: number, message: string) => void;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+}
+
+export interface ApiCallResult {
+	success: boolean;
+	data?: unknown;
+	outputUrl?: string;
+	error?: string;
+	duration: number;
+	cost?: number;
+}
+
+/**
+ * Proxy-mode implementation of callModelApi.
+ * Routes through the license server so provider keys never leave the server.
+ */
+export async function callModelApiViaProxy(
+	options: ProxyApiCallOptions,
+	startTime: number
+): Promise<ApiCallResult> {
+	const { endpoint, payload, provider, signal } = options;
+	const providerUrl = buildProviderUrl(provider, endpoint);
+
+	try {
+		const res = await proxyRequest({
+			provider,
+			endpoint: providerUrl,
+			method: "POST",
+			body:
+				provider === "gmi" && endpoint && endpoint !== "requests"
+					? { model: endpoint, payload }
+					: payload,
+			signal,
+			timeoutMs: options.timeoutMs,
+		});
+
+		if (!res.ok) {
+			return {
+				success: false,
+				error: `API error ${res.status}: ${typeof res.data === "string" ? res.data : JSON.stringify(res.data)}`,
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		const data = res.data as Record<string, unknown>;
+
+		if (provider === "fal" && options.async !== false) {
+			const requestId =
+				typeof data.request_id === "string" ? data.request_id : "";
+			if (requestId && data.status !== "COMPLETED") {
+				return pollViaProxy({
+					provider: "fal",
+					endpoint,
+					requestId,
+					onProgress: options.onProgress,
+					signal,
+					startTime,
+				});
+			}
+		}
+
+		if (provider === "gmi") {
+			const requestId =
+				typeof data.request_id === "string"
+					? data.request_id
+					: typeof data.id === "string"
+						? data.id
+						: "";
+			if (requestId) {
+				return pollViaProxy({
+					provider: "gmi",
+					endpoint,
+					requestId,
+					onProgress: options.onProgress,
+					signal,
+					startTime,
+				});
+			}
+		}
+
+		return {
+			success: true,
+			data,
+			outputUrl: extractOutputUrl(data),
+			duration: (Date.now() - startTime) / 1000,
+		};
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			success: false,
+			error: msg.includes("aborted") ? "Cancelled" : msg,
+			duration: (Date.now() - startTime) / 1000,
+		};
+	}
+}
+
+/** Poll an async job through the proxy until completion. */
+async function pollViaProxy({
+	provider,
+	endpoint,
+	requestId,
+	onProgress,
+	signal,
+	startTime,
+}: {
+	provider: string;
+	endpoint: string;
+	requestId: string;
+	onProgress?: (percent: number, message: string) => void;
+	signal?: AbortSignal;
+	startTime: number;
+}): Promise<ApiCallResult> {
+	let lastPercent = 10;
+
+	while (!signal?.aborted) {
+		const elapsed = Date.now() - startTime;
+		const interval = getAdaptivePollInterval(elapsed);
+		await new Promise((r) => setTimeout(r, interval));
+
+		const poll = await proxyPollStatus({
+			provider,
+			endpoint: provider === "fal" ? endpoint : undefined,
+			requestId,
+			signal,
+		});
+
+		const status = poll.data as Record<string, unknown>;
+		const statusStr = String(status?.status ?? "").toUpperCase();
+
+		if (statusStr === "COMPLETED" || statusStr === "SUCCESS") {
+			if (provider === "fal") {
+				const result = await proxyFetchResult({
+					provider: "fal",
+					endpoint,
+					requestId,
+					signal,
+				});
+				const data = result.data as Record<string, unknown>;
+				return {
+					success: true,
+					data,
+					outputUrl: extractOutputUrl(data),
+					duration: (Date.now() - startTime) / 1000,
+				};
+			}
+			const outcome = status.outcome as Record<string, unknown> | undefined;
+			return {
+				success: true,
+				data: status,
+				outputUrl: extractOutputUrl(outcome ?? status),
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		if (statusStr === "FAILED" || statusStr === "CANCELLED") {
+			return {
+				success: false,
+				error: `Job ${statusStr.toLowerCase()}: ${String(status?.error ?? "unknown error")}`,
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		if (onProgress && lastPercent < 90) {
+			lastPercent = Math.min(lastPercent + 5, 90);
+			onProgress(lastPercent, `${provider} processing...`);
+		}
+	}
+
+	return {
+		success: false,
+		error: "Cancelled",
+		duration: (Date.now() - startTime) / 1000,
+	};
+}

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -228,6 +228,8 @@ export interface ProxyApiCallOptions {
 	onProgress?: (percent: number, message: string) => void;
 	timeoutMs?: number;
 	signal?: AbortSignal;
+	/** Credit info for server-side deduction. */
+	credits?: { amount: number; modelKey: string; description: string };
 }
 
 export interface ApiCallResult {
@@ -247,7 +249,7 @@ export async function callModelApiViaProxy(
 	options: ProxyApiCallOptions,
 	startTime: number
 ): Promise<ApiCallResult> {
-	const { endpoint, payload, provider, signal } = options;
+	const { endpoint, payload, provider, signal, credits } = options;
 	const providerUrl = buildProviderUrl(provider, endpoint);
 
 	try {
@@ -259,6 +261,7 @@ export async function callModelApiViaProxy(
 				provider === "gmi" && endpoint && endpoint !== "requests"
 					? { model: endpoint, payload }
 					: payload,
+			credits,
 			signal,
 			timeoutMs: options.timeoutMs,
 		});
@@ -323,6 +326,8 @@ export async function callModelApiViaProxy(
 	}
 }
 
+const MAX_POLL_ATTEMPTS = 360;
+
 /** Poll an async job through the proxy until completion. */
 async function pollViaProxy({
 	provider,
@@ -341,7 +346,11 @@ async function pollViaProxy({
 }): Promise<ApiCallResult> {
 	let lastPercent = 10;
 
-	while (!signal?.aborted) {
+	for (
+		let attempt = 0;
+		attempt < MAX_POLL_ATTEMPTS && !signal?.aborted;
+		attempt++
+	) {
 		const elapsed = Date.now() - startTime;
 		const interval = getAdaptivePollInterval(elapsed);
 		await new Promise((r) => setTimeout(r, interval));
@@ -397,7 +406,9 @@ async function pollViaProxy({
 
 	return {
 		success: false,
-		error: "Cancelled",
+		error: signal?.aborted
+			? "Cancelled"
+			: `Polling timed out after ${MAX_POLL_ATTEMPTS} attempts`,
 		duration: (Date.now() - startTime) / 1000,
 	};
 }

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -26,6 +26,7 @@ export function getLicenseServerUrl(): string {
 /** Session token provider — injected at startup from license-handler. */
 let sessionTokenProvider: (() => Promise<string>) | null = null;
 
+/** Registers the callback that supplies session tokens for proxy auth. */
 export function setSessionTokenProvider(provider: () => Promise<string>): void {
 	sessionTokenProvider = provider;
 }

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -141,7 +141,7 @@ export async function proxyUploadUrl({
 		);
 	}
 
-	return response.json();
+	return response.json() as Promise<{ uploadUrl: string; fileUrl: string }>;
 }
 
 /**

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -289,6 +289,21 @@ export async function callModelApiViaProxy(
 					startTime,
 				});
 			}
+			if (requestId && data.status === "COMPLETED") {
+				const result = await proxyFetchResult({
+					provider: "fal",
+					endpoint,
+					requestId,
+					signal,
+				});
+				const resultData = result.data as Record<string, unknown>;
+				return {
+					success: true,
+					data: resultData,
+					outputUrl: extractOutputUrl(resultData),
+					duration: (Date.now() - startTime) / 1000,
+				};
+			}
 		}
 
 		if (provider === "gmi") {

--- a/qcut/packages/license-server/.env.example
+++ b/qcut/packages/license-server/.env.example
@@ -33,6 +33,9 @@ PAYMENTS_WEBHOOK_ENABLED=false
 PAYMENTS_CANARY_ONLY=true
 PAYMENTS_EMAIL_ALLOWLIST=
 
+# Admin API (for bulk credit grants, plan upgrades)
+ADMIN_API_KEY=
+
 # Extra CORS origins (comma-separated). Optional.
 CORS_ALLOWED_ORIGINS=
 

--- a/qcut/packages/license-server/.env.example
+++ b/qcut/packages/license-server/.env.example
@@ -36,6 +36,18 @@ PAYMENTS_EMAIL_ALLOWLIST=
 # Admin API (for bulk credit grants, plan upgrades)
 ADMIN_API_KEY=
 
+# AI provider keys (used by /api/ai/proxy — stored as Wrangler secrets in prod)
+FAL_API_KEY=
+GEMINI_API_KEY=
+OPENROUTER_API_KEY=
+ELEVENLABS_API_KEY=
+GMI_API_KEY=
+RUNWAY_API_KEY=
+FREESOUND_API_KEY=
+
+# AI proxy rate limit (requests per minute per user, default 60)
+AI_PROXY_RATE_LIMIT=60
+
 # Extra CORS origins (comma-separated). Optional.
 CORS_ALLOWED_ORIGINS=
 

--- a/qcut/packages/license-server/src/index.ts
+++ b/qcut/packages/license-server/src/index.ts
@@ -6,6 +6,7 @@ import { stripeRoutes } from "./routes/stripe";
 import { creditsRoutes } from "./routes/credits";
 import { authRoutes } from "./routes/auth";
 import { youtubeRoutes } from "./routes/youtube";
+import { adminRoutes } from "./routes/admin";
 import { getMockResponse, isMockMode } from "./middleware/mock";
 import { getAllowedCorsOrigins } from "./services/payment-config";
 
@@ -75,5 +76,6 @@ app.route("/api/credits", creditsRoutes);
 app.route("/api/stripe", stripeRoutes);
 app.route("/api/auth", authRoutes);
 app.route("/api/youtube", youtubeRoutes);
+app.route("/api/admin", adminRoutes);
 
 export default app;

--- a/qcut/packages/license-server/src/index.ts
+++ b/qcut/packages/license-server/src/index.ts
@@ -7,6 +7,7 @@ import { creditsRoutes } from "./routes/credits";
 import { authRoutes } from "./routes/auth";
 import { youtubeRoutes } from "./routes/youtube";
 import { adminRoutes } from "./routes/admin";
+import { aiProxyRoutes } from "./routes/ai-proxy";
 import { getMockResponse, isMockMode } from "./middleware/mock";
 import { getAllowedCorsOrigins } from "./services/payment-config";
 
@@ -77,5 +78,6 @@ app.route("/api/stripe", stripeRoutes);
 app.route("/api/auth", authRoutes);
 app.route("/api/youtube", youtubeRoutes);
 app.route("/api/admin", adminRoutes);
+app.route("/api/ai", aiProxyRoutes);
 
 export default app;

--- a/qcut/packages/license-server/src/middleware/admin-auth.test.ts
+++ b/qcut/packages/license-server/src/middleware/admin-auth.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { adminAuthMiddleware } from "./admin-auth";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) {
+			delete process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+afterEach(() => {
+	resetEnv();
+});
+
+function buildApp(): Hono {
+	const app = new Hono();
+	app.use("/*", adminAuthMiddleware);
+	app.get("/test", (c) => c.json({ ok: true }));
+	return app;
+}
+
+describe("adminAuthMiddleware", () => {
+	it("returns 503 when ADMIN_API_KEY is not set", async () => {
+		delete process.env.ADMIN_API_KEY;
+		const res = await buildApp().request("/test");
+		expect(res.status).toBe(503);
+		const body = await res.json();
+		expect(body.error).toBe("Admin API not configured");
+	});
+
+	it("returns 401 when no x-admin-key header is provided", async () => {
+		process.env.ADMIN_API_KEY = "secret-key";
+		const res = await buildApp().request("/test");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 401 when x-admin-key does not match", async () => {
+		process.env.ADMIN_API_KEY = "secret-key";
+		const res = await buildApp().request("/test", {
+			headers: { "x-admin-key": "wrong-key" },
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("passes through when x-admin-key matches", async () => {
+		process.env.ADMIN_API_KEY = "secret-key";
+		const res = await buildApp().request("/test", {
+			headers: { "x-admin-key": "secret-key" },
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.ok).toBe(true);
+	});
+
+	it("trims whitespace from the header value", async () => {
+		process.env.ADMIN_API_KEY = "secret-key";
+		const res = await buildApp().request("/test", {
+			headers: { "x-admin-key": "  secret-key  " },
+		});
+		expect(res.status).toBe(200);
+	});
+});

--- a/qcut/packages/license-server/src/middleware/admin-auth.ts
+++ b/qcut/packages/license-server/src/middleware/admin-auth.ts
@@ -1,0 +1,19 @@
+import type { Context, Next } from "hono";
+
+/**
+ * Validates requests against the ADMIN_API_KEY environment variable.
+ * Expects the key in the `x-admin-key` header.
+ */
+export async function adminAuthMiddleware(c: Context, next: Next) {
+	const adminKey = process.env.ADMIN_API_KEY;
+	if (!adminKey || adminKey.length === 0) {
+		return c.json({ error: "Admin API not configured" }, 503);
+	}
+
+	const provided = c.req.header("x-admin-key")?.trim() ?? "";
+	if (provided.length === 0 || provided !== adminKey) {
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+
+	await next();
+}

--- a/qcut/packages/license-server/src/middleware/rate-limit.test.ts
+++ b/qcut/packages/license-server/src/middleware/rate-limit.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { rateLimitMiddleware, resetRateLimitState } from "./rate-limit";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) {
+			delete process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+function buildApp(limit?: number): Hono {
+	if (limit !== undefined) {
+		process.env.AI_PROXY_RATE_LIMIT = String(limit);
+	}
+	const app = new Hono();
+	// Simulate authMiddleware by setting userId
+	app.use("/*", async (c, next) => {
+		c.set("userId", "test-user-1");
+		await next();
+	});
+	app.use("/*", rateLimitMiddleware);
+	app.get("/test", (c) => c.json({ ok: true }));
+	return app;
+}
+
+beforeEach(() => {
+	resetRateLimitState();
+});
+
+afterEach(() => {
+	resetEnv();
+	resetRateLimitState();
+});
+
+describe("rateLimitMiddleware", () => {
+	it("allows requests under the limit", async () => {
+		const app = buildApp(5);
+		const res = await app.request("/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("returns 429 when limit is exceeded", async () => {
+		const app = buildApp(3);
+		for (let i = 0; i < 3; i++) {
+			const res = await app.request("/test");
+			expect(res.status).toBe(200);
+		}
+		const res = await app.request("/test");
+		expect(res.status).toBe(429);
+		const body = await res.json();
+		expect(body.error).toBe("Too many requests");
+		expect(body.retryAfter).toBeGreaterThan(0);
+		expect(res.headers.get("Retry-After")).toBeTruthy();
+	});
+
+	it("defaults to 60 when env var is not set", async () => {
+		delete process.env.AI_PROXY_RATE_LIMIT;
+		const app = buildApp();
+		// Should allow at least 10 requests (default is 60)
+		for (let i = 0; i < 10; i++) {
+			const res = await app.request("/test");
+			expect(res.status).toBe(200);
+		}
+	});
+
+	it("returns 401 when userId is not set", async () => {
+		const app = new Hono();
+		app.use("/*", rateLimitMiddleware);
+		app.get("/test", (c) => c.json({ ok: true }));
+
+		const res = await app.request("/test");
+		expect(res.status).toBe(401);
+	});
+
+	it("tracks different users independently", async () => {
+		const app = new Hono();
+		let currentUser = "user-a";
+		app.use("/*", async (c, next) => {
+			c.set("userId", currentUser);
+			await next();
+		});
+		app.use("/*", rateLimitMiddleware);
+		app.get("/test", (c) => c.json({ ok: true }));
+
+		process.env.AI_PROXY_RATE_LIMIT = "2";
+
+		// User A: 2 requests (at limit)
+		for (let i = 0; i < 2; i++) {
+			const res = await app.request("/test");
+			expect(res.status).toBe(200);
+		}
+
+		// User A: over limit
+		let res = await app.request("/test");
+		expect(res.status).toBe(429);
+
+		// User B: should still have quota
+		currentUser = "user-b";
+		res = await app.request("/test");
+		expect(res.status).toBe(200);
+	});
+});

--- a/qcut/packages/license-server/src/middleware/rate-limit.ts
+++ b/qcut/packages/license-server/src/middleware/rate-limit.ts
@@ -1,0 +1,86 @@
+import type { Context, Next } from "hono";
+
+/**
+ * Simple in-memory sliding-window rate limiter.
+ * Keyed by userId (set by authMiddleware). Limits requests per minute.
+ *
+ * Note: In a multi-instance deployment each worker has its own counter,
+ * so the effective limit is per-worker. For Cloudflare Workers on a single
+ * isolate this is fine; for horizontal scaling consider Durable Objects or KV.
+ */
+
+interface WindowEntry {
+	timestamps: number[];
+}
+
+const windows = new Map<string, WindowEntry>();
+
+const WINDOW_MS = 60_000; // 1 minute
+const CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
+
+let lastCleanup = Date.now();
+
+function getLimit(): number {
+	const envLimit = Number(process.env.AI_PROXY_RATE_LIMIT);
+	return Number.isFinite(envLimit) && envLimit > 0 ? envLimit : 60;
+}
+
+/** Removes stale entries to prevent unbounded memory growth. */
+function cleanupIfNeeded(now: number): void {
+	if (now - lastCleanup < CLEANUP_INTERVAL_MS) {
+		return;
+	}
+	lastCleanup = now;
+	const cutoff = now - WINDOW_MS;
+	for (const [key, entry] of windows) {
+		entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+		if (entry.timestamps.length === 0) {
+			windows.delete(key);
+		}
+	}
+}
+
+export async function rateLimitMiddleware(c: Context, next: Next) {
+	const userId = c.get("userId") as string | undefined;
+	if (!userId) {
+		// No user context — auth middleware should have rejected already
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+
+	const now = Date.now();
+	const limit = getLimit();
+
+	cleanupIfNeeded(now);
+
+	const entry = windows.get(userId) ?? { timestamps: [] };
+	const cutoff = now - WINDOW_MS;
+
+	// Drop timestamps outside the current window
+	entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+	if (entry.timestamps.length >= limit) {
+		const oldestInWindow = entry.timestamps[0] ?? now;
+		const retryAfterSeconds = Math.ceil(
+			(oldestInWindow + WINDOW_MS - now) / 1000
+		);
+		c.header("Retry-After", String(retryAfterSeconds));
+		return c.json(
+			{
+				error: "Too many requests",
+				retryAfter: retryAfterSeconds,
+			},
+			429
+		);
+	}
+
+	entry.timestamps.push(now);
+	windows.set(userId, entry);
+
+	await next();
+}
+
+/** Resets all rate-limit state. Useful for tests. */
+export function resetRateLimitState(): void {
+	windows.clear();
+	lastCleanup = Date.now();
+}

--- a/qcut/packages/license-server/src/middleware/rate-limit.ts
+++ b/qcut/packages/license-server/src/middleware/rate-limit.ts
@@ -40,6 +40,7 @@ function cleanupIfNeeded(now: number): void {
 	}
 }
 
+/** Sliding-window rate limiter middleware keyed by authenticated userId. */
 export async function rateLimitMiddleware(c: Context, next: Next) {
 	const userId = c.get("userId") as string | undefined;
 	if (!userId) {

--- a/qcut/packages/license-server/src/routes/admin.test.ts
+++ b/qcut/packages/license-server/src/routes/admin.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Mock the DB module before importing the routes
+vi.mock("../db/drizzle", () => ({
+	db: {
+		select: vi.fn(),
+		update: vi.fn(),
+		insert: vi.fn(),
+	},
+}));
+
+vi.mock("../services/credit-service", () => ({
+	addTopUpCreditsForUser: vi.fn(),
+	getCreditBalanceByUserId: vi.fn(),
+	resetPlanCreditsForUser: vi.fn(),
+}));
+
+// Must import after mocks are set up
+const { db } = await import("../db/drizzle");
+const {
+	addTopUpCreditsForUser,
+	getCreditBalanceByUserId,
+	resetPlanCreditsForUser,
+} = await import("../services/credit-service");
+const { adminRoutes } = await import("./admin");
+
+const ADMIN_KEY = "test-admin-key";
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) {
+			delete process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+function buildApp(): Hono {
+	const app = new Hono();
+	app.route("/api/admin", adminRoutes);
+	return app;
+}
+
+function adminHeaders(): Record<string, string> {
+	return { "x-admin-key": ADMIN_KEY, "Content-Type": "application/json" };
+}
+
+/** Helper to make a chainable select mock that resolves to rows. */
+function mockSelectChain(rows: Record<string, unknown>[]): void {
+	const chain = {
+		from: vi.fn().mockReturnThis(),
+		where: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockResolvedValue(rows),
+	};
+	vi.mocked(db.select).mockReturnValue(chain as never);
+}
+
+/** Helper for update chain. */
+function mockUpdateChain(): {
+	set: ReturnType<typeof vi.fn>;
+	where: ReturnType<typeof vi.fn>;
+} {
+	const chain = {
+		set: vi.fn().mockReturnThis(),
+		where: vi.fn().mockResolvedValue(undefined),
+	};
+	vi.mocked(db.update).mockReturnValue(chain as never);
+	return chain;
+}
+
+beforeEach(() => {
+	process.env.ADMIN_API_KEY = ADMIN_KEY;
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	resetEnv();
+});
+
+describe("GET /api/admin/user", () => {
+	it("returns 400 when email is missing", async () => {
+		const res = await buildApp().request("/api/admin/user", {
+			headers: adminHeaders(),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 when user not found", async () => {
+		mockSelectChain([]);
+		const res = await buildApp().request(
+			"/api/admin/user?email=nobody@test.com",
+			{ headers: adminHeaders() }
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns user info with credits", async () => {
+		// First select: user lookup
+		const userChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi
+				.fn()
+				.mockResolvedValue([
+					{ id: "u1", name: "Test", email: "test@test.com" },
+				]),
+		};
+		// Second select: license lookup
+		const licenseChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([{ plan: "pro", status: "active" }]),
+		};
+
+		vi.mocked(db.select)
+			.mockReturnValueOnce(userChain as never)
+			.mockReturnValueOnce(licenseChain as never);
+
+		vi.mocked(getCreditBalanceByUserId).mockResolvedValue({
+			planCredits: 500,
+			topUpCredits: 100,
+			totalCredits: 600,
+			planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+		});
+
+		const res = await buildApp().request(
+			"/api/admin/user?email=test@test.com",
+			{ headers: adminHeaders() }
+		);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.user.email).toBe("test@test.com");
+		expect(body.user.plan).toBe("pro");
+		expect(body.credits.totalCredits).toBe(600);
+	});
+});
+
+describe("POST /api/admin/grant-credits", () => {
+	it("returns 400 when no emails provided", async () => {
+		const res = await buildApp().request("/api/admin/grant-credits", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ amount: 100 }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when amount is invalid", async () => {
+		const res = await buildApp().request("/api/admin/grant-credits", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ email: "a@b.com", amount: -5 }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("grants credits to found users and reports missing ones", async () => {
+		// First call: found user
+		const foundChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([{ id: "u1" }]),
+		};
+		// Second call: not found
+		const notFoundChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([]),
+		};
+
+		vi.mocked(db.select)
+			.mockReturnValueOnce(foundChain as never)
+			.mockReturnValueOnce(notFoundChain as never);
+
+		vi.mocked(addTopUpCreditsForUser).mockResolvedValue({
+			planCredits: 50,
+			topUpCredits: 200,
+			totalCredits: 250,
+			planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+		});
+
+		const res = await buildApp().request("/api/admin/grant-credits", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({
+				emails: ["found@test.com", "missing@test.com"],
+				amount: 200,
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.summary.succeeded).toBe(1);
+		expect(body.summary.failed).toBe(1);
+		expect(body.results[0].success).toBe(true);
+		expect(body.results[1].success).toBe(false);
+		expect(body.results[1].error).toBe("User not found");
+	});
+
+	it("accepts single email string", async () => {
+		const chain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([{ id: "u1" }]),
+		};
+		vi.mocked(db.select).mockReturnValue(chain as never);
+		vi.mocked(addTopUpCreditsForUser).mockResolvedValue({
+			planCredits: 50,
+			topUpCredits: 100,
+			totalCredits: 150,
+			planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+		});
+
+		const res = await buildApp().request("/api/admin/grant-credits", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ email: "solo@test.com", amount: 100 }),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.summary.succeeded).toBe(1);
+	});
+});
+
+describe("POST /api/admin/upgrade-plan", () => {
+	it("returns 400 when email is missing", async () => {
+		const res = await buildApp().request("/api/admin/upgrade-plan", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ plan: "pro" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 for invalid plan", async () => {
+		const res = await buildApp().request("/api/admin/upgrade-plan", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ email: "a@b.com", plan: "enterprise" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("upgrades plan and resets credits", async () => {
+		// User lookup
+		const userChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([{ id: "u1" }]),
+		};
+		// License lookup
+		const licenseChain = {
+			from: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			limit: vi.fn().mockResolvedValue([{ id: "lic1" }]),
+		};
+
+		vi.mocked(db.select)
+			.mockReturnValueOnce(userChain as never)
+			.mockReturnValueOnce(licenseChain as never);
+
+		mockUpdateChain();
+
+		vi.mocked(resetPlanCreditsForUser).mockResolvedValue({
+			planCredits: 2000,
+			topUpCredits: 0,
+			totalCredits: 2000,
+			planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+		});
+
+		const res = await buildApp().request("/api/admin/upgrade-plan", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ email: "tester@test.com", plan: "team" }),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.user.plan).toBe("team");
+		expect(body.user.maxDevices).toBe(10);
+		expect(body.credits.totalCredits).toBe(2000);
+	});
+
+	it("returns 404 when user not found", async () => {
+		mockSelectChain([]);
+		const res = await buildApp().request("/api/admin/upgrade-plan", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({ email: "nobody@test.com", plan: "pro" }),
+		});
+		expect(res.status).toBe(404);
+	});
+});

--- a/qcut/packages/license-server/src/routes/admin.ts
+++ b/qcut/packages/license-server/src/routes/admin.ts
@@ -63,7 +63,12 @@ adminRoutes.get("/user", async (c) => {
 /** Grant top-up credits to one or more users by email. */
 adminRoutes.post("/grant-credits", async (c) => {
 	try {
-		const payload = await c.req.json();
+		let payload: Record<string, unknown>;
+		try {
+			payload = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
 		const emails: string[] = Array.isArray(payload?.emails)
 			? payload.emails
 			: typeof payload?.email === "string"
@@ -160,7 +165,12 @@ adminRoutes.post("/grant-credits", async (c) => {
 /** Upgrade a user's plan by email. */
 adminRoutes.post("/upgrade-plan", async (c) => {
 	try {
-		const payload = await c.req.json();
+		let payload: Record<string, unknown>;
+		try {
+			payload = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
 		const email =
 			typeof payload?.email === "string"
 				? payload.email.trim().toLowerCase()
@@ -198,6 +208,16 @@ adminRoutes.post("/upgrade-plan", async (c) => {
 
 		if (!license) {
 			return c.json({ error: "User has no license record" }, 404);
+		}
+
+		if (license.plan === plan) {
+			const credits = await getCreditBalanceByUserId({ userId: user.id });
+			return c.json({
+				success: true,
+				user: { email, plan, maxDevices },
+				credits,
+				note: "Plan unchanged — no credit reset performed",
+			});
 		}
 
 		await db

--- a/qcut/packages/license-server/src/routes/admin.ts
+++ b/qcut/packages/license-server/src/routes/admin.ts
@@ -187,7 +187,11 @@ adminRoutes.post("/upgrade-plan", async (c) => {
 		}
 
 		const [license] = await db
-			.select({ id: licenses.id })
+			.select({
+				id: licenses.id,
+				plan: licenses.plan,
+				maxDevices: licenses.maxDevices,
+			})
 			.from(licenses)
 			.where(eq(licenses.userId, user.id))
 			.limit(1);
@@ -209,10 +213,14 @@ adminRoutes.post("/upgrade-plan", async (c) => {
 				description: `Admin upgraded plan to ${plan}`,
 			});
 		} catch (creditError) {
-			// Roll back the plan change if credit reset fails
+			// Roll back to the original plan if credit reset fails
 			await db
 				.update(licenses)
-				.set({ plan: "free", maxDevices: 1, updatedAt: new Date() })
+				.set({
+					plan: license.plan,
+					maxDevices: license.maxDevices,
+					updatedAt: new Date(),
+				})
 				.where(eq(licenses.id, license.id));
 			throw creditError;
 		}

--- a/qcut/packages/license-server/src/routes/admin.ts
+++ b/qcut/packages/license-server/src/routes/admin.ts
@@ -1,0 +1,213 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { adminAuthMiddleware } from "../middleware/admin-auth";
+import { db } from "../db/drizzle";
+import { users, licenses } from "@qcut/db/schema";
+import {
+	addTopUpCreditsForUser,
+	getCreditBalanceByUserId,
+	resetPlanCreditsForUser,
+} from "../services/credit-service";
+
+const adminRoutes = new Hono();
+
+adminRoutes.use("/*", adminAuthMiddleware);
+
+/** Look up a user by email. Returns user ID, plan, and credit balance. */
+adminRoutes.get("/user", async (c) => {
+	try {
+		const email = c.req.query("email")?.trim().toLowerCase();
+		if (!email) {
+			return c.json({ error: "email query parameter is required" }, 400);
+		}
+
+		const [user] = await db
+			.select({ id: users.id, name: users.name, email: users.email })
+			.from(users)
+			.where(eq(users.email, email))
+			.limit(1);
+
+		if (!user) {
+			return c.json({ error: `No user found with email: ${email}` }, 404);
+		}
+
+		const [license] = await db
+			.select({ plan: licenses.plan, status: licenses.status })
+			.from(licenses)
+			.where(eq(licenses.userId, user.id))
+			.limit(1);
+
+		const credits = await getCreditBalanceByUserId({ userId: user.id });
+
+		return c.json({
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				plan: license?.plan ?? "free",
+				status: license?.status ?? "none",
+			},
+			credits,
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error ? error.message : "Failed to look up user",
+			},
+			500
+		);
+	}
+});
+
+/** Grant top-up credits to one or more users by email. */
+adminRoutes.post("/grant-credits", async (c) => {
+	try {
+		const payload = await c.req.json();
+		const emails: string[] = Array.isArray(payload?.emails)
+			? payload.emails
+			: typeof payload?.email === "string"
+				? [payload.email]
+				: [];
+		const amount = Number(payload?.amount);
+		const description =
+			typeof payload?.description === "string"
+				? payload.description.trim()
+				: "Admin credit grant";
+
+		if (emails.length === 0) {
+			return c.json(
+				{ error: "emails (array) or email (string) is required" },
+				400
+			);
+		}
+		if (!Number.isFinite(amount) || amount <= 0) {
+			return c.json({ error: "amount must be a positive number" }, 400);
+		}
+
+		const results: Array<{
+			email: string;
+			success: boolean;
+			credits?: { totalCredits: number };
+			error?: string;
+		}> = [];
+
+		for (const rawEmail of emails) {
+			const email = rawEmail.trim().toLowerCase();
+			try {
+				const [user] = await db
+					.select({ id: users.id })
+					.from(users)
+					.where(eq(users.email, email))
+					.limit(1);
+
+				if (!user) {
+					results.push({ email, success: false, error: "User not found" });
+					continue;
+				}
+
+				const balance = await addTopUpCreditsForUser({
+					userId: user.id,
+					credits: amount,
+					description,
+				});
+
+				results.push({
+					email,
+					success: true,
+					credits: { totalCredits: balance.totalCredits },
+				});
+			} catch (error) {
+				results.push({
+					email,
+					success: false,
+					error: error instanceof Error ? error.message : "Unknown error",
+				});
+			}
+		}
+
+		const succeeded = results.filter((r) => r.success).length;
+		const failed = results.filter((r) => !r.success).length;
+
+		return c.json({
+			summary: { succeeded, failed, total: results.length },
+			results,
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error ? error.message : "Failed to grant credits",
+			},
+			500
+		);
+	}
+});
+
+/** Upgrade a user's plan by email. */
+adminRoutes.post("/upgrade-plan", async (c) => {
+	try {
+		const payload = await c.req.json();
+		const email =
+			typeof payload?.email === "string"
+				? payload.email.trim().toLowerCase()
+				: "";
+		const plan = payload?.plan;
+
+		if (email.length === 0) {
+			return c.json({ error: "email is required" }, 400);
+		}
+		if (plan !== "free" && plan !== "pro" && plan !== "team") {
+			return c.json({ error: 'plan must be "free", "pro", or "team"' }, 400);
+		}
+
+		const maxDevices = plan === "team" ? 10 : plan === "pro" ? 3 : 1;
+
+		const [user] = await db
+			.select({ id: users.id })
+			.from(users)
+			.where(eq(users.email, email))
+			.limit(1);
+
+		if (!user) {
+			return c.json({ error: `No user found with email: ${email}` }, 404);
+		}
+
+		const [license] = await db
+			.select({ id: licenses.id })
+			.from(licenses)
+			.where(eq(licenses.userId, user.id))
+			.limit(1);
+
+		if (!license) {
+			return c.json({ error: "User has no license record" }, 404);
+		}
+
+		await db
+			.update(licenses)
+			.set({ plan, maxDevices, updatedAt: new Date() })
+			.where(eq(licenses.id, license.id));
+
+		const credits = await resetPlanCreditsForUser({
+			userId: user.id,
+			plan,
+			description: `Admin upgraded plan to ${plan}`,
+		});
+
+		return c.json({
+			success: true,
+			user: { email, plan, maxDevices },
+			credits,
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error ? error.message : "Failed to upgrade plan",
+			},
+			500
+		);
+	}
+});
+
+export { adminRoutes };

--- a/qcut/packages/license-server/src/routes/admin.ts
+++ b/qcut/packages/license-server/src/routes/admin.ts
@@ -85,6 +85,20 @@ adminRoutes.post("/grant-credits", async (c) => {
 			return c.json({ error: "amount must be a positive number" }, 400);
 		}
 
+		// Validate and de-duplicate
+		const uniqueEmails = [
+			...new Set(
+				emails
+					.filter(
+						(e): e is string => typeof e === "string" && e.trim().length > 0
+					)
+					.map((e) => e.trim().toLowerCase())
+			),
+		];
+		if (uniqueEmails.length === 0) {
+			return c.json({ error: "No valid email addresses provided" }, 400);
+		}
+
 		const results: Array<{
 			email: string;
 			success: boolean;
@@ -92,8 +106,7 @@ adminRoutes.post("/grant-credits", async (c) => {
 			error?: string;
 		}> = [];
 
-		for (const rawEmail of emails) {
-			const email = rawEmail.trim().toLowerCase();
+		for (const email of uniqueEmails) {
 			try {
 				const [user] = await db
 					.select({ id: users.id })
@@ -188,11 +201,21 @@ adminRoutes.post("/upgrade-plan", async (c) => {
 			.set({ plan, maxDevices, updatedAt: new Date() })
 			.where(eq(licenses.id, license.id));
 
-		const credits = await resetPlanCreditsForUser({
-			userId: user.id,
-			plan,
-			description: `Admin upgraded plan to ${plan}`,
-		});
+		let credits;
+		try {
+			credits = await resetPlanCreditsForUser({
+				userId: user.id,
+				plan,
+				description: `Admin upgraded plan to ${plan}`,
+			});
+		} catch (creditError) {
+			// Roll back the plan change if credit reset fails
+			await db
+				.update(licenses)
+				.set({ plan: "free", maxDevices: 1, updatedAt: new Date() })
+				.where(eq(licenses.id, license.id));
+			throw creditError;
+		}
 
 		return c.json({
 			success: true,

--- a/qcut/packages/license-server/src/routes/ai-proxy.test.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { Hono } from "hono";
 import { resetRateLimitState } from "../middleware/rate-limit";
 
@@ -24,8 +32,13 @@ vi.mock("../middleware/auth", () => ({
 }));
 
 // Mock global fetch for provider calls
+const originalFetch = globalThis.fetch;
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+});
 
 const { deductCreditsForUser } = await import("../services/credit-service");
 const { aiProxyRoutes } = await import("./ai-proxy");

--- a/qcut/packages/license-server/src/routes/ai-proxy.test.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { resetRateLimitState } from "../middleware/rate-limit";
+
+// Mock DB and credit service
+vi.mock("../db/drizzle", () => ({
+	db: {
+		select: vi.fn(),
+		update: vi.fn(),
+		insert: vi.fn(),
+	},
+}));
+
+vi.mock("../services/credit-service", () => ({
+	deductCreditsForUser: vi.fn(),
+}));
+
+// Mock auth middleware to inject userId
+vi.mock("../middleware/auth", () => ({
+	authMiddleware: vi.fn().mockImplementation(async (c: any, next: any) => {
+		c.set("userId", "test-user-1");
+		await next();
+	}),
+}));
+
+// Mock global fetch for provider calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { deductCreditsForUser } = await import("../services/credit-service");
+const { aiProxyRoutes } = await import("./ai-proxy");
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) {
+			delete process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+function buildApp(): Hono {
+	const app = new Hono();
+	app.route("/api/ai", aiProxyRoutes);
+	return app;
+}
+
+function jsonHeaders(): Record<string, string> {
+	return { "Content-Type": "application/json" };
+}
+
+function mockProviderResponse(body: object, status = 200): void {
+	mockFetch.mockResolvedValueOnce(
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { "Content-Type": "application/json" },
+		})
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	resetRateLimitState();
+	// Set all provider keys for tests
+	process.env.FAL_API_KEY = "test-fal-key";
+	process.env.GEMINI_API_KEY = "test-gemini-key";
+	process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+	process.env.ELEVENLABS_API_KEY = "test-elevenlabs-key";
+	process.env.GMI_API_KEY = "test-gmi-key";
+	process.env.RUNWAY_API_KEY = "test-runway-key";
+	process.env.AI_PROXY_RATE_LIMIT = "1000"; // high limit for tests
+});
+
+afterEach(() => {
+	resetEnv();
+});
+
+// ── POST /api/ai/proxy ─────────────────────────────────────────────────────
+
+describe("POST /api/ai/proxy", () => {
+	it("returns 400 for invalid provider", async () => {
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "openai",
+				endpoint: "https://api.openai.com/v1/chat",
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain("Invalid provider");
+	});
+
+	it("returns 400 when endpoint is missing", async () => {
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({ provider: "fal" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 403 for disallowed endpoint", async () => {
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://evil.com/steal",
+			}),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("returns 503 when provider key is not configured", async () => {
+		delete process.env.FAL_API_KEY;
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://queue.fal.run/fal-ai/test",
+				body: { prompt: "test" },
+			}),
+		});
+		expect(res.status).toBe(503);
+	});
+
+	it("forwards request to provider with correct auth headers (FAL)", async () => {
+		mockProviderResponse({ request_id: "req-123" });
+
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://queue.fal.run/fal-ai/test",
+				body: { prompt: "a cat" },
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.request_id).toBe("req-123");
+
+		// Verify fetch was called with correct auth
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const [url, opts] = mockFetch.mock.calls[0];
+		expect(url).toBe("https://queue.fal.run/fal-ai/test");
+		expect(opts.headers.Authorization).toBe("Key test-fal-key");
+	});
+
+	it("forwards request with Gemini auth format", async () => {
+		mockProviderResponse({ candidates: [] });
+
+		await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "gemini",
+				endpoint:
+					"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+				body: { contents: [] },
+			}),
+		});
+
+		const [, opts] = mockFetch.mock.calls[0];
+		expect(opts.headers["x-goog-api-key"]).toBe("test-gemini-key");
+	});
+
+	it("deducts credits when credits field is provided", async () => {
+		vi.mocked(deductCreditsForUser).mockResolvedValue({
+			success: true,
+			balance: {
+				planCredits: 40,
+				topUpCredits: 0,
+				totalCredits: 40,
+				planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+			},
+		});
+		mockProviderResponse({ ok: true });
+
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://queue.fal.run/fal-ai/test",
+				body: { prompt: "test" },
+				credits: {
+					amount: 10,
+					modelKey: "fal-test",
+					description: "Test gen",
+				},
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(deductCreditsForUser).toHaveBeenCalledWith({
+			userId: "test-user-1",
+			amount: 10,
+			modelKey: "fal-test",
+			description: "Test gen",
+		});
+	});
+
+	it("returns 402 when credits are insufficient", async () => {
+		vi.mocked(deductCreditsForUser).mockResolvedValue({
+			success: false,
+			balance: {
+				planCredits: 0,
+				topUpCredits: 0,
+				totalCredits: 0,
+				planCreditsResetAt: "2026-05-01T00:00:00.000Z",
+			},
+		});
+
+		const res = await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://queue.fal.run/fal-ai/test",
+				body: {},
+				credits: { amount: 100, modelKey: "fal-test", description: "" },
+			}),
+		});
+
+		expect(res.status).toBe(402);
+		// Should NOT have called the provider
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("skips credit deduction when credits field is absent", async () => {
+		mockProviderResponse({ ok: true });
+
+		await buildApp().request("/api/ai/proxy", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				endpoint: "https://queue.fal.run/fal-ai/test",
+				body: {},
+			}),
+		});
+
+		expect(deductCreditsForUser).not.toHaveBeenCalled();
+	});
+});
+
+// ── POST /api/ai/upload-url ─────────────────────────────────────────────────
+
+describe("POST /api/ai/upload-url", () => {
+	it("returns 400 for non-fal provider", async () => {
+		const res = await buildApp().request("/api/ai/upload-url", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({ provider: "gemini", fileName: "test.mp4" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when fileName is missing", async () => {
+		const res = await buildApp().request("/api/ai/upload-url", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({ provider: "fal" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns signed upload URL from FAL", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					upload_url: "https://storage.fal.ai/signed/abc",
+					file_url: "https://cdn.fal.ai/files/abc.mp4",
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } }
+			)
+		);
+
+		const res = await buildApp().request("/api/ai/upload-url", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				fileName: "video.mp4",
+				contentType: "video/mp4",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.uploadUrl).toBe("https://storage.fal.ai/signed/abc");
+		expect(body.fileUrl).toBe("https://cdn.fal.ai/files/abc.mp4");
+
+		// Verify the FAL key was used
+		const [, opts] = mockFetch.mock.calls[0];
+		expect(opts.headers.Authorization).toBe("Key test-fal-key");
+	});
+
+	it("returns 503 when FAL key is not configured", async () => {
+		delete process.env.FAL_API_KEY;
+		const res = await buildApp().request("/api/ai/upload-url", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				provider: "fal",
+				fileName: "test.mp4",
+			}),
+		});
+		expect(res.status).toBe(503);
+	});
+});
+
+// ── GET /api/ai/status ──────────────────────────────────────────────────────
+
+describe("GET /api/ai/status", () => {
+	it("returns 400 for invalid provider", async () => {
+		const res = await buildApp().request(
+			"/api/ai/status?provider=openai&requestId=abc"
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when requestId is missing", async () => {
+		const res = await buildApp().request(
+			"/api/ai/status?provider=fal&endpoint=test"
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 for requestId with invalid characters", async () => {
+		const res = await buildApp().request(
+			"/api/ai/status?provider=fal&endpoint=test&requestId=../../../etc"
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("polls FAL status and returns result", async () => {
+		mockProviderResponse({
+			status: "COMPLETED",
+			response_url: "https://queue.fal.run/result",
+		});
+
+		const res = await buildApp().request(
+			"/api/ai/status?provider=fal&endpoint=fal-ai/test&requestId=req-123"
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe("COMPLETED");
+
+		const [url, opts] = mockFetch.mock.calls[0];
+		expect(url).toBe(
+			"https://queue.fal.run/fal-ai/test/requests/req-123/status"
+		);
+		expect(opts.headers.Authorization).toBe("Key test-fal-key");
+	});
+
+	it("polls GMI status with correct URL", async () => {
+		mockProviderResponse({ status: "processing" });
+
+		await buildApp().request(
+			"/api/ai/status?provider=gmi&requestId=gmi-req-456"
+		);
+
+		const [url] = mockFetch.mock.calls[0];
+		expect(url).toBe(
+			"https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey/requests/gmi-req-456"
+		);
+	});
+
+	it("returns 400 for providers that don't support polling", async () => {
+		const res = await buildApp().request(
+			"/api/ai/status?provider=gemini&requestId=abc"
+		);
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain("not supported");
+	});
+});
+
+// ── GET /api/ai/result ──────────────────────────────────────────────────────
+
+describe("GET /api/ai/result", () => {
+	it("returns 400 for non-fal provider", async () => {
+		const res = await buildApp().request(
+			"/api/ai/result?provider=gmi&endpoint=test&requestId=abc"
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("fetches FAL result with correct URL", async () => {
+		mockProviderResponse({ video: { url: "https://cdn.fal.ai/v.mp4" } });
+
+		const res = await buildApp().request(
+			"/api/ai/result?provider=fal&endpoint=fal-ai/test&requestId=req-789"
+		);
+
+		expect(res.status).toBe(200);
+		const [url] = mockFetch.mock.calls[0];
+		expect(url).toBe("https://queue.fal.run/fal-ai/test/requests/req-789");
+	});
+});

--- a/qcut/packages/license-server/src/routes/ai-proxy.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.ts
@@ -14,6 +14,10 @@ const MAX_PROXY_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
 const MAX_UPLOAD_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
 const PROXY_FETCH_TIMEOUT_MS = 120_000; // 2 min
 
+/** Only alphanumeric, hyphens, underscores, and forward slashes (for FAL endpoint paths). */
+const VALID_REQUEST_ID = /^[a-zA-Z0-9_-]+$/;
+const VALID_ENDPOINT_PATH = /^[a-zA-Z0-9_\-/]+$/;
+
 const aiProxyRoutes = new Hono();
 
 aiProxyRoutes.use("/*", authMiddleware);
@@ -235,8 +239,7 @@ aiProxyRoutes.get("/status", async (c) => {
 			return c.json({ error: "requestId is required" }, 400);
 		}
 
-		// Prevent path traversal in requestId
-		if (/[^a-zA-Z0-9_-]/.test(requestId)) {
+		if (!VALID_REQUEST_ID.test(requestId)) {
 			return c.json({ error: "Invalid requestId format" }, 400);
 		}
 
@@ -244,6 +247,9 @@ aiProxyRoutes.get("/status", async (c) => {
 		if (provider === "fal") {
 			if (endpoint.length === 0) {
 				return c.json({ error: "endpoint is required for fal polling" }, 400);
+			}
+			if (!VALID_ENDPOINT_PATH.test(endpoint)) {
+				return c.json({ error: "Invalid endpoint format" }, 400);
 			}
 			statusUrl = `https://queue.fal.run/${endpoint}/requests/${requestId}/status`;
 		} else if (provider === "gmi") {
@@ -304,8 +310,11 @@ aiProxyRoutes.get("/result", async (c) => {
 		if (endpoint.length === 0 || requestId.length === 0) {
 			return c.json({ error: "endpoint and requestId are required" }, 400);
 		}
-		if (/[^a-zA-Z0-9_-]/.test(requestId)) {
+		if (!VALID_REQUEST_ID.test(requestId)) {
 			return c.json({ error: "Invalid requestId format" }, 400);
+		}
+		if (!VALID_ENDPOINT_PATH.test(endpoint)) {
+			return c.json({ error: "Invalid endpoint format" }, 400);
 		}
 
 		const resultUrl = `https://queue.fal.run/${endpoint}/requests/${requestId}`;

--- a/qcut/packages/license-server/src/routes/ai-proxy.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.ts
@@ -1,0 +1,343 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import {
+	type AiProvider,
+	buildProviderAuthHeaders,
+	getProviderKey,
+	isEndpointAllowed,
+	isValidProvider,
+} from "../services/provider-keys";
+import { deductCreditsForUser } from "../services/credit-service";
+import { rateLimitMiddleware } from "../middleware/rate-limit";
+
+const MAX_PROXY_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_UPLOAD_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
+const PROXY_FETCH_TIMEOUT_MS = 120_000; // 2 min
+
+const aiProxyRoutes = new Hono();
+
+aiProxyRoutes.use("/*", authMiddleware);
+aiProxyRoutes.use("/*", rateLimitMiddleware);
+
+// ---------------------------------------------------------------------------
+// POST /proxy — forward a JSON request to an AI provider
+// ---------------------------------------------------------------------------
+aiProxyRoutes.post("/proxy", async (c) => {
+	try {
+		const userId = c.get("userId") as string;
+		const raw = await c.req.text();
+
+		if (raw.length > MAX_PROXY_BODY_BYTES) {
+			return c.json({ error: "Request body too large (10 MB max)" }, 413);
+		}
+
+		let payload: {
+			provider?: string;
+			endpoint?: string;
+			method?: string;
+			body?: unknown;
+			credits?: { amount: number; modelKey: string; description: string };
+		};
+		try {
+			payload = JSON.parse(raw);
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const { provider, endpoint, method, body, credits } = payload;
+
+		if (typeof provider !== "string" || !isValidProvider(provider)) {
+			return c.json(
+				{
+					error:
+						"Invalid provider. Must be one of: fal, gemini, openrouter, elevenlabs, gmi, runway, freesound",
+				},
+				400
+			);
+		}
+
+		if (typeof endpoint !== "string" || endpoint.length === 0) {
+			return c.json({ error: "endpoint is required" }, 400);
+		}
+
+		if (!isEndpointAllowed({ provider, url: endpoint })) {
+			return c.json({ error: "Endpoint not allowed for this provider" }, 403);
+		}
+
+		const authHeaders = buildProviderAuthHeaders(provider);
+		if (!authHeaders) {
+			return c.json(
+				{ error: `API key not configured for provider: ${provider}` },
+				503
+			);
+		}
+
+		// Deduct credits if the client requested it
+		if (credits) {
+			const amount = Number(credits.amount);
+			const modelKey =
+				typeof credits.modelKey === "string" ? credits.modelKey.trim() : "";
+			const description =
+				typeof credits.description === "string"
+					? credits.description.trim()
+					: "";
+
+			if (Number.isFinite(amount) && amount > 0 && modelKey.length > 0) {
+				const deduction = await deductCreditsForUser({
+					userId,
+					amount,
+					modelKey,
+					description:
+						description.length > 0 ? description : `${provider} — ${modelKey}`,
+				});
+				if (!deduction.success) {
+					return c.json(
+						{
+							error: "Insufficient credits",
+							credits: deduction.balance,
+						},
+						402
+					);
+				}
+			}
+		}
+
+		const httpMethod = (method ?? "POST").toUpperCase();
+		const providerResponse = await fetch(endpoint, {
+			method: httpMethod,
+			headers: {
+				"Content-Type": "application/json",
+				...authHeaders,
+			},
+			...(httpMethod !== "GET" && body != null
+				? { body: JSON.stringify(body) }
+				: {}),
+			signal: AbortSignal.timeout(PROXY_FETCH_TIMEOUT_MS),
+		});
+
+		const responseBody = await providerResponse.text();
+		return new Response(responseBody, {
+			status: providerResponse.status,
+			headers: {
+				"Content-Type":
+					providerResponse.headers.get("Content-Type") ?? "application/json",
+			},
+		});
+	} catch (error) {
+		if (error instanceof DOMException && error.name === "TimeoutError") {
+			return c.json({ error: "Provider request timed out" }, 504);
+		}
+		return c.json(
+			{
+				error: error instanceof Error ? error.message : "Proxy request failed",
+			},
+			500
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// POST /upload-url — vend a signed upload URL (FAL storage)
+// ---------------------------------------------------------------------------
+aiProxyRoutes.post("/upload-url", async (c) => {
+	try {
+		c.get("userId"); // ensure authenticated
+
+		const payload = await c.req.json();
+		const provider = payload?.provider;
+		const fileName =
+			typeof payload?.fileName === "string" ? payload.fileName.trim() : "";
+		const contentType =
+			typeof payload?.contentType === "string"
+				? payload.contentType.trim()
+				: "application/octet-stream";
+		const fileSize = Number(payload?.fileSize ?? 0);
+
+		if (provider !== "fal") {
+			return c.json(
+				{ error: "Upload URL vending is only supported for fal" },
+				400
+			);
+		}
+		if (fileName.length === 0) {
+			return c.json({ error: "fileName is required" }, 400);
+		}
+		if (fileSize > MAX_UPLOAD_FILE_SIZE) {
+			return c.json({ error: "File too large (500 MB max)" }, 413);
+		}
+
+		const falKey = getProviderKey("fal");
+		if (!falKey) {
+			return c.json({ error: "FAL API key not configured on server" }, 503);
+		}
+
+		const initiateResponse = await fetch(
+			"https://rest.alpha.fal.ai/storage/upload/initiate?storage_type=fal-cdn-v3",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Key ${falKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					file_name: fileName,
+					content_type: contentType,
+				}),
+				signal: AbortSignal.timeout(15_000),
+			}
+		);
+
+		if (!initiateResponse.ok) {
+			const errorText = await initiateResponse.text();
+			return c.json(
+				{
+					error: `FAL upload initiation failed: ${initiateResponse.status}`,
+					detail: errorText,
+				},
+				502
+			);
+		}
+
+		const result = await initiateResponse.json();
+		return c.json({
+			uploadUrl: result.upload_url,
+			fileUrl: result.file_url,
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? error.message
+						: "Failed to generate upload URL",
+			},
+			500
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// GET /status — poll async job status (FAL queue, GMI queue)
+// ---------------------------------------------------------------------------
+aiProxyRoutes.get("/status", async (c) => {
+	try {
+		c.get("userId"); // ensure authenticated
+
+		const provider = c.req.query("provider") ?? "";
+		const endpoint = c.req.query("endpoint") ?? "";
+		const requestId = c.req.query("requestId") ?? "";
+
+		if (!isValidProvider(provider)) {
+			return c.json({ error: "Invalid provider" }, 400);
+		}
+
+		if (requestId.length === 0) {
+			return c.json({ error: "requestId is required" }, 400);
+		}
+
+		// Prevent path traversal in requestId
+		if (/[^a-zA-Z0-9_-]/.test(requestId)) {
+			return c.json({ error: "Invalid requestId format" }, 400);
+		}
+
+		let statusUrl: string;
+		if (provider === "fal") {
+			if (endpoint.length === 0) {
+				return c.json({ error: "endpoint is required for fal polling" }, 400);
+			}
+			statusUrl = `https://queue.fal.run/${endpoint}/requests/${requestId}/status`;
+		} else if (provider === "gmi") {
+			statusUrl = `https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey/requests/${requestId}`;
+		} else {
+			return c.json(
+				{ error: `Polling not supported for provider: ${provider}` },
+				400
+			);
+		}
+
+		const authHeaders = buildProviderAuthHeaders(provider as AiProvider);
+		if (!authHeaders) {
+			return c.json(
+				{ error: `API key not configured for provider: ${provider}` },
+				503
+			);
+		}
+
+		const providerResponse = await fetch(statusUrl, {
+			method: "GET",
+			headers: authHeaders,
+			signal: AbortSignal.timeout(15_000),
+		});
+
+		const responseBody = await providerResponse.text();
+		return new Response(responseBody, {
+			status: providerResponse.status,
+			headers: {
+				"Content-Type":
+					providerResponse.headers.get("Content-Type") ?? "application/json",
+			},
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error: error instanceof Error ? error.message : "Failed to poll status",
+			},
+			500
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// GET /result — fetch completed async job result (FAL queue)
+// ---------------------------------------------------------------------------
+aiProxyRoutes.get("/result", async (c) => {
+	try {
+		c.get("userId"); // ensure authenticated
+
+		const provider = c.req.query("provider") ?? "";
+		const endpoint = c.req.query("endpoint") ?? "";
+		const requestId = c.req.query("requestId") ?? "";
+
+		if (provider !== "fal") {
+			return c.json({ error: "Result fetching only supported for fal" }, 400);
+		}
+		if (endpoint.length === 0 || requestId.length === 0) {
+			return c.json({ error: "endpoint and requestId are required" }, 400);
+		}
+		if (/[^a-zA-Z0-9_-]/.test(requestId)) {
+			return c.json({ error: "Invalid requestId format" }, 400);
+		}
+
+		const resultUrl = `https://queue.fal.run/${endpoint}/requests/${requestId}`;
+
+		const authHeaders = buildProviderAuthHeaders("fal");
+		if (!authHeaders) {
+			return c.json({ error: "FAL API key not configured" }, 503);
+		}
+
+		const providerResponse = await fetch(resultUrl, {
+			method: "GET",
+			headers: authHeaders,
+			signal: AbortSignal.timeout(30_000),
+		});
+
+		const responseBody = await providerResponse.text();
+		return new Response(responseBody, {
+			status: providerResponse.status,
+			headers: {
+				"Content-Type":
+					providerResponse.headers.get("Content-Type") ?? "application/json",
+			},
+		});
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error ? error.message : "Failed to fetch result",
+			},
+			500
+		);
+	}
+});
+
+export { aiProxyRoutes };

--- a/qcut/packages/license-server/src/routes/ai-proxy.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.ts
@@ -16,7 +16,7 @@ const PROXY_FETCH_TIMEOUT_MS = 120_000; // 2 min
 
 /** Only alphanumeric, hyphens, underscores, and forward slashes (for FAL endpoint paths). */
 const VALID_REQUEST_ID = /^[a-zA-Z0-9_-]+$/;
-const VALID_ENDPOINT_PATH = /^[a-zA-Z0-9_\-/]+$/;
+const VALID_ENDPOINT_PATH = /^[a-zA-Z0-9_.\-/]+$/;
 
 const aiProxyRoutes = new Hono();
 

--- a/qcut/packages/license-server/src/services/provider-keys.test.ts
+++ b/qcut/packages/license-server/src/services/provider-keys.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	buildProviderAuthHeaders,
+	getProviderKey,
+	isEndpointAllowed,
+	isValidProvider,
+} from "./provider-keys";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) {
+			delete process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+afterEach(() => {
+	resetEnv();
+});
+
+describe("isValidProvider", () => {
+	it("accepts known providers", () => {
+		expect(isValidProvider("fal")).toBe(true);
+		expect(isValidProvider("gemini")).toBe(true);
+		expect(isValidProvider("openrouter")).toBe(true);
+		expect(isValidProvider("elevenlabs")).toBe(true);
+		expect(isValidProvider("gmi")).toBe(true);
+		expect(isValidProvider("runway")).toBe(true);
+		expect(isValidProvider("freesound")).toBe(true);
+	});
+
+	it("rejects unknown providers", () => {
+		expect(isValidProvider("openai")).toBe(false);
+		expect(isValidProvider("")).toBe(false);
+		expect(isValidProvider("FAL")).toBe(false);
+	});
+});
+
+describe("getProviderKey", () => {
+	it("reads key from env var", () => {
+		process.env.FAL_API_KEY = "fal-key-123";
+		expect(getProviderKey("fal")).toBe("fal-key-123");
+	});
+
+	it("returns undefined when env var is missing", () => {
+		delete process.env.GEMINI_API_KEY;
+		expect(getProviderKey("gemini")).toBeUndefined();
+	});
+
+	it("returns undefined for empty string", () => {
+		process.env.FAL_API_KEY = "  ";
+		expect(getProviderKey("fal")).toBeUndefined();
+	});
+});
+
+describe("buildProviderAuthHeaders", () => {
+	it("builds FAL headers with Key prefix", () => {
+		process.env.FAL_API_KEY = "fal-key";
+		const headers = buildProviderAuthHeaders("fal");
+		expect(headers).toEqual({ Authorization: "Key fal-key" });
+	});
+
+	it("builds Gemini headers with x-goog-api-key", () => {
+		process.env.GEMINI_API_KEY = "gem-key";
+		const headers = buildProviderAuthHeaders("gemini");
+		expect(headers).toEqual({ "x-goog-api-key": "gem-key" });
+	});
+
+	it("builds Runway headers with Bearer and version", () => {
+		process.env.RUNWAY_API_KEY = "rw-key";
+		const headers = buildProviderAuthHeaders("runway");
+		expect(headers).toEqual({
+			Authorization: "Bearer rw-key",
+			"X-Runway-Version": "2024-11-06",
+		});
+	});
+
+	it("builds ElevenLabs headers with xi-api-key", () => {
+		process.env.ELEVENLABS_API_KEY = "el-key";
+		const headers = buildProviderAuthHeaders("elevenlabs");
+		expect(headers).toEqual({ "xi-api-key": "el-key" });
+	});
+
+	it("returns null when key is not set", () => {
+		delete process.env.FAL_API_KEY;
+		expect(buildProviderAuthHeaders("fal")).toBeNull();
+	});
+});
+
+describe("isEndpointAllowed", () => {
+	it("allows FAL queue URLs", () => {
+		expect(
+			isEndpointAllowed({
+				provider: "fal",
+				url: "https://queue.fal.run/fal-ai/kling-video/v2",
+			})
+		).toBe(true);
+	});
+
+	it("allows FAL storage URLs", () => {
+		expect(
+			isEndpointAllowed({
+				provider: "fal",
+				url: "https://rest.alpha.fal.ai/storage/upload/initiate",
+			})
+		).toBe(true);
+	});
+
+	it("rejects cross-provider URLs", () => {
+		expect(
+			isEndpointAllowed({
+				provider: "fal",
+				url: "https://api.openai.com/v1/chat",
+			})
+		).toBe(false);
+	});
+
+	it("rejects path traversal attempts", () => {
+		expect(
+			isEndpointAllowed({
+				provider: "fal",
+				url: "https://evil.com/?redirect=https://queue.fal.run/",
+			})
+		).toBe(false);
+	});
+
+	it("allows Gemini URLs", () => {
+		expect(
+			isEndpointAllowed({
+				provider: "gemini",
+				url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+			})
+		).toBe(true);
+	});
+});

--- a/qcut/packages/license-server/src/services/provider-keys.ts
+++ b/qcut/packages/license-server/src/services/provider-keys.ts
@@ -1,0 +1,106 @@
+/**
+ * Maps AI provider names to their environment variable keys, auth header
+ * formats, and allowed endpoint prefixes (SSRF whitelist).
+ */
+
+export type AiProvider =
+	| "fal"
+	| "gemini"
+	| "openrouter"
+	| "elevenlabs"
+	| "gmi"
+	| "runway"
+	| "freesound";
+
+interface ProviderConfig {
+	envVar: string;
+	/** Builds the auth headers for this provider given the resolved key. */
+	buildHeaders: (key: string) => Record<string, string>;
+	/** URL prefixes that the proxy is allowed to forward requests to. */
+	allowedPrefixes: string[];
+}
+
+const PROVIDER_CONFIGS: Record<AiProvider, ProviderConfig> = {
+	fal: {
+		envVar: "FAL_API_KEY",
+		buildHeaders: (key) => ({ Authorization: `Key ${key}` }),
+		allowedPrefixes: [
+			"https://queue.fal.run/",
+			"https://fal.run/",
+			"https://rest.alpha.fal.ai/",
+		],
+	},
+	gemini: {
+		envVar: "GEMINI_API_KEY",
+		buildHeaders: (key) => ({ "x-goog-api-key": key }),
+		allowedPrefixes: ["https://generativelanguage.googleapis.com/"],
+	},
+	openrouter: {
+		envVar: "OPENROUTER_API_KEY",
+		buildHeaders: (key) => ({ Authorization: `Bearer ${key}` }),
+		allowedPrefixes: ["https://openrouter.ai/api/"],
+	},
+	elevenlabs: {
+		envVar: "ELEVENLABS_API_KEY",
+		buildHeaders: (key) => ({ "xi-api-key": key }),
+		allowedPrefixes: ["https://api.elevenlabs.io/"],
+	},
+	gmi: {
+		envVar: "GMI_API_KEY",
+		buildHeaders: (key) => ({ Authorization: `Bearer ${key}` }),
+		allowedPrefixes: ["https://console.gmicloud.ai/api/"],
+	},
+	runway: {
+		envVar: "RUNWAY_API_KEY",
+		buildHeaders: (key) => ({
+			Authorization: `Bearer ${key}`,
+			"X-Runway-Version": "2024-11-06",
+		}),
+		allowedPrefixes: ["https://api.runwayml.com/"],
+	},
+	freesound: {
+		envVar: "FREESOUND_API_KEY",
+		buildHeaders: (key) => ({ Authorization: `Token ${key}` }),
+		allowedPrefixes: ["https://freesound.org/apiv2/"],
+	},
+};
+
+/** Checks whether a string is a supported provider name. */
+export function isValidProvider(provider: string): provider is AiProvider {
+	return provider in PROVIDER_CONFIGS;
+}
+
+/** Returns the full config for a provider. */
+export function getProviderConfig(provider: AiProvider): ProviderConfig {
+	return PROVIDER_CONFIGS[provider];
+}
+
+/** Resolves the API key for a provider from environment variables. */
+export function getProviderKey(provider: AiProvider): string | undefined {
+	const config = PROVIDER_CONFIGS[provider];
+	const key = process.env[config.envVar]?.trim();
+	return key && key.length > 0 ? key : undefined;
+}
+
+/** Builds the auth headers for a provider using the key from env. */
+export function buildProviderAuthHeaders(
+	provider: AiProvider
+): Record<string, string> | null {
+	const key = getProviderKey(provider);
+	if (!key) {
+		return null;
+	}
+	return PROVIDER_CONFIGS[provider].buildHeaders(key);
+}
+
+/** Validates that a target URL is within the provider's allowed prefixes. */
+export function isEndpointAllowed({
+	provider,
+	url,
+}: {
+	provider: AiProvider;
+	url: string;
+}): boolean {
+	const config = PROVIDER_CONFIGS[provider];
+	return config.allowedPrefixes.some((prefix) => url.startsWith(prefix));
+}

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -14,3 +14,14 @@ PAYMENTS_CHECKOUT_ENABLED = "true"
 PAYMENTS_WEBHOOK_ENABLED = "true"
 PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
+AI_PROXY_RATE_LIMIT = "60"
+
+# AI provider keys are stored as Wrangler secrets (not vars):
+# wrangler secret put FAL_API_KEY
+# wrangler secret put GEMINI_API_KEY
+# wrangler secret put OPENROUTER_API_KEY
+# wrangler secret put ELEVENLABS_API_KEY
+# wrangler secret put GMI_API_KEY
+# wrangler secret put RUNWAY_API_KEY
+# wrangler secret put FREESOUND_API_KEY
+# wrangler secret put ADMIN_API_KEY


### PR DESCRIPTION
## Summary
- Add AI proxy server on the license server (Cloudflare Worker) for secure API key management — beta testers use credits without needing their own API keys
- Add admin API for bulk credit grants and plan upgrades
- Add client-side proxy mode in the native pipeline that routes AI calls through the proxy server
- Add beta tester invite guide and tracking docs
- Add rate limiting and admin auth middleware with full test coverage

## Test plan
- [ ] Verify proxy client routes requests through the license server
- [ ] Test admin endpoints for credit grants and plan upgrades
- [ ] Run existing test suite: `bun run test`
- [ ] Verify direct API mode still works when proxy is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/quriosity-agent/qcut/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side "proxy mode" to route AI requests and signed uploads through the license server; proxy-aware credit estimation and passthrough
  * Server-side AI proxy endpoints and admin APIs with per-user rate limiting and admin auth

* **Bug Fixes**
  * Prevent double-charging by skipping client-side deduction when BYOK or active license/proxy is used
  * Improved error messages and safe fallbacks when provider API keys are missing

* **Documentation**
  * Added AI proxy design and beta tester onboarding guides

* **Tests**
  * Extensive unit and integration tests for proxy, admin, rate-limit, and credit flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->