### PR TITLE
chore(release): Windows signing roadmap (#289) + AI video save ENOENT fix (#290)

### DIFF
--- a/qcut/.vscode/tasks.json
+++ b/qcut/.vscode/tasks.json
@@ -1,65 +1,72 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "label": "QCut",
-      "type": "shell",
-      "command": "zsh",
-      "isBackground": true,
-      "icon": { "id": "film", "color": "terminal.ansiRed" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Claude Git",
-      "type": "shell",
-      "command": "claude --dangerously-skip-permissions",
-      "isBackground": true,
-      "icon": { "id": "git-branch", "color": "terminal.ansiBlue" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Claude Branch",
-      "type": "shell",
-      "command": "claude --dangerously-skip-permissions",
-      "isBackground": true,
-      "icon": { "id": "source-control", "color": "terminal.ansiMagenta" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Claude Build",
-      "type": "shell",
-      "command": "claude --dangerously-skip-permissions",
-      "isBackground": true,
-      "icon": { "id": "package", "color": "terminal.ansiGreen" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Codex",
-      "type": "shell",
-      "command": "codex --full-auto",
-      "isBackground": true,
-      "icon": { "id": "hubot", "color": "terminal.ansiYellow" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Discord",
-      "type": "shell",
-      "command": "claude --dangerously-skip-permissions",
-      "isBackground": true,
-      "icon": { "id": "comment-discussion", "color": "terminal.ansiCyan" },
-      "presentation": { "reveal": "always", "panel": "new" },
-      "problemMatcher": []
-    },
-    {
-      "label": "Open All Agents",
-      "dependsOn": ["QCut", "Claude Git", "Claude Branch", "Claude Build", "Codex", "Discord"],
-      "runOptions": { "runOn": "folderOpen" },
-      "problemMatcher": []
-    }
-  ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "QCut",
+			"type": "shell",
+			"command": "zsh",
+			"isBackground": true,
+			"icon": { "id": "film", "color": "terminal.ansiRed" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Claude Git",
+			"type": "shell",
+			"command": "claude --dangerously-skip-permissions",
+			"isBackground": true,
+			"icon": { "id": "git-branch", "color": "terminal.ansiBlue" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Claude Branch",
+			"type": "shell",
+			"command": "claude --dangerously-skip-permissions",
+			"isBackground": true,
+			"icon": { "id": "source-control", "color": "terminal.ansiMagenta" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Claude Build",
+			"type": "shell",
+			"command": "claude --dangerously-skip-permissions",
+			"isBackground": true,
+			"icon": { "id": "package", "color": "terminal.ansiGreen" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Codex",
+			"type": "shell",
+			"command": "codex --full-auto",
+			"isBackground": true,
+			"icon": { "id": "hubot", "color": "terminal.ansiYellow" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Discord",
+			"type": "shell",
+			"command": "claude --dangerously-skip-permissions",
+			"isBackground": true,
+			"icon": { "id": "comment-discussion", "color": "terminal.ansiCyan" },
+			"presentation": { "reveal": "always", "panel": "new" },
+			"problemMatcher": []
+		},
+		{
+			"label": "Open All Agents",
+			"dependsOn": [
+				"QCut",
+				"Claude Git",
+				"Claude Branch",
+				"Claude Build",
+				"Codex",
+				"Discord"
+			],
+			"runOptions": { "runOn": "folderOpen" },
+			"problemMatcher": []
+		}
+	]
 }

--- a/qcut/apps/web/src/components/editor/properties-panel/__tests__/api-keys-view-helpers.test.ts
+++ b/qcut/apps/web/src/components/editor/properties-panel/__tests__/api-keys-view-helpers.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import type {
+	PlatformApiKeyStatus,
+	PlatformApiKeysStatus,
+} from "@qcut/platform-core";
+import {
+	countShadowedAppSaves,
+	getShadowedBy,
+} from "../api-keys-view";
+
+// A status object as returned by the IPC bridge in the wild. The shape is
+// permissive — older Electron builds (pre `computeKeyStatus`) and certain
+// IPC serialization edge cases can drop the `shadowedBy` array even though
+// the TypeScript type marks it required.
+type LooseStatus = Partial<Pick<PlatformApiKeyStatus, "shadowedBy">> &
+	Omit<PlatformApiKeyStatus, "shadowedBy">;
+
+function status(s: LooseStatus): PlatformApiKeyStatus {
+	return s as PlatformApiKeyStatus;
+}
+
+const VALUES = {
+	anthropicApiKey: "",
+	elevenLabsApiKey: "",
+	falApiKey: "",
+	freesoundApiKey: "",
+	geminiApiKey: "",
+	gmiApiKey: "",
+	openRouterApiKey: "",
+	runwayApiKey: "",
+};
+
+describe("countShadowedAppSaves — defensive against missing shadowedBy", () => {
+	it("does not throw when a field's status entry is missing entirely", () => {
+		const statuses: PlatformApiKeysStatus = {};
+		expect(() =>
+			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+		).not.toThrow();
+		expect(
+			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+		).toBe(0);
+	});
+
+	it("does not throw when shadowedBy is undefined on a present entry", () => {
+		// Reproduces the issue: status returned without `shadowedBy`.
+		const statuses: PlatformApiKeysStatus = {
+			runwayApiKey: status({ set: true, source: "electron" }),
+		};
+		expect(() =>
+			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+		).not.toThrow();
+		expect(
+			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+		).toBe(0);
+	});
+
+	it("counts entries whose shadowedBy includes 'electron'", () => {
+		const statuses: PlatformApiKeysStatus = {
+			falApiKey: {
+				set: true,
+				source: "environment",
+				shadowedBy: ["electron"],
+			},
+			geminiApiKey: {
+				set: true,
+				source: "environment",
+				shadowedBy: ["electron", "file"],
+			},
+			runwayApiKey: { set: true, source: "electron", shadowedBy: [] },
+		};
+		expect(
+			countShadowedAppSaves({
+				statuses,
+				values: {
+					...VALUES,
+					falApiKey: "x",
+					geminiApiKey: "y",
+					runwayApiKey: "z",
+				},
+			})
+		).toBe(2);
+	});
+
+	it("ignores fields whose value is empty even if shadowed", () => {
+		const statuses: PlatformApiKeysStatus = {
+			falApiKey: {
+				set: true,
+				source: "environment",
+				shadowedBy: ["electron"],
+			},
+		};
+		expect(countShadowedAppSaves({ statuses, values: VALUES })).toBe(0);
+	});
+});
+
+describe("getShadowedBy — defensive against missing shadowedBy", () => {
+	it("returns undefined when status is undefined", () => {
+		expect(getShadowedBy({ fieldIsDirty: true, status: undefined })).toBeUndefined();
+	});
+
+	it("returns [] when status.shadowedBy is undefined and field is clean", () => {
+		const result = getShadowedBy({
+			fieldIsDirty: false,
+			status: status({ set: true, source: "electron" }),
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("appends 'electron' when dirty + environment-source + missing shadowedBy", () => {
+		const result = getShadowedBy({
+			fieldIsDirty: true,
+			status: status({ set: true, source: "environment" }),
+		});
+		expect(result).toEqual(["electron"]);
+	});
+
+	it("does not duplicate 'electron' when already present", () => {
+		const result = getShadowedBy({
+			fieldIsDirty: true,
+			status: {
+				set: true,
+				source: "environment",
+				shadowedBy: ["electron"],
+			},
+		});
+		expect(result).toEqual(["electron"]);
+	});
+
+	it("returns the existing shadowedBy array when not dirty", () => {
+		const result = getShadowedBy({
+			fieldIsDirty: false,
+			status: {
+				set: true,
+				source: "environment",
+				shadowedBy: ["electron", "file"],
+			},
+		});
+		expect(result).toEqual(["electron", "file"]);
+	});
+});

--- a/qcut/apps/web/src/components/editor/properties-panel/__tests__/api-keys-view-helpers.test.ts
+++ b/qcut/apps/web/src/components/editor/properties-panel/__tests__/api-keys-view-helpers.test.ts
@@ -3,10 +3,7 @@ import type {
 	PlatformApiKeyStatus,
 	PlatformApiKeysStatus,
 } from "@qcut/platform-core";
-import {
-	countShadowedAppSaves,
-	getShadowedBy,
-} from "../api-keys-view";
+import { countShadowedAppSaves, getShadowedBy } from "../api-keys-view";
 
 // A status object as returned by the IPC bridge in the wild. The shape is
 // permissive — older Electron builds (pre `computeKeyStatus`) and certain
@@ -34,10 +31,16 @@ describe("countShadowedAppSaves — defensive against missing shadowedBy", () =>
 	it("does not throw when a field's status entry is missing entirely", () => {
 		const statuses: PlatformApiKeysStatus = {};
 		expect(() =>
-			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+			countShadowedAppSaves({
+				statuses,
+				values: { ...VALUES, runwayApiKey: "rw_x" },
+			})
 		).not.toThrow();
 		expect(
-			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+			countShadowedAppSaves({
+				statuses,
+				values: { ...VALUES, runwayApiKey: "rw_x" },
+			})
 		).toBe(0);
 	});
 
@@ -47,10 +50,16 @@ describe("countShadowedAppSaves — defensive against missing shadowedBy", () =>
 			runwayApiKey: status({ set: true, source: "electron" }),
 		};
 		expect(() =>
-			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+			countShadowedAppSaves({
+				statuses,
+				values: { ...VALUES, runwayApiKey: "rw_x" },
+			})
 		).not.toThrow();
 		expect(
-			countShadowedAppSaves({ statuses, values: { ...VALUES, runwayApiKey: "rw_x" } })
+			countShadowedAppSaves({
+				statuses,
+				values: { ...VALUES, runwayApiKey: "rw_x" },
+			})
 		).toBe(0);
 	});
 
@@ -95,7 +104,9 @@ describe("countShadowedAppSaves — defensive against missing shadowedBy", () =>
 
 describe("getShadowedBy — defensive against missing shadowedBy", () => {
 	it("returns undefined when status is undefined", () => {
-		expect(getShadowedBy({ fieldIsDirty: true, status: undefined })).toBeUndefined();
+		expect(
+			getShadowedBy({ fieldIsDirty: true, status: undefined })
+		).toBeUndefined();
 	});
 
 	it("returns [] when status.shadowedBy is undefined and field is clean", () => {

--- a/qcut/apps/web/src/components/editor/properties-panel/api-keys-view.tsx
+++ b/qcut/apps/web/src/components/editor/properties-panel/api-keys-view.tsx
@@ -71,7 +71,9 @@ function getActiveSource({
 // Defensive accessor: `shadowedBy` is typed as required, but a status entry
 // returned by an older Electron build (or a not-yet-rebuilt preload bundle)
 // can omit it. Treat missing as "no shadows" rather than crashing the save.
-function shadowedByOf(status: PlatformApiKeyStatus | undefined): readonly KeySource[] {
+function shadowedByOf(
+	status: PlatformApiKeyStatus | undefined
+): readonly KeySource[] {
 	return status?.shadowedBy ?? [];
 }
 
@@ -84,8 +86,7 @@ export function countShadowedAppSaves({
 }) {
 	return EDITABLE_API_KEY_FIELDS.filter(
 		(field) =>
-			values[field] !== "" &&
-			shadowedByOf(statuses[field]).includes("electron")
+			values[field] !== "" && shadowedByOf(statuses[field]).includes("electron")
 	).length;
 }
 

--- a/qcut/apps/web/src/components/editor/properties-panel/api-keys-view.tsx
+++ b/qcut/apps/web/src/components/editor/properties-panel/api-keys-view.tsx
@@ -68,7 +68,14 @@ function getActiveSource({
 	return status.source;
 }
 
-function countShadowedAppSaves({
+// Defensive accessor: `shadowedBy` is typed as required, but a status entry
+// returned by an older Electron build (or a not-yet-rebuilt preload bundle)
+// can omit it. Treat missing as "no shadows" rather than crashing the save.
+function shadowedByOf(status: PlatformApiKeyStatus | undefined): readonly KeySource[] {
+	return status?.shadowedBy ?? [];
+}
+
+export function countShadowedAppSaves({
 	statuses,
 	values,
 }: {
@@ -77,11 +84,12 @@ function countShadowedAppSaves({
 }) {
 	return EDITABLE_API_KEY_FIELDS.filter(
 		(field) =>
-			values[field] !== "" && statuses[field]?.shadowedBy.includes("electron")
+			values[field] !== "" &&
+			shadowedByOf(statuses[field]).includes("electron")
 	).length;
 }
 
-function getShadowedBy({
+export function getShadowedBy({
 	fieldIsDirty,
 	status,
 }: {
@@ -92,15 +100,17 @@ function getShadowedBy({
 		return undefined;
 	}
 
+	const shadowedBy = shadowedByOf(status);
+
 	if (
 		fieldIsDirty &&
 		status.source === "environment" &&
-		!status.shadowedBy.includes("electron")
+		!shadowedBy.includes("electron")
 	) {
-		return [...status.shadowedBy, "electron"];
+		return [...shadowedBy, "electron"];
 	}
 
-	return status.shadowedBy;
+	return shadowedBy;
 }
 
 function ApiKeyLabel({

--- a/qcut/docs/task/ai-video-save-enoent-fix/plan.md
+++ b/qcut/docs/task/ai-video-save-enoent-fix/plan.md
@@ -1,0 +1,435 @@
+# Plan: Fix `ENOENT` when saving generated AI videos to project media folder
+
+**Issue**: [Quriosity-agent/qcut#290](https://github.com/Quriosity-agent/qcut/issues/290)
+**Status**: 🟡 Planned
+**Estimated time**: ~100–130 minutes (4 subtasks: refactor + stat-guard+retry + redact + tests)
+**Risk**: Low–Medium — touches a critical write path used by every AI video generation, but the surface area is one Electron handler plus one renderer-side error mapper
+
+---
+
+## Background
+
+### The bug this fixes
+
+Saving a generated AI video can fail with an `ENOENT` while writing the `.mp4`
+into the project media folder. The user sees:
+
+```text
+Failed to save video to disk: Failed to write video file to disk:
+ENOENT: no such file or directory, open
+'<project-root>\media\generated\videos\AI-Video-<model>-<timestamp>-...-<id>.mp4'
+```
+
+This aborts `integrateVideoToMediaStore()` even though generation and download
+succeeded. The generated clip never reaches the media store.
+
+### Where the bug lives
+
+- `electron/ai-video-save-handler.ts:131-185` — `saveAIVideoToDisk()`
+  - calls `fs.promises.mkdir(projectDir, { recursive: true, mode: 0o755 })` once
+  - then calls `fs.promises.writeFile(filePath, buffer, { mode: 0o644 })`
+  - has no re-check of the directory between `mkdir` and `writeFile`, no retry on `ENOENT`,
+    and no redaction of the local path in the returned error string.
+- `apps/web/src/components/editor/media-panel/views/ai/hooks/generation/media-integration.ts:154-181`
+  — `integrateVideoToMediaStore()` treats any `saveResult.success === false` as
+  fatal and surfaces the raw `error` string straight into a `toast`/`onError` call.
+- `electron/project-folder-handler.ts:108-118, 370-407` — already centralizes the
+  required project folder structure (`media/generated/videos/` is in `REQUIRED_FOLDERS`)
+  via the `project-folder:ensure-structure` IPC. **`saveAIVideoToDisk()` does not
+  use this**; it only `mkdir`s the deepest leaf directory.
+
+### Root causes (multiple, ranked by likelihood)
+
+1. **Cloud-synced Documents folders (OneDrive / iCloud)** — the directory entry
+   exists as a "online-only" placeholder, `mkdir` returns success, but `writeFile`
+   races against rehydration and gets `ENOENT`. This is the dominant cause on
+   Windows machines where `Documents\` is OneDrive-mirrored.
+2. **Project structure was never created** — the project folder for `projectId`
+   may have been created in a prior session that crashed before
+   `project-folder:ensure-structure` ran, or may have been deleted out from under
+   the running app. `mkdir(projectDir, { recursive: true })` will create the leaf,
+   but if a parent (`Documents/QCut/Projects/<id>/media/generated/`) is in a weird
+   state on a cloud-synced volume, the leaf creation can succeed-then-disappear.
+3. **TOCTOU race** — directory deleted/moved between `mkdir`, `statfs`, and
+   `writeFile`.
+
+### Why the current shape is the wrong shape
+
+`saveAIVideoToDisk` independently re-implements directory creation that already
+lives in `project-folder-handler.ts`. The two paths can drift (e.g. someone adds
+a new required subfolder to `REQUIRED_FOLDERS` and forgets `saveAIVideoToDisk`).
+The fix should funnel both through one shared helper so the project structure
+contract is enforced in exactly one place.
+
+### Goals
+
+1. **Make AI video save reliable** when the project folder structure is missing,
+   partially synced, or transiently unavailable.
+2. **Centralize project folder ensure** logic — `saveAIVideoToDisk()` calls the
+   same code path as `project-folder:ensure-structure`, not its own ad-hoc
+   `mkdir`.
+3. **Single retry with full structure recreation** when `writeFile` throws
+   `ENOENT`, so cloud-sync placeholder cases self-heal.
+4. **Redact full filesystem paths** from user-facing errors (debug log keeps the
+   path).
+5. **Regression tests** that pin the new behavior so the bug cannot silently
+   come back.
+
+### Non-goals (explicitly out of scope)
+
+- Rewriting OneDrive detection / warning the user about cloud-synced Documents.
+  (Could be a follow-up if telemetry shows it remains common.)
+- Changing the project folder layout or moving away from `Documents/QCut/Projects/`.
+- Touching `media-import-handler.ts` / image / audio save paths (they have the
+  same anti-pattern but are out of scope for this issue — flagged at the bottom).
+- Replacing `console.log` instrumentation with a real logger.
+
+---
+
+## Target architecture
+
+### New shared helper
+
+A new module `electron/lib/project-structure.ts` (extracted from the inline
+`REQUIRED_FOLDERS` + ensure logic in `project-folder-handler.ts`) exposes:
+
+```ts
+// electron/lib/project-structure.ts
+
+export const REQUIRED_PROJECT_FOLDERS = [
+  "media",
+  "media/imported",
+  "media/generated",
+  "media/generated/images",
+  "media/generated/videos",
+  "media/generated/audio",
+  "media/temp",
+  "output",
+  "cache",
+] as const;
+
+export interface EnsureStructureResult {
+  created: string[];
+  existing: string[];
+  projectRoot: string;
+}
+
+/**
+ * Ensure the full QCut project folder tree exists under
+ * Documents/QCut/Projects/<sanitized projectId>/.
+ * Idempotent and safe to call repeatedly; safe under concurrent calls
+ * because mkdir({ recursive: true }) tolerates EEXIST.
+ */
+export async function ensureProjectStructure(
+  projectId: string
+): Promise<EnsureStructureResult>;
+
+/**
+ * Resolve the projects base path (Documents/QCut/Projects).
+ */
+export function getProjectsBasePath(): string;
+
+/**
+ * Sanitize a single path component (no separators, no ..).
+ */
+export function sanitizePathComponent(component: string): string;
+```
+
+### Refactored save path
+
+`saveAIVideoToDisk()` becomes:
+
+```ts
+// pseudocode — see Subtask 2 for actual diff
+const projectDir = getAIVideoDir(projectId);
+
+await ensureProjectStructure(projectId);   // ← replaces ad-hoc mkdir of leaf only
+
+// ... build filePath ...
+
+try {
+  await writeFileWithStatGuard(filePath, projectDir, buffer, projectId);
+} catch (writeError) {
+  return {
+    success: false,
+    error: redactPath(`Failed to write video file: ${writeError.message}`),
+  };
+}
+```
+
+Where `writeFileWithStatGuard` does the **pre-write stat re-check** plus the
+**single ENOENT retry** required by the issue's proposed fix:
+
+```ts
+async function writeFileWithStatGuard(
+  filePath: string,
+  projectDir: string,
+  buffer: Buffer,
+  projectId: string
+): Promise<void> {
+  // Step A: immediately before writeFile, confirm projectDir exists AND is a dir.
+  // This catches the OneDrive placeholder / TOCTOU case before we even try to write.
+  const dirOk = await isExistingDirectory(projectDir);
+  if (!dirOk) {
+    await ensureProjectStructure(projectId);
+  }
+
+  // Step B: write. If ENOENT, retry once after recreating the structure.
+  try {
+    await fs.promises.writeFile(filePath, buffer, { mode: 0o644 });
+    return;
+  } catch (err: any) {
+    if (err?.code !== "ENOENT") throw err;
+    await ensureProjectStructure(projectId);
+    await fs.promises.writeFile(filePath, buffer, { mode: 0o644 });
+  }
+}
+
+async function isExistingDirectory(p: string): Promise<boolean> {
+  try {
+    const s = await fs.promises.stat(p);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+```
+
+Note the two-layer defence: the `stat` guard handles the *predictable* missing-dir
+case (cloud-sync placeholder you can detect), and the ENOENT catch handles the
+*unpredictable* race (dir disappears between stat and writeFile). Both are
+needed because either alone is insufficient against TOCTOU.
+
+### Error redaction (UI **and** logs gated by debug)
+
+The issue requires that full local paths not leak to the UI **or logs unless
+debug logging is enabled**. So redaction applies in two places:
+
+```ts
+// Debug flag: only when QCUT_DEBUG_PATHS=1 (env), or app.isPackaged === false,
+// do we log the unredacted path. Production logs are redacted too.
+const PATH_DEBUG =
+  process.env.QCUT_DEBUG_PATHS === "1" || !app.isPackaged;
+
+function redactPath(message: string): string {
+  if (PATH_DEBUG) return message;
+  const base = getProjectsBasePath();
+  return message.replaceAll(base, "<project>");
+}
+
+// Use it for BOTH logs and IPC return values:
+console.error("AI Video Save Error:", redactPath(error));
+return { success: false, error: redactPath(error) };
+```
+
+This means a developer running `bun run electron:dev` still sees full paths
+(`!app.isPackaged` → debug on); a customer running the packaged app sees
+`<project>/media/generated/videos/AI-Video-...mp4` in both the UI toast and the
+log file shipped with bug reports.
+
+### Renderer-side error message
+
+`media-integration.ts` keeps its current "Failed to save video to disk: …"
+prefix, which now wraps the already-redacted server-side error.
+
+---
+
+## Subtasks
+
+### Subtask 1 — Extract `ensureProjectStructure` into a shared module
+
+**Time**: ~20 min
+**Files**:
+
+- **NEW** `electron/lib/project-structure.ts` — owns `REQUIRED_PROJECT_FOLDERS`,
+  `getProjectsBasePath`, `sanitizePathComponent`, `ensureProjectStructure`.
+- **EDIT** `electron/project-folder-handler.ts:99-154, 370-407`
+  - Remove inline `REQUIRED_FOLDERS`, `getProjectsBasePath`, `sanitizePathComponent`
+    constants/helpers.
+  - Import them from `./lib/project-structure`.
+  - The `project-folder:ensure-structure` IPC handler now delegates to
+    `ensureProjectStructure(projectId)` so behavior is byte-for-byte preserved.
+- **EDIT** `electron/preload-integrations.ts:183-184` — no change needed (just
+  verify the IPC name `project-folder:ensure-structure` is unchanged).
+
+**Acceptance**: All existing project-folder-handler tests still pass; the
+`project-folder:ensure-structure` IPC returns the same shape.
+
+---
+
+### Subtask 2 — Pre-write `stat` guard + ENOENT retry in `saveAIVideoToDisk`
+
+**Time**: ~30 min
+**Files**:
+
+- **EDIT** `electron/ai-video-save-handler.ts:130-193`
+  - Replace the ad-hoc `mkdir(projectDir, { recursive: true, mode: 0o755 })`
+    block at lines 137-146 with a call to `ensureProjectStructure(projectId)`.
+  - Add a private `isExistingDirectory(p)` helper.
+  - Add a private `writeFileWithStatGuard(filePath, projectDir, buffer, projectId)`
+    that:
+    1. **Pre-write check** — calls `isExistingDirectory(projectDir)`; if false,
+       calls `ensureProjectStructure(projectId)` before attempting `writeFile`.
+       This is the explicit "immediately before `writeFile`, re-check that
+       `projectDir` exists and is a directory" requirement from the issue.
+    2. **ENOENT retry** — on `writeFile` rejecting with `code === "ENOENT"`,
+       calls `ensureProjectStructure(projectId)` and retries `writeFile` exactly
+       once. Other errors propagate without retry.
+  - Replace the existing `writeFile` call site (line 185) with
+    `await writeFileWithStatGuard(...)`.
+  - Both `ensureProjectStructure` failures and the second `writeFile` failure
+    return `{ success: false, error }` with the redacted message.
+- **EDIT** `electron/ai-video-save-handler.ts:18-34` — keep `getAIVideoDir`
+  signature unchanged; it just composes `getProjectsBasePath()` + `media/generated/videos`.
+  Internally rewrite to import `getProjectsBasePath` from the new shared module
+  so both helpers agree on the base path.
+- **EDIT** `electron/ai-video-save-handler.ts:9-13` — drop the local
+  `sanitizeFilename`'s use for project IDs (still used for filenames). Use
+  `sanitizePathComponent` from the shared module for project IDs.
+
+**Acceptance**:
+- The `stat` guard runs before every `writeFile`, even on the happy path
+  (assertable in tests via spy on `fs.promises.stat`).
+- ENOENT on first `writeFile` triggers exactly one retry and exactly one extra
+  `ensureProjectStructure` call.
+- Non-ENOENT errors propagate without a retry (unchanged behavior).
+- The directory structure created matches `REQUIRED_PROJECT_FOLDERS`.
+
+---
+
+### Subtask 3 — Redact local paths from BOTH user-facing errors AND production logs
+
+**Time**: ~20 min
+**Files**:
+
+- **EDIT** `electron/ai-video-save-handler.ts`
+  - Add a module-level `PATH_DEBUG = process.env.QCUT_DEBUG_PATHS === "1" || !app.isPackaged`.
+  - Add a private `redactPath(message: string): string` that no-ops when
+    `PATH_DEBUG === true` and otherwise replaces `getProjectsBasePath()` with
+    `<project>` in the message.
+  - Apply `redactPath()` to **both**:
+    1. Every `error` string returned from `saveAIVideoToDisk` (lines
+       101, 112, 122, 140, 171, 187, 201, 209, 251).
+    2. Every `console.error("AI Video Save Error:", ...)` call (same lines).
+       This is the issue's "or logs unless debug logging is enabled" clause.
+  - Leave `console.log` instrumentation (lines 30-33, 132-134, 240-242, 343, 348)
+    untouched — those are explicit dev breadcrumbs and only run when the dev
+    starts the app via `bun run electron:dev`. Document this exclusion at the
+    top of the file with a one-line comment.
+- **EDIT** `apps/web/src/components/editor/media-panel/views/ai/hooks/generation/media-integration.ts:177-181`
+  - No content change — confirm the now-redacted error string still composes
+    cleanly into the existing toast prefix `"Failed to save video to disk: "`.
+  - Leave `console.error("🚨 step 6e: CRITICAL - Save to disk FAILED:", error)`
+    in place; the IPC payload is already redacted by the time it reaches the
+    renderer.
+
+**Acceptance**:
+- In a packaged build with no `QCUT_DEBUG_PATHS=1`, neither IPC return values
+  nor `console.error` output contain anything starting with the user's Documents
+  folder.
+- In `bun run electron:dev` (or with `QCUT_DEBUG_PATHS=1` set), full paths are
+  preserved in `console.error` for debugging.
+- Test case 6 (Subtask 4) asserts both halves with `app.isPackaged` mocked.
+
+---
+
+### Subtask 4 — Unit tests for ENOENT retry, structure ensure, and redaction
+
+**Time**: ~30 min
+**Files**:
+
+- **NEW** `electron/__tests__/ai-video-save-handler.test.ts`
+  - Mocks `electron` `app.getPath("documents")` (mirrors
+    `electron/__tests__/ai-video-migration.test.ts:11-23` setup).
+  - Mocks `fs.promises.writeFile` and `fs.promises.mkdir` selectively.
+  - Cases (mapped to the issue's three required regression scenarios):
+    1. **happy path** — `writeFile` succeeds first try; `stat(projectDir)`
+       returns `isDirectory()=true`. → exactly one `ensureProjectStructure`
+       call (the upfront one), one `stat`, one `writeFile`, returns
+       `{ success: true, localPath, fileName, fileSize }`.
+    2. **issue case A — `media/generated/videos` missing** — `stat(projectDir)`
+       initially throws `ENOENT`; `ensureProjectStructure` then creates it;
+       `writeFile` succeeds. Asserts the pre-write stat guard triggered an
+       extra `ensureProjectStructure` call **before** any `writeFile` attempt.
+    3. **issue case B — directory removed between `mkdir` and `writeFile`** —
+       `stat(projectDir)` returns `isDirectory()=true` (TOCTOU); first
+       `writeFile` rejects with `Object.assign(new Error("ENOENT…"), { code:
+       "ENOENT" })`; second `writeFile` (after retry-time
+       `ensureProjectStructure`) succeeds. Assert exactly two `writeFile`
+       calls and exactly two `ensureProjectStructure` calls.
+    4. **ENOENT twice (no infinite retry)** — both `writeFile` calls reject
+       with `ENOENT`. Result is `{ success: false, error }`. Assert no more
+       than two `writeFile` calls.
+    5. **non-ENOENT error** — `writeFile` rejects with `EPERM`. Assert exactly
+       one `writeFile` call (no retry) and `{ success: false }`.
+    6. **issue case C — redacted user-facing error** — with `app.isPackaged =
+       true` and `QCUT_DEBUG_PATHS` unset, both the IPC return value's `error`
+       AND the `console.error` spy receive a string containing `"<project>"`
+       and **not** containing the mocked `/mock/Documents` path. Then flip
+       `app.isPackaged = false`, re-run, assert the full path IS present (debug
+       mode passthrough).
+- **NEW** `electron/__tests__/project-structure.test.ts`
+  - Pure unit test of `ensureProjectStructure`:
+    1. All folders missing → returns full `created` array, empty `existing`.
+    2. All folders present → returns empty `created`, full `existing`.
+    3. `mkdir` rejects on one folder → that folder appears in neither array;
+       function still returns (does not throw); other folders still processed.
+    4. `sanitizePathComponent` strips `..`, `/`, `\`.
+    5. Path traversal in `projectId` is neutered (asserts `..` strings cannot
+       escape `getProjectsBasePath()`).
+
+**Acceptance**: `bun run test electron/__tests__/ai-video-save-handler.test.ts`
+and `bun run test electron/__tests__/project-structure.test.ts` both pass; total
+new coverage ≥ the six handler scenarios + five helper scenarios above.
+
+---
+
+## Verification checklist (before marking issue closed)
+
+Tied to acceptance criteria from the issue:
+
+- [ ] AI video save succeeds when `media/generated/videos` is missing but
+      can be created. *(covered by test case 2 in Subtask 4)*
+- [ ] AI video save retries once when the directory disappears between `mkdir`
+      and `writeFile`. *(covered by test case 3)*
+- [ ] User-facing errors do not expose full local filesystem paths.
+      *(covered by test case 6, plus a manual `bun run electron:dev`
+      smoke-test where you `rmdir` the videos folder mid-generation)*
+- [ ] Tests cover the `ENOENT` case and directory recreation behavior.
+      *(test cases 3, 4, plus structure test 1)*
+- [ ] Manual smoke test on a OneDrive-synced `Documents` folder
+      (Windows): trigger an AI video generation, confirm the save succeeds
+      end-to-end. *(no automated coverage possible)*
+
+---
+
+## Future considerations (NOT in this PR — long-term direction)
+
+These are noted so the next person touching this area knows they exist; do not
+implement them here.
+
+1. **Apply the same retry pattern to image and audio save paths**
+   (`electron/ai-pipeline-output.ts`, `electron/media-import-handler.ts`).
+   They have the same `mkdir` + `writeFile` shape and almost certainly the same
+   latent bug. Track as a follow-up issue once this fix soaks.
+2. **Detect cloud-synced Documents (OneDrive/iCloud) at app startup** and warn
+   the user once. The signal is the presence of OneDrive-specific reparse points
+   (Windows) or `com.apple.icloud` xattr (macOS) under `getPath("documents")`.
+3. **Telemetry** — count ENOENT-then-recovered vs ENOENT-then-failed events to
+   see whether the retry materially helps in the field. If retry-success rate is
+   >95% we know the cloud-sync hypothesis was right; if not, there's another
+   root cause to chase.
+
+---
+
+## Out-of-band notes
+
+- Save handler currently logs absolute paths via `console.log` at
+  `ai-video-save-handler.ts:30-33, 132-134, 240-242, 343, 348`. Those are dev
+  logs and intentionally unredacted; do not redact `console.log` output.
+- `getLegacyAIVideoDir` (line 40) and `migrateAIVideosToDocuments` (line 366)
+  are used only by the one-shot AppData→Documents migration, not by the
+  generation path. Untouched by this plan.
+- The plugin layout (`packages/qagent/`, `electron/native-pipeline/`) does not
+  duplicate this code path — only `electron/ai-video-save-handler.ts` writes
+  generated AI videos in the Electron main process.

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
@@ -34,11 +34,17 @@ failing release, or rotating Apple credentials.
 With cert in your local keychain and env vars set:
 
 \`\`\`bash
-APPLE_ID="apple-dev@qcut.app" \
+cd qcut && \
+  APPLE_ID="apple-dev@qcut.app" \
   APPLE_APP_SPECIFIC_PASSWORD="..." \
   APPLE_TEAM_ID="ABCDE12345" \
-  cd qcut && bun run dist:mac
+  bun run dist:mac
 \`\`\`
+
+> Bash applies the `VAR=value` prefix only to the **first** command in the
+> chain. Putting the assignments before `cd qcut && bun run dist:mac` would
+> scope them to `cd` and lose them by the time `bun run` starts — keep the
+> assignments after the `&&` so they reach `bun run dist:mac`.
 
 If the cert is NOT in your keychain, also set CSC_LINK + CSC_KEY_PASSWORD.
 

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
@@ -150,7 +150,7 @@ Add a section near the top (or merge with the Windows signing section if both ex
 macOS releases must be signed by Quriosity's Developer ID Application
 certificate AND notarized by Apple. The release workflow will fail if
 either step fails — do not bypass. See
-`docs/setup/macos-code-signing.md` for credential setup and rotation.
+`setup/macos-code-signing.md` for credential setup and rotation.
 ```
 
 ## Modified: `qcut/CLAUDE.md`

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
@@ -1,0 +1,169 @@
+# macOS Code Signing — Documentation Tasks
+
+Maintainer-facing docs to land alongside the code.
+
+## New file: `qcut/docs/setup/macos-code-signing.md`
+
+**Audience:** anyone bringing up a new release runner, debugging a
+failing release, or rotating Apple credentials.
+
+**Outline:**
+
+```markdown
+# macOS Code Signing — Setup Guide
+
+## Apple Developer Program
+- Membership tier: **Organization**, USD 99/yr.
+- Apple ID: an org-shared inbox (e.g. `apple-dev@qcut.app`); never a personal email.
+- 2FA: enabled on multiple trusted devices. Apple does NOT remove 2FA.
+- Team ID: stored as GitHub variable `APPLE_TEAM_ID`.
+- Membership renewal: auto-renews. **Set a billing alert** on the Apple ID — if renewal fails, ALL signing breaks within ~30 days.
+- D-U-N-S Number: see `docs/task/macos-code-signing/PROCUREMENT.md`.
+
+## GitHub Actions secrets / variables
+
+| Name | Type | Source |
+|------|------|--------|
+| MAC_CSC_LINK | secret | base64 of `quriosity-developer-id.p12` (kept in 1Password) |
+| MAC_CSC_KEY_PASSWORD | secret | the .p12 export password (1Password) |
+| APPLE_ID | secret | the org Apple ID email |
+| APPLE_APP_SPECIFIC_PASSWORD | secret | from appleid.apple.com → App-Specific Passwords |
+| APPLE_TEAM_ID | variable | 10-char Team ID from developer.apple.com → Membership Details |
+
+## Local signed builds
+With cert in your local keychain and env vars set:
+
+\`\`\`bash
+APPLE_ID="apple-dev@qcut.app" \
+  APPLE_APP_SPECIFIC_PASSWORD="..." \
+  APPLE_TEAM_ID="ABCDE12345" \
+  cd qcut && bun run dist:mac
+\`\`\`
+
+If the cert is NOT in your keychain, also set CSC_LINK + CSC_KEY_PASSWORD.
+
+## Verifying a signed installer
+\`\`\`bash
+codesign --verify --deep --strict --verbose=2 /Applications/QCut.app
+spctl -a -t exec -vv /Applications/QCut.app
+xcrun stapler validate ~/Downloads/QCut*.dmg
+\`\`\`
+
+Expected:
+- `codesign` exits 0 silently.
+- `spctl` prints `accepted` and `source=Notarized Developer ID`.
+- `xcrun stapler validate` prints `The validate action worked!`.
+
+## Troubleshooting
+
+### "User interaction is not allowed" during signing
+The build is trying to use a login keychain on a CI runner. Ensure
+`CSC_LINK` and `CSC_KEY_PASSWORD` are set so a temporary keychain is
+created.
+
+### "errSecInternalComponent"
+The keychain is locked or the password was wrong. Verify
+`CSC_KEY_PASSWORD` matches the .p12 export password from §3.3 of the
+PROCUREMENT doc.
+
+### Notarization status "Invalid"
+Apple's notary rejected the bundle. Get the detailed log:
+
+\`\`\`bash
+xcrun notarytool log <submission-id> \
+  --apple-id <APPLE_ID> \
+  --password <APPLE_APP_SPECIFIC_PASSWORD> \
+  --team-id <APPLE_TEAM_ID>
+\`\`\`
+
+Most common cause: a nested binary (FFmpeg, AICP) is unsigned or has
+mismatched/missing entitlements. Re-sign or update entitlements and
+retry.
+
+### Stapling fails but notarization succeeded
+Known issue with offline machines or transient Apple-side flakes.
+Staple manually:
+
+\`\`\`bash
+xcrun stapler staple /path/to/QCut.dmg
+\`\`\`
+
+### Gatekeeper blocks the app despite signing
+Check whether the app is *actually* notarized:
+\`\`\`bash
+spctl -a -t exec -vv /Applications/QCut.app
+\`\`\`
+
+If output says `signed Developer ID` (without "Notarized") the bundle
+was signed but notarization failed silently. Check the build log.
+
+## Rotating credentials
+
+### App-Specific Password
+1. Sign into appleid.apple.com → App-Specific Passwords.
+2. Revoke the old one.
+3. Generate a new one labeled `QCut release notarization` (date suffix optional).
+4. Update GitHub secret `APPLE_APP_SPECIFIC_PASSWORD`.
+5. Trigger a `*-rc.N` release tag and confirm the workflow succeeds.
+
+### Cert (.p12)
+1. Generate a new Developer ID Application cert in developer.apple.com.
+2. Export as .p12 with private key (see PROCUREMENT.md §3.3).
+3. base64-encode and update `MAC_CSC_LINK` and `MAC_CSC_KEY_PASSWORD`.
+4. The old cert remains valid for already-signed builds; do not revoke unless compromised.
+
+### Apple ID owner change
+1. Invite the new owner to the team in App Store Connect.
+2. Transfer ownership.
+3. Update `APPLE_ID` GitHub secret.
+4. Generate a new App-Specific Password under the new account.
+5. Update `APPLE_APP_SPECIFIC_PASSWORD`.
+
+## Renewal
+Apple Developer Program: USD 99/yr, auto-renews. **Confirm the billing
+card in the Apple ID account is current** every 6 months. If renewal
+fails, ALL signing breaks within ~30 days.
+```
+
+## Modified: `qcut/docs/release.md`
+
+Add a section near the top (or merge with the Windows signing section if both exist):
+
+```markdown
+## Prerequisites for macOS releases
+macOS releases must be signed by Quriosity's Developer ID Application
+certificate AND notarized by Apple. The release workflow will fail if
+either step fails — do not bypass. See
+`docs/setup/macos-code-signing.md` for credential setup and rotation.
+```
+
+## Modified: `qcut/CLAUDE.md`
+
+Append under "Architecture Guidelines → DON'T":
+
+```markdown
+- Disable macOS code signing or notarization in the release workflow.
+  See `docs/setup/macos-code-signing.md`. Local-dev unsigned builds use
+  `bun run dist:mac` without the Apple env vars set.
+```
+
+This makes the rule visible to future Claude Code sessions so we do not
+silently regress.
+
+## Optional: PR template note
+
+If `qcut/.github/PULL_REQUEST_TEMPLATE.md` exists, add a checkbox:
+
+```markdown
+- [ ] If touching `release.yml` build-macos job or `package.json` `build.mac`,
+      I have not disabled code signing or notarization.
+```
+
+Skip if no template exists yet — do not create one solely for this.
+
+## What NOT to document
+
+- Actual values of any secret/variable.
+- Step-by-step "how Gatekeeper works" — Apple's docs cover this.
+- Mac App Store submission — different cert, different review, separate task.
+- iOS distribution — out of scope.

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.md
@@ -30,6 +30,16 @@ failing release, or rotating Apple credentials.
 | APPLE_APP_SPECIFIC_PASSWORD | secret | from appleid.apple.com → App-Specific Passwords |
 | APPLE_TEAM_ID | variable | 10-char Team ID from developer.apple.com → Membership Details |
 
+> ⚠️ **Workflow wiring is part of the implementation PR, not this planning
+> doc.** The current `.github/workflows/release.yml` `build-macos` job (around
+> lines 169–178) exposes only `GH_TOKEN` and `USE_HARD_LINKS` to the
+> "Build Electron application" step. The signing/notarization PR must
+> expand the `env:` block to also forward `MAC_CSC_LINK`,
+> `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and
+> `APPLE_TEAM_ID` — without that change, electron-builder will fall back
+> to producing an unsigned, un-notarized `.app` even after the secrets
+> exist on the repo.
+
 ## Local signed builds
 With cert in your local keychain and env vars set:
 

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
@@ -141,7 +141,7 @@ Apple ID 上的账单卡有效**。续费失败的话约 30 天内所有签名�
 ## macOS 发布前置条件
 macOS 发布产物**必须**用 Quriosity 的 Developer ID Application 证书
 签名**并且**经过 Apple 公证。任一步失败发布工作流都会失败 — **不要**
-绕过。设置和凭据轮换见 `docs/setup/macos-code-signing.md`。
+绕过。设置和凭据轮换见 `setup/macos-code-signing.md`。
 ```
 
 ## 修改：`qcut/CLAUDE.md`

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
@@ -36,11 +36,14 @@
 本地钥匙串里有证书 + 环境变量都设好后：
 
 \`\`\`bash
-APPLE_ID="apple-dev@qcut.app" \
+cd qcut && \
+  APPLE_ID="apple-dev@qcut.app" \
   APPLE_APP_SPECIFIC_PASSWORD="..." \
   APPLE_TEAM_ID="ABCDE12345" \
-  cd qcut && bun run dist:mac
+  bun run dist:mac
 \`\`\`
+
+> Bash 中 `VAR=value` 前缀只作用于命令链里的**第一个**命令。如果写在 `cd qcut && bun run dist:mac` 之前，环境变量只会作用于 `cd`，等 `bun run` 启动时已经丢失 — 必须把赋值放在 `&&` 之后，才能传给 `bun run dist:mac`。
 
 如果证书**不在**钥匙串里，再设 CSC_LINK + CSC_KEY_PASSWORD。
 

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
@@ -1,0 +1,164 @@
+# macOS 代码签名 — 文档任务
+
+随代码一起提交的、面向维护者的文档。
+
+## 新增文件：`qcut/docs/setup/macos-code-signing.md`
+
+**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换 Apple
+凭据的人。
+
+**大纲：**
+
+```markdown
+# macOS 代码签名 — 设置指南
+
+## Apple Developer Program
+- 会员席位：**Organization**，USD 99/年。
+- Apple ID：组织共享邮箱（例如 `apple-dev@qcut.app`），永远不要用
+  个人邮箱。
+- 2FA：在多个可信设备上启用。Apple **不会**帮你撤销 2FA。
+- Team ID：存到 GitHub variable `APPLE_TEAM_ID`。
+- 续费：自动续费。**给 Apple ID 设账单告警** — 续费失败的话约 30 天内
+  所有签名都会失效。
+- D-U-N-S Number：见 `docs/task/macos-code-signing/PROCUREMENT.zh-CN.md`。
+
+## GitHub Actions secret / variable
+
+| 名称 | 类型 | 来源 |
+|------|------|------|
+| MAC_CSC_LINK | secret | `quriosity-developer-id.p12` 的 base64（存在 1Password） |
+| MAC_CSC_KEY_PASSWORD | secret | `.p12` 导出密码（1Password） |
+| APPLE_ID | secret | 组织 Apple ID 邮箱 |
+| APPLE_APP_SPECIFIC_PASSWORD | secret | appleid.apple.com → App-Specific Passwords |
+| APPLE_TEAM_ID | variable | developer.apple.com → Membership Details 里的 10 位 Team ID |
+
+## 本地签名构建
+本地钥匙串里有证书 + 环境变量都设好后：
+
+\`\`\`bash
+APPLE_ID="apple-dev@qcut.app" \
+  APPLE_APP_SPECIFIC_PASSWORD="..." \
+  APPLE_TEAM_ID="ABCDE12345" \
+  cd qcut && bun run dist:mac
+\`\`\`
+
+如果证书**不在**钥匙串里，再设 CSC_LINK + CSC_KEY_PASSWORD。
+
+## 校验签名安装包
+\`\`\`bash
+codesign --verify --deep --strict --verbose=2 /Applications/QCut.app
+spctl -a -t exec -vv /Applications/QCut.app
+xcrun stapler validate ~/Downloads/QCut*.dmg
+\`\`\`
+
+预期：
+- `codesign` 安静地退出 0。
+- `spctl` 打印 `accepted` 且 `source=Notarized Developer ID`。
+- `xcrun stapler validate` 打印 `The validate action worked!`。
+
+## 故障排查
+
+### 签名时报 "User interaction is not allowed"
+构建在 CI runner 上想用登录钥匙串。确保 `CSC_LINK` 和
+`CSC_KEY_PASSWORD` 已设，这样会创建一个临时钥匙串。
+
+### "errSecInternalComponent"
+钥匙串被锁，或密码错。检查 `CSC_KEY_PASSWORD` 与 PROCUREMENT 文档
+§3.3 设的 `.p12` 导出密码一致。
+
+### 公证状态 "Invalid"
+Apple 公证拒绝了 bundle。拿详细日志：
+
+\`\`\`bash
+xcrun notarytool log <submission-id> \
+  --apple-id <APPLE_ID> \
+  --password <APPLE_APP_SPECIFIC_PASSWORD> \
+  --team-id <APPLE_TEAM_ID>
+\`\`\`
+
+最常见的原因：嵌套二进制（FFmpeg、AICP）未签名或权限不匹配。重新
+签名或修权限后重试。
+
+### 公证成功但 stapling 失败
+离线机器或 Apple 端瞬时抖动的已知问题。手工 staple：
+
+\`\`\`bash
+xcrun stapler staple /path/to/QCut.dmg
+\`\`\`
+
+### 已签名，但 Gatekeeper 还拦
+看是不是真的*公证*过：
+\`\`\`bash
+spctl -a -t exec -vv /Applications/QCut.app
+\`\`\`
+
+如果输出是 `signed Developer ID`（没有 "Notarized"），说明签名成功
+但公证悄悄失败了。回去看构建日志。
+
+## 凭据轮换
+
+### App-Specific Password
+1. 登录 appleid.apple.com → App-Specific Passwords。
+2. 撤销旧的。
+3. 生成新的，名字 `QCut release notarization`（可加日期后缀）。
+4. 更新 GitHub secret `APPLE_APP_SPECIFIC_PASSWORD`。
+5. 推一个 `*-rc.N` tag，确认工作流成功。
+
+### 证书 (.p12)
+1. 在 developer.apple.com 生成新的 Developer ID Application 证书。
+2. 导出 .p12（带私钥，见 PROCUREMENT.zh-CN.md §3.3）。
+3. base64 编码后更新 `MAC_CSC_LINK` 和 `MAC_CSC_KEY_PASSWORD`。
+4. 旧证书对已签名的旧版本仍然有效；除非泄漏，否则不撤销。
+
+### Apple ID 持有者变更
+1. 在 App Store Connect 邀请新持有者加入 team。
+2. 转移所有权。
+3. 更新 GitHub secret `APPLE_ID`。
+4. 在新账号下生成新的 App-Specific Password。
+5. 更新 `APPLE_APP_SPECIFIC_PASSWORD`。
+
+## 续期
+Apple Developer Program：USD 99/年，自动续费。**每 6 个月确认一次
+Apple ID 上的账单卡有效**。续费失败的话约 30 天内所有签名都会失效。
+```
+
+## 修改：`qcut/docs/release.md`
+
+在文件靠前位置加一节（或与 Windows 签名章节合并）：
+
+```markdown
+## macOS 发布前置条件
+macOS 发布产物**必须**用 Quriosity 的 Developer ID Application 证书
+签名**并且**经过 Apple 公证。任一步失败发布工作流都会失败 — **不要**
+绕过。设置和凭据轮换见 `docs/setup/macos-code-signing.md`。
+```
+
+## 修改：`qcut/CLAUDE.md`
+
+在 "Architecture Guidelines → DON'T" 一节下追加一条：
+
+```markdown
+- 不要在发布工作流里禁用 macOS 代码签名或公证。详见
+  `docs/setup/macos-code-signing.md`。本地未签名开发构建用
+  `bun run dist:mac`（不设 Apple 环境变量）。
+```
+
+这样将来 Claude Code 会话能看到这条规则，避免悄悄退化。
+
+## 可选低优先级：PR 模板
+
+如果 `qcut/.github/PULL_REQUEST_TEMPLATE.md` 已经存在，加一个 checkbox：
+
+```markdown
+- [ ] 如果改动了 `release.yml` 的 build-macos 任务或 `package.json` 的
+      `build.mac`，我没有禁用代码签名或公证。
+```
+
+如果 PR 模板还不存在，**不要**专门为这个新建一个。
+
+## 不需要写的内容
+
+- 任何 secret / variable 的真实值。
+- "Gatekeeper 是怎么工作的" — Apple 文档已有。
+- Mac App Store 提交 — 不同证书、不同审核，单独立任务。
+- iOS 分发 — 不在范围内。

--- a/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/DOCUMENTATION.zh-CN.md
@@ -32,6 +32,14 @@
 | APPLE_APP_SPECIFIC_PASSWORD | secret | appleid.apple.com → App-Specific Passwords |
 | APPLE_TEAM_ID | variable | developer.apple.com → Membership Details 里的 10 位 Team ID |
 
+> ⚠️ **工作流接线属于实现 PR，不属于这份规划文档。** 当前
+> `.github/workflows/release.yml` 的 `build-macos` 任务（约 169–178 行）的
+> "Build Electron application" 步骤只把 `GH_TOKEN` 和 `USE_HARD_LINKS` 塞进
+> `env:`。签名/公证那个 PR 必须扩充该 `env:` 块，再把 `MAC_CSC_LINK`、
+> `MAC_CSC_KEY_PASSWORD`、`APPLE_ID`、`APPLE_APP_SPECIFIC_PASSWORD` 和
+> `APPLE_TEAM_ID` 也透传过去 — 没有这一步，即使仓库里已经有这些 secret，
+> electron-builder 仍会回退到产出未签名、未公证的 `.app`。
+
 ## 本地签名构建
 本地钥匙串里有证书 + 环境变量都设好后：
 

--- a/qcut/docs/task/macos-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/macos-code-signing/IMPLEMENTATION.md
@@ -1,0 +1,294 @@
+# macOS Code Signing — Implementation
+
+Engineering subtasks. Each is independently mergeable.
+
+> **Prerequisite:** [`PROCUREMENT.md`](PROCUREMENT.md) subtasks 1–4
+> completed and the five GitHub repo secrets/variables (`MAC_CSC_LINK`,
+> `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`,
+> `APPLE_TEAM_ID`) are set.
+
+---
+
+## 1. Update `electron-builder` mac config
+
+**File:** `qcut/package.json` (the `build.mac` block, lines 265–286).
+
+### Before
+
+```json
+"mac": {
+  "category": "public.app-category.video",
+  "icon": "build/icon.icns",
+  "target": [
+    {"target": "dmg", "arch": ["arm64"]},
+    {"target": "zip", "arch": ["arm64"]}
+  ],
+  "hardenedRuntime": true,
+  "gatekeeperAssess": false,
+  "entitlements": "build/entitlements.mac.plist",
+  "entitlementsInherit": "build/entitlements.mac.plist"
+}
+```
+
+### After
+
+```json
+"mac": {
+  "category": "public.app-category.video",
+  "icon": "build/icon.icns",
+  "target": [
+    {"target": "dmg", "arch": ["arm64"]},
+    {"target": "zip", "arch": ["arm64"]}
+  ],
+  "hardenedRuntime": true,
+  "gatekeeperAssess": false,
+  "entitlements": "build/entitlements.mac.plist",
+  "entitlementsInherit": "build/entitlements.mac.plist",
+  "identity": "Developer ID Application: Quriosity Pty Ltd (${env.APPLE_TEAM_ID})",
+  "notarize": {
+    "teamId": "${env.APPLE_TEAM_ID}"
+  }
+}
+```
+
+### Why every flag matters
+
+- **`identity`** — pins the signing identity by name. Without this, `electron-builder` picks the first matching cert in keychain, which can break if multiple Apple Developer certs are present. It also makes failures explicit ("identity not found") instead of silently skipping signing.
+- **`notarize: { teamId }`** — `electron-builder ≥24.13` has built-in notarization. The build will:
+  1. Sign the `.app` and inner binaries.
+  2. Submit to Apple's notary service.
+  3. Wait for verdict (typically 5–10 minutes).
+  4. Staple the notarization ticket to the `.dmg` and `.app`.
+
+  No `afterSign` hook needed.
+- **`hardenedRuntime: true`** — already present and required for notarization. Notarization rejects bundles without hardened runtime.
+- **`entitlements`** — already present. The current entitlements
+  (`com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`,
+  `disable-library-validation`, `audio-input`, `camera`,
+  `files.user-selected.read-write`) are *necessary* for FFmpeg WASM and
+  dynamic loading. Notarization accepts these because they are explicit
+  entitlements, not blanket exceptions.
+
+### Verify locally before merging
+
+If you have the cert in your local keychain and the env vars set:
+
+```bash
+cd qcut
+APPLE_ID="..." APPLE_APP_SPECIFIC_PASSWORD="..." APPLE_TEAM_ID="..." \
+  bun run dist:mac
+```
+
+Watch the log for:
+
+- `signing app file ... mac-arm64/QCut.app`
+- `notarization started`, `notarization succeeded`
+- `stapling app file ...`
+
+---
+
+## 2. Update GitHub Actions release workflow
+
+**File:** `qcut/.github/workflows/release.yml` (`build-macos` job, around lines 110–200).
+
+### 2.1 — Add Apple secrets to the "Build Electron application" env block
+
+The current step (around line 170) looks roughly like:
+
+```yaml
+- name: Build Electron application
+  run: |
+    rm -rf dist-electron
+    echo "::group::Electron Builder"
+    time npx electron-builder --mac --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+    echo "::endgroup::"
+    ls -lah dist-electron/
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    USE_HARD_LINKS: false
+```
+
+Change the `env:` block to:
+
+```yaml
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    USE_HARD_LINKS: false
+    CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+    CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+    APPLE_ID: ${{ secrets.APPLE_ID }}
+    APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+    APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+```
+
+`electron-builder` automatically:
+
+1. Decodes `CSC_LINK` from base64 and imports the `.p12` into a temporary keychain.
+2. Uses `CSC_KEY_PASSWORD` to unlock the `.p12`.
+3. Uses `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID` for notarization.
+
+### 2.2 — Add a verification step after build, before upload
+
+```yaml
+- name: Verify macOS signature and notarization
+  run: cd qcut && bun run verify:macos-signature
+  env:
+    APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+```
+
+(Script added in §3.)
+
+### 2.3 — Self-hosted Mac runner consideration
+
+`release.yml` already has a `USE_SELF_HOSTED_MAC` toggle. Both runner
+types work with the env block above:
+
+- **GitHub-hosted runner**: `electron-builder` imports the `.p12` from `CSC_LINK` into a temporary keychain.
+- **Self-hosted runner**: if the cert is already in the runner's user keychain, `electron-builder` uses it directly. The `CSC_LINK` env var is still respected — it imports into a temporary keychain for the build duration, then cleans up. No conflict.
+
+For consistency, **keep `CSC_LINK` and `CSC_KEY_PASSWORD` in the env
+block** — they are no-ops when the keychain already has the cert and
+avoid divergent behaviour between runner types.
+
+---
+
+## 3. Add signature/notarization verifier
+
+**New file:** `qcut/scripts/verify-macos-signature.ts`.
+
+### Behaviour spec
+
+1. Find the latest `QCut*.dmg` in `qcut/dist-electron/`.
+2. Find the corresponding `QCut.app` (`electron-builder` unpacks during build to `qcut/dist-electron/mac-arm64/QCut.app`).
+3. Run, in order:
+   - `codesign --verify --deep --strict --verbose=2 <QCut.app>` → exit 0.
+   - `spctl -a -t exec -vv <QCut.app>` → must report `accepted` AND `source=Notarized Developer ID`.
+   - `xcrun stapler validate <QCut.dmg>` → must report `The validate action worked!`.
+4. If `APPLE_TEAM_ID` is set, run `codesign -dvv <QCut.app>` and confirm the Team ID is in the output.
+5. Exit non-zero on any failure with a clear message.
+6. On non-macOS hosts, warn and skip.
+
+### Sketch
+
+```ts
+// qcut/scripts/verify-macos-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedTeamId = process.env.APPLE_TEAM_ID;
+
+function findLatestDmg(): string {
+  if (!existsSync(distDir)) {
+    throw new Error(`dist-electron not found at ${distDir}`);
+  }
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*\.dmg$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`No QCut*.dmg found in ${distDir}`);
+  }
+  return join(distDir, candidates[0].f);
+}
+
+function findApp(): string {
+  const candidate = join(distDir, "mac-arm64", "QCut.app");
+  if (!existsSync(candidate)) {
+    throw new Error(`QCut.app not found at ${candidate}`);
+  }
+  return candidate;
+}
+
+function run(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: "utf8" });
+}
+
+if (process.platform !== "darwin") {
+  console.warn("[verify-macos-signature] non-macOS host, skipping");
+  process.exit(0);
+}
+
+const app = findApp();
+const dmg = findLatestDmg();
+
+console.log(`[verify-macos-signature] codesign --verify ${app}`);
+const codesignOut = run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", app]);
+console.log(codesignOut);
+
+console.log(`[verify-macos-signature] spctl --assess ${app}`);
+const spctlOut = run("spctl", ["-a", "-t", "exec", "-vv", app]);
+console.log(spctlOut);
+if (!spctlOut.includes("accepted")) {
+  throw new Error("spctl did not accept the app");
+}
+if (!spctlOut.includes("Notarized Developer ID")) {
+  throw new Error("spctl reports app is signed but not notarized");
+}
+
+console.log(`[verify-macos-signature] xcrun stapler validate ${dmg}`);
+const staplerOut = run("xcrun", ["stapler", "validate", dmg]);
+console.log(staplerOut);
+if (!staplerOut.includes("worked")) {
+  throw new Error("stapler validation failed");
+}
+
+if (expectedTeamId) {
+  const codesignDisplayOut = run("codesign", ["-dvv", app]);
+  if (!codesignDisplayOut.includes(`(${expectedTeamId})`)) {
+    throw new Error(`Signed by unexpected team; expected ${expectedTeamId}`);
+  }
+}
+
+console.log("[verify-macos-signature] OK");
+```
+
+Add to `qcut/package.json` `scripts`:
+
+```json
+"verify:macos-signature": "bun scripts/verify-macos-signature.ts"
+```
+
+### Why a separate verify step
+
+`electron-builder` already fails the build if signing or notarization
+fails. The separate verify step:
+
+1. Catches any post-build mutation (e.g. a step that re-zips the `.app` and breaks signature attachment).
+2. Produces explicit log output that humans can scan when debugging.
+3. Costs ~5 seconds (network calls to Apple are NOT made — these tools verify locally against the stapled ticket).
+
+---
+
+## 4. Dry-run release on clean macOS VM
+
+After all PRs land, do a manual end-to-end test:
+
+1. Push a `v2026.5.0-rc.1` tag.
+2. Wait for `build-macos` to succeed.
+3. Download the `.dmg` from the artifact.
+4. On a clean macOS Sequoia or Sonoma VM (or a fresh user account):
+   - Double-click the `.dmg`.
+   - Drag `QCut.app` to `/Applications`.
+   - Open QCut from Applications.
+   - **Expected:** macOS shows "QCut.app was downloaded from the Internet. Are you sure you want to open it?" with an "Open" button. **Not** "cannot be opened because the developer cannot be verified".
+   - Click Open — app launches.
+5. From terminal:
+   ```bash
+   codesign --verify --deep --strict --verbose=2 /Applications/QCut.app
+   spctl -a -t exec -vv /Applications/QCut.app
+   xcrun stapler validate /Applications/QCut.app
+   ```
+   All three should succeed.
+
+If anything fails, **do not promote** the rc tag. Roll back the workflow change and investigate.
+
+---
+
+## 5. Future hardening (track separately)
+
+- **App Store Connect API key** to replace `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD`. Survives Apple ID owner changes. See [`PROCUREMENT.md` § Future hardening](PROCUREMENT.md#future-hardening-app-store-connect-api-key).
+- **Universal binary (x64 + arm64)** if/when Intel Mac support is required again. Currently the `target` is arm64-only.
+- **electron-updater signature verification** — already used by default on macOS; document in setup guide.
+- **Migrate to a self-hosted Mac runner** if GitHub-hosted runner cost or queue time becomes a problem.

--- a/qcut/docs/task/macos-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/IMPLEMENTATION.zh-CN.md
@@ -1,0 +1,315 @@
+# macOS 代码签名 — 实现细节
+
+工程子任务。每个都能独立合并。
+
+> **前置条件：** [`PROCUREMENT.zh-CN.md`](PROCUREMENT.zh-CN.md) 子任务
+> 1–4 全部完成，5 个 GitHub 仓库 secret/variable
+> （`MAC_CSC_LINK`、`MAC_CSC_KEY_PASSWORD`、`APPLE_ID`、
+> `APPLE_APP_SPECIFIC_PASSWORD`、`APPLE_TEAM_ID`）已配好。
+
+---
+
+## 1. 修改 `electron-builder` mac 配置
+
+**文件：** `qcut/package.json`（`build.mac` 块，第 265–286 行）。
+
+### 修改前
+
+```json
+"mac": {
+  "category": "public.app-category.video",
+  "icon": "build/icon.icns",
+  "target": [
+    {"target": "dmg", "arch": ["arm64"]},
+    {"target": "zip", "arch": ["arm64"]}
+  ],
+  "hardenedRuntime": true,
+  "gatekeeperAssess": false,
+  "entitlements": "build/entitlements.mac.plist",
+  "entitlementsInherit": "build/entitlements.mac.plist"
+}
+```
+
+### 修改后
+
+```json
+"mac": {
+  "category": "public.app-category.video",
+  "icon": "build/icon.icns",
+  "target": [
+    {"target": "dmg", "arch": ["arm64"]},
+    {"target": "zip", "arch": ["arm64"]}
+  ],
+  "hardenedRuntime": true,
+  "gatekeeperAssess": false,
+  "entitlements": "build/entitlements.mac.plist",
+  "entitlementsInherit": "build/entitlements.mac.plist",
+  "identity": "Developer ID Application: Quriosity Pty Ltd (${env.APPLE_TEAM_ID})",
+  "notarize": {
+    "teamId": "${env.APPLE_TEAM_ID}"
+  }
+}
+```
+
+### 每个 flag 的意义
+
+- **`identity`** — 显式指定签名身份的名字。不写的话，
+  `electron-builder` 会自动选钥匙串里第一个匹配的证书；如果钥匙串里
+  有多张 Apple Developer 证书就会出错。显式指定也让失败更明显
+  （会报 "identity not found"），不会悄无声息地跳过签名。
+- **`notarize: { teamId }`** — `electron-builder ≥24.13` 自带公证支持。
+  构建会：
+  1. 签名 `.app` 和内层二进制。
+  2. 提交给 Apple 公证服务。
+  3. 等结果（一般 5–10 分钟）。
+  4. 把公证票据 staple 到 `.dmg` 和 `.app`。
+
+  不需要 `afterSign` 钩子。
+- **`hardenedRuntime: true`** — 已存在，公证必需。没开 hardened runtime
+  的 bundle 公证会拒。
+- **`entitlements`** — 已存在。当前授权
+  （`com.apple.security.cs.allow-jit`、`allow-unsigned-executable-memory`、
+  `disable-library-validation`、`audio-input`、`camera`、
+  `files.user-selected.read-write`）是 FFmpeg WASM 和动态加载**必需的**。
+  这些是显式声明的授权（不是空白豁免），公证会接受。
+
+### 合并前本地验证
+
+如果本地钥匙串有证书且环境变量都设了：
+
+```bash
+cd qcut
+APPLE_ID="..." APPLE_APP_SPECIFIC_PASSWORD="..." APPLE_TEAM_ID="..." \
+  bun run dist:mac
+```
+
+观察日志里：
+
+- `signing app file ... mac-arm64/QCut.app`
+- `notarization started`、`notarization succeeded`
+- `stapling app file ...`
+
+---
+
+## 2. 修改 GitHub Actions 发布工作流
+
+**文件：** `qcut/.github/workflows/release.yml`（`build-macos` 任务，
+约第 110–200 行）。
+
+### 2.1 — 在 "Build Electron application" 的 env 块里加 Apple secret
+
+当前步骤（约第 170 行）大致是：
+
+```yaml
+- name: Build Electron application
+  run: |
+    rm -rf dist-electron
+    echo "::group::Electron Builder"
+    time npx electron-builder --mac --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+    echo "::endgroup::"
+    ls -lah dist-electron/
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    USE_HARD_LINKS: false
+```
+
+把 `env:` 块改成：
+
+```yaml
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    USE_HARD_LINKS: false
+    CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+    CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+    APPLE_ID: ${{ secrets.APPLE_ID }}
+    APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+    APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+```
+
+`electron-builder` 会自动：
+
+1. 把 base64 的 `CSC_LINK` 解码，导入到一个临时钥匙串。
+2. 用 `CSC_KEY_PASSWORD` 解锁 `.p12`。
+3. 用 `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID` 做
+   公证。
+
+### 2.2 — 在 build 之后、upload 之前加校验步骤
+
+```yaml
+- name: Verify macOS signature and notarization
+  run: cd qcut && bun run verify:macos-signature
+  env:
+    APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+```
+
+（脚本在 §3 里。）
+
+### 2.3 — 自托管 Mac runner 的考虑
+
+`release.yml` 已经有 `USE_SELF_HOSTED_MAC` 开关。两种 runner 在上面的
+env 块下都能跑：
+
+- **GitHub-hosted runner**：`electron-builder` 把 `CSC_LINK` 里的 `.p12`
+  导入到一个临时钥匙串。
+- **自托管 runner**：如果证书已经在 runner 用户钥匙串里，
+  `electron-builder` 会直接用。`CSC_LINK` 仍然有效 — 它会再导入一次到
+  临时钥匙串，构建结束后清理，不冲突。
+
+为了保持一致，**`CSC_LINK` 和 `CSC_KEY_PASSWORD` 都保留在 env 块里** —
+钥匙串已经有证书时它们是 no-op，但能避免两种 runner 行为发散。
+
+---
+
+## 3. 增加签名/公证校验脚本
+
+**新增文件：** `qcut/scripts/verify-macos-signature.ts`。
+
+### 行为规范
+
+1. 在 `qcut/dist-electron/` 找最新的 `QCut*.dmg`。
+2. 找对应的 `QCut.app`（`electron-builder` 构建期间会解包到
+   `qcut/dist-electron/mac-arm64/QCut.app`）。
+3. 按顺序跑：
+   - `codesign --verify --deep --strict --verbose=2 <QCut.app>` → 退出 0。
+   - `spctl -a -t exec -vv <QCut.app>` → 必须报告 `accepted` **并且**
+     `source=Notarized Developer ID`。
+   - `xcrun stapler validate <QCut.dmg>` → 必须报告
+     `The validate action worked!`。
+4. 如果设置了 `APPLE_TEAM_ID`，跑 `codesign -dvv <QCut.app>` 并确认
+   Team ID 在输出里。
+5. 任一失败就退出非零，并输出明确信息。
+6. 非 macOS 主机上打 warn 后跳过。
+
+### 代码草稿
+
+```ts
+// qcut/scripts/verify-macos-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedTeamId = process.env.APPLE_TEAM_ID;
+
+function findLatestDmg(): string {
+  if (!existsSync(distDir)) {
+    throw new Error(`找不到 dist-electron：${distDir}`);
+  }
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*\.dmg$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`${distDir} 里找不到 QCut*.dmg`);
+  }
+  return join(distDir, candidates[0].f);
+}
+
+function findApp(): string {
+  const candidate = join(distDir, "mac-arm64", "QCut.app");
+  if (!existsSync(candidate)) {
+    throw new Error(`找不到 ${candidate}`);
+  }
+  return candidate;
+}
+
+function run(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: "utf8" });
+}
+
+if (process.platform !== "darwin") {
+  console.warn("[verify-macos-signature] 非 macOS 主机，跳过");
+  process.exit(0);
+}
+
+const app = findApp();
+const dmg = findLatestDmg();
+
+console.log(`[verify-macos-signature] codesign --verify ${app}`);
+const codesignOut = run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", app]);
+console.log(codesignOut);
+
+console.log(`[verify-macos-signature] spctl --assess ${app}`);
+const spctlOut = run("spctl", ["-a", "-t", "exec", "-vv", app]);
+console.log(spctlOut);
+if (!spctlOut.includes("accepted")) {
+  throw new Error("spctl 没有接受这个 app");
+}
+if (!spctlOut.includes("Notarized Developer ID")) {
+  throw new Error("spctl 报告 app 已签名但未公证");
+}
+
+console.log(`[verify-macos-signature] xcrun stapler validate ${dmg}`);
+const staplerOut = run("xcrun", ["stapler", "validate", dmg]);
+console.log(staplerOut);
+if (!staplerOut.includes("worked")) {
+  throw new Error("stapler 校验失败");
+}
+
+if (expectedTeamId) {
+  const codesignDisplayOut = run("codesign", ["-dvv", app]);
+  if (!codesignDisplayOut.includes(`(${expectedTeamId})`)) {
+    throw new Error(`签名 team 不匹配；期望 ${expectedTeamId}`);
+  }
+}
+
+console.log("[verify-macos-signature] OK");
+```
+
+加到 `qcut/package.json` 的 `scripts`：
+
+```json
+"verify:macos-signature": "bun scripts/verify-macos-signature.ts"
+```
+
+### 为什么单独做一次校验
+
+`electron-builder` 已经会在签名或公证失败时让构建失败。但单独的校验
+步骤还有几个好处：
+
+1. 抓到构建后任何被改过的情况（例如某步重新打包 `.app` 破坏了签名
+   附着）。
+2. 在日志里输出明确的成功/失败信息，将来人工排查时能快速定位。
+3. 大约 5 秒（**不**会发请求到 Apple — 这些工具是基于 staple 的票据
+   本地校验）。
+
+---
+
+## 4. 在干净 macOS VM 上做发布演练
+
+所有 PR 落地后，做一次端到端人工测试：
+
+1. 推 `v2026.5.0-rc.1` tag。
+2. 等 `build-macos` 成功。
+3. 从 artifact 下载 `.dmg`。
+4. 在干净的 macOS Sequoia 或 Sonoma VM（或新用户账号）上：
+   - 双击 `.dmg`。
+   - 把 `QCut.app` 拖到 `/Applications`。
+   - 从 Applications 打开 QCut。
+   - **预期：** macOS 显示"QCut.app 是从互联网下载的，确定要打开
+     吗？"带"打开"按钮。**不应**显示"无法打开，因为无法验证开发者"。
+   - 点"打开" — 应用启动。
+5. 终端里跑：
+   ```bash
+   codesign --verify --deep --strict --verbose=2 /Applications/QCut.app
+   spctl -a -t exec -vv /Applications/QCut.app
+   xcrun stapler validate /Applications/QCut.app
+   ```
+   三个都要成功。
+
+任何一步失败就**不要**把 rc tag 提升为 release。回滚工作流改动，
+排查问题。
+
+---
+
+## 5. 后续加固（单独跟踪）
+
+- **App Store Connect API key** 替代 `APPLE_ID` +
+  `APPLE_APP_SPECIFIC_PASSWORD`。Apple ID 持有者变化也不影响。详见
+  [`PROCUREMENT.zh-CN.md` § 后续加固](PROCUREMENT.zh-CN.md#后续加固app-store-connect-api-key)。
+- **通用二进制（x64 + arm64）** — 如果以后要重新支持 Intel Mac。
+  目前 target 只配了 arm64。
+- **electron-updater 签名校验** — macOS 默认就有；在 setup 文档里
+  说明一下。
+- **迁移到自托管 Mac runner** — 如果 GitHub-hosted runner 的费用或
+  排队时间成为问题再考虑。

--- a/qcut/docs/task/macos-code-signing/PLAN.md
+++ b/qcut/docs/task/macos-code-signing/PLAN.md
@@ -34,8 +34,8 @@ Per-platform comparison:
 | Platform | Vendor | Annual cost | What you get |
 |----------|--------|-------------|--------------|
 | **Mac** | Apple | $99 | Unlimited Developer ID certs + notarization + iOS access |
-| **Windows** | Azure Trusted Signing | ~$120 | Public Trust signing identity, monthly billing |
-| **Total** | | **~$219/yr** | Both platforms covered |
+| **Windows** | Certum SimplySign (OV) | ~$200 | Cloud-HSM Authenticode cert with phone-approval signing — see [windows-code-signing/CERTIFICATE-OPTIONS.md](../windows-code-signing/CERTIFICATE-OPTIONS.md) |
+| **Total** | | **~$299/yr** | Both platforms covered |
 
 ## Subtask map
 

--- a/qcut/docs/task/macos-code-signing/PLAN.md
+++ b/qcut/docs/task/macos-code-signing/PLAN.md
@@ -1,0 +1,102 @@
+# macOS Code Signing & Notarization — Plan
+
+**Branch:** `gpt-image-2`
+**Created:** 2026-04-25
+
+## Goal
+
+Sign and notarize the QCut macOS distribution (`.dmg`, `.zip`, inner
+`.app`) so:
+
+1. Gatekeeper does not block first launch with "QCut.app cannot be
+   opened because the developer cannot be verified".
+2. Right-click → Open is not required.
+3. The verified developer name "Quriosity Pty Ltd" appears in the
+   security prompt.
+
+The verified team-decision is to **buy a commercial cert** (not use any
+free path) because QCut may close-source later. Apple Developer Program
+covers both worlds — works whether QCut stays open or closes.
+
+## What you are buying
+
+**Apple Developer Program — Organization tier, USD 99/year.**
+
+That single membership covers:
+
+- Mac + iOS development (we only use Mac).
+- **Unlimited certificates** — Apple does *not* charge per cert.
+- **Notarization** — Apple's malware-scanning service, included free.
+- Adding additional team members later, at no extra cost.
+
+Per-platform comparison:
+
+| Platform | Vendor | Annual cost | What you get |
+|----------|--------|-------------|--------------|
+| **Mac** | Apple | $99 | Unlimited Developer ID certs + notarization + iOS access |
+| **Windows** | Azure Trusted Signing | ~$120 | Public Trust signing identity, monthly billing |
+| **Total** | | **~$219/yr** | Both platforms covered |
+
+## Subtask map
+
+| # | Subtask | Code? | Wall time | Detail |
+|---|---------|-------|-----------|--------|
+| 1 | Look up / request D-U-N-S Number for Quriosity | No | 5 min lookup; 5–14 days if requesting | [PROCUREMENT.md §1](PROCUREMENT.md#1-d-u-n-s-number) |
+| 2 | Apple Developer Program enrollment (Organization) | No | 30 min submit + 1–2 days verification | [PROCUREMENT.md §2](PROCUREMENT.md#2-apple-developer-program-enrollment) |
+| 3 | Generate Developer ID Application cert, export .p12 | No | 15 min | [PROCUREMENT.md §3](PROCUREMENT.md#3-developer-id-application-certificate) |
+| 4 | App-Specific Password + capture Team ID | No | 5 min | [PROCUREMENT.md §4](PROCUREMENT.md#4-app-specific-password-and-team-id) |
+| 5 | Update `electron-builder` mac config | Yes | 30 min | [IMPLEMENTATION.md §1](IMPLEMENTATION.md#1-update-electron-builder-mac-config) |
+| 6 | Update GitHub Actions mac job | Yes | 30 min | [IMPLEMENTATION.md §2](IMPLEMENTATION.md#2-update-github-actions-release-workflow) |
+| 7 | Post-build signature + notarization verifier | Yes | 1 hr | [IMPLEMENTATION.md §3](IMPLEMENTATION.md#3-add-signaturenotarization-verifier) |
+| 8 | Documentation | Yes (docs) | 45 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
+| 9 | Tests | Yes | 1 hr | [TESTING.md](TESTING.md) |
+| 10 | Dry-run release on clean macOS VM | No | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-dry-run-release-on-clean-macos-vm) |
+
+**Total engineering: ~5 hours. Total wall time depends on Apple — D-U-N-S can be 1–14 days, then enrollment 1–2 days.**
+
+## Files this plan will touch
+
+### Modified
+- `qcut/package.json` — `build.mac` block (lines 265–286): add `identity` and `notarize` config.
+- `qcut/.github/workflows/release.yml` — `build-macos` job (around lines 110–200): add Apple secrets to env block, add verify step.
+- `qcut/docs/release.md` — signing prerequisites note (create if missing).
+
+### Added
+- `qcut/scripts/verify-macos-signature.ts` — `codesign` + `spctl` + `xcrun stapler` verification.
+- `qcut/scripts/__tests__/verify-macos-signature.test.ts` — Vitest unit tests.
+- `qcut/scripts/__tests__/package-json-mac-signing.test.ts` — `package.json` shape guardrail.
+- `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts` — workflow YAML guardrail.
+- `qcut/docs/setup/macos-code-signing.md` — maintainer-facing setup guide.
+- `qcut/docs/task/macos-code-signing/` — this folder.
+
+### Not touched
+- `qcut/build/entitlements.mac.plist` — already correct. The current entitlements (`com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, `audio-input`, `camera`, `files.user-selected.read-write`) are required for FFmpeg WASM and dynamic loading. Notarization accepts these because they are explicit entitlements, not blanket exceptions.
+- `qcut/build/icon.icns` — icon stays.
+- iOS code path — QCut is Electron desktop, no iOS submission.
+
+## Risks & open questions
+
+1. **D-U-N-S delay is the long pole.** If Quriosity does not have a D-U-N-S Number yet, this gates everything. 5–14 days. **Start subtask 1 today.**
+2. **Apple verification phone call.** Apple may call the phone number on the D-U-N-S record to verify the authorized signer. If that number is wrong, enrollment stalls until fixed.
+3. **Notarization can fail in non-obvious ways.** Any nested binary inside the `.app` that is unsigned or has missing entitlements rejects the whole bundle. QCut stages native binaries via `stage-ffmpeg-binaries` and `stage-aicp-binaries` (per `qcut/package.json:98-99`); these MUST sign cleanly. Plan for one or two debugging cycles.
+4. **GitHub-hosted vs self-hosted Mac runner.** `release.yml` has `USE_SELF_HOSTED_MAC` toggle. Both paths work with `CSC_LINK` env var, but signing on a self-hosted Mac with the cert pre-installed in keychain is faster.
+5. **App-Specific Password is tied to one Apple ID.** If the Apple ID owner leaves Quriosity, password becomes invalid. Mitigation:
+   - Register the Apple ID against an org-shared inbox like `apple-dev@qcut.app` (not anyone's personal email).
+   - Plan migration to App Store Connect API key as future hardening (see [`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-future-hardening-track-separately)).
+6. **Cert renewal.** Apple Developer Program auto-renews $99/yr. If renewal payment fails (expired card, etc.) ALL signing breaks within ~30 days. Set a billing alert on the Apple ID.
+
+## Success criteria
+
+- [ ] `codesign --verify --deep --strict --verbose=2 QCut.app` exits 0.
+- [ ] `spctl -a -t exec -vv QCut.app` reports `accepted` with `source=Notarized Developer ID`.
+- [ ] `xcrun stapler validate QCut.dmg` reports `The validate action worked!`.
+- [ ] On a clean macOS Sequoia/Sonoma VM, double-clicking the `.dmg`, dragging to Applications, and opening, does NOT show "cannot be opened" or require right-click → Open.
+- [ ] Verified developer name shown in the macOS security prompt is "Quriosity Pty Ltd".
+- [ ] Maintainer signing setup is documented at `qcut/docs/setup/macos-code-signing.md`.
+
+## Out of scope
+
+- Mac App Store submission (different cert types, sandboxing, App Review).
+- iOS / iPadOS distribution.
+- Migrating from app-specific password to App Store Connect API key (future hardening, separate task).
+- Universal binary (currently arm64-only — track separately if Intel Mac support is reintroduced).

--- a/qcut/docs/task/macos-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/PLAN.zh-CN.md
@@ -33,8 +33,8 @@ Apple Developer Program 在开源/闭源两种状态下都适用，**不需要**
 | 平台 | 厂商 | 年成本 | 包含 |
 |------|------|--------|------|
 | **Mac** | Apple | $99 | 无限 Developer ID 证书 + 公证 + iOS 资格 |
-| **Windows** | Azure Trusted Signing | ~$120 | Public Trust 签名身份，按月计费 |
-| **合计** | | **~$219/年** | 双平台齐全 |
+| **Windows** | Certum SimplySign（OV） | ~$200 | 云端 HSM Authenticode 证书 + 手机审批签名 — 详见 [windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md](../windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md) |
+| **合计** | | **~$299/年** | 双平台齐全 |
 
 ## 子任务拆分
 

--- a/qcut/docs/task/macos-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/PLAN.zh-CN.md
@@ -1,0 +1,121 @@
+# macOS 代码签名 + 公证 — 总体方案
+
+**分支：** `gpt-image-2`
+**创建日期：** 2026-04-25
+
+## 目标
+
+对 QCut 的 macOS 发布产物（`.dmg`、`.zip`、内层 `.app`）做签名和公证，
+使其：
+
+1. 用户首次打开时 Gatekeeper 不拦（不弹"无法打开 QCut.app，因为无法
+   验证开发者"）。
+2. 用户不需要"右键 → 打开"绕过。
+3. 安全弹窗里显示已验证的开发者名 "Quriosity Pty Ltd"。
+
+团队决议是**买商用证书**（不走任何免费路径），因为 QCut 之后可能闭源。
+Apple Developer Program 在开源/闭源两种状态下都适用，**不需要**重选
+方案。
+
+## 你要买的东西
+
+**Apple Developer Program — 组织席位（Organization tier），USD 99/年。**
+
+这一份会员包含：
+
+- Mac + iOS 开发资格（我们只用 Mac）。
+- **无限张证书** — Apple **不**按张计费。
+- **公证服务** — Apple 的恶意软件扫描，免费包含。
+- 后续无成本添加团队成员。
+
+跨平台对比：
+
+| 平台 | 厂商 | 年成本 | 包含 |
+|------|------|--------|------|
+| **Mac** | Apple | $99 | 无限 Developer ID 证书 + 公证 + iOS 资格 |
+| **Windows** | Azure Trusted Signing | ~$120 | Public Trust 签名身份，按月计费 |
+| **合计** | | **~$219/年** | 双平台齐全 |
+
+## 子任务拆分
+
+| # | 子任务 | 改代码？ | 耗时 | 详情 |
+|---|--------|---------|------|------|
+| 1 | 查找 / 申请 Quriosity 的 D-U-N-S Number | 否 | 查 5 分钟；申请要等 5–14 天 | [PROCUREMENT.zh-CN.md §1](PROCUREMENT.zh-CN.md#1-d-u-n-s-number) |
+| 2 | 注册 Apple Developer Program（组织席位） | 否 | 提交 30 分钟 + 审核 1–2 天 | [PROCUREMENT.zh-CN.md §2](PROCUREMENT.zh-CN.md#2-apple-developer-program-注册) |
+| 3 | 生成 Developer ID Application 证书，导出 .p12 | 否 | 15 分钟 | [PROCUREMENT.zh-CN.md §3](PROCUREMENT.zh-CN.md#3-developer-id-application-证书) |
+| 4 | App-Specific Password + 记下 Team ID | 否 | 5 分钟 | [PROCUREMENT.zh-CN.md §4](PROCUREMENT.zh-CN.md#4-app-specific-password-和-team-id) |
+| 5 | 改 `electron-builder` mac 配置 | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §1](IMPLEMENTATION.zh-CN.md#1-修改-electron-builder-mac-配置) |
+| 6 | 改 GitHub Actions mac 任务 | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §2](IMPLEMENTATION.zh-CN.md#2-修改-github-actions-发布工作流) |
+| 7 | 加构建后签名 + 公证校验 | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §3](IMPLEMENTATION.zh-CN.md#3-增加签名公证校验脚本) |
+| 8 | 文档 | 是（文档） | 45 分钟 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) |
+| 9 | 测试 | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
+| 10 | 在干净 macOS VM 上做发布演练 | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-在干净-macos-vm-上做发布演练) |
+
+**工程总耗时：约 5 小时。墙上时间取决于 Apple — D-U-N-S 1–14 天 + 注册审核 1–2 天。**
+
+## 本方案会动到的文件
+
+### 需要修改
+- `qcut/package.json` — `build.mac` 块（第 265–286 行）：加 `identity` 和 `notarize` 配置。
+- `qcut/.github/workflows/release.yml` — `build-macos` 任务（约第 110–200 行）：在 env 块加 Apple secret，加 verify 步骤。
+- `qcut/docs/release.md` — 加签名前置条件说明（不存在则新建）。
+
+### 需要新增
+- `qcut/scripts/verify-macos-signature.ts` — `codesign` + `spctl` + `xcrun stapler` 校验。
+- `qcut/scripts/__tests__/verify-macos-signature.test.ts` — Vitest 单元测试。
+- `qcut/scripts/__tests__/package-json-mac-signing.test.ts` — `package.json` 形态守门。
+- `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts` — 工作流 YAML 守门。
+- `qcut/docs/setup/macos-code-signing.md` — 维护者签名设置指南。
+- `qcut/docs/task/macos-code-signing/` — 本目录。
+
+### 故意不动
+- `qcut/build/entitlements.mac.plist` — 已经是对的。当前授权
+  （`com.apple.security.cs.allow-jit`、`allow-unsigned-executable-memory`、
+  `disable-library-validation`、`audio-input`、`camera`、
+  `files.user-selected.read-write`）是 FFmpeg WASM 和动态加载必需的。
+  这些是显式声明的授权，不是空白豁免，公证会接受。
+- `qcut/build/icon.icns` — 图标保持原样。
+- iOS 路径 — QCut 是 Electron 桌面，没有 iOS 提交。
+
+## 风险与待定问题
+
+1. **D-U-N-S 延迟是关键路径。** 如果 Quriosity 还没有 D-U-N-S Number，
+   后面所有事都卡这里，5–14 天。**子任务 1 今天就开始。**
+2. **Apple 核实电话。** Apple 可能会打 D-U-N-S 上登记的电话验证授权
+   签字人。号码不对的话会一直卡。
+3. **公证可能因不明显的原因失败。** `.app` 里任何嵌套二进制如果未
+   签名或缺权限，整个 bundle 都会被拒。QCut 通过
+   `stage-ffmpeg-binaries` 和 `stage-aicp-binaries`（见
+   `qcut/package.json:98-99`）打包了原生二进制；这些**必须**能干净
+   签名。预留 1–2 轮调试时间。
+4. **GitHub-hosted vs 自托管 Mac runner。** `release.yml` 里有
+   `USE_SELF_HOSTED_MAC` 开关。两条路都能用 `CSC_LINK` env 变量；
+   自托管 Mac 把证书提前装进钥匙串会更快。
+5. **App-Specific Password 绑定到一个 Apple ID。** 如果 Apple ID 的
+   持有者离开 Quriosity，密码就废了。缓解：
+   - 把 Apple ID 注册到组织共享邮箱（例如 `apple-dev@qcut.app`），
+     不要用任何人的个人邮箱。
+   - 计划迁移到 App Store Connect API key（后续加固，见
+     [`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-后续加固单独跟踪)）。
+6. **证书续期。** Apple Developer Program $99/年自动续费。如果续费
+   失败（卡过期等），约 30 天内**所有**签名会失效。给 Apple ID 设
+   账单告警。
+
+## 验收标准
+
+- [ ] `codesign --verify --deep --strict --verbose=2 QCut.app` 退出 0。
+- [ ] `spctl -a -t exec -vv QCut.app` 报告 `accepted` 且 `source=Notarized Developer ID`。
+- [ ] `xcrun stapler validate QCut.dmg` 报告 `The validate action worked!`。
+- [ ] 在干净 macOS Sequoia/Sonoma VM 上双击 `.dmg`、拖到 Applications、
+      打开，**不**弹"无法打开"也**不**需要右键 → 打开。
+- [ ] macOS 安全弹窗里显示的开发者名是 "Quriosity Pty Ltd"。
+- [ ] 维护者签名指南已发布在 `qcut/docs/setup/macos-code-signing.md`。
+
+## 本方案不覆盖的部分
+
+- Mac App Store 提交（不同证书、沙盒约束、应用审核）。
+- iOS / iPadOS 分发。
+- 从 app-specific password 迁移到 App Store Connect API key（后续
+  加固，单独立任务）。
+- 通用二进制（目前只支持 arm64 — 若以后要重新支持 Intel Mac，单独
+  跟踪）。

--- a/qcut/docs/task/macos-code-signing/PROCUREMENT.md
+++ b/qcut/docs/task/macos-code-signing/PROCUREMENT.md
@@ -1,0 +1,184 @@
+# macOS Signing — Procurement Steps
+
+This is the manual, out-of-code work the user does in Apple's web
+console. Subtasks 1–4 of [`PLAN.md`](PLAN.md).
+
+> **Order matters.** D-U-N-S blocks enrollment; enrollment blocks cert
+> generation; cert blocks CI integration. **Start subtask 1 today.**
+
+## 1. D-U-N-S Number
+
+Apple requires every Organization-tier applicant to have a Dun &
+Bradstreet **D-U-N-S Number** — a free 9-digit identifier that proves
+the legal entity exists.
+
+### Step 1.1 — Look up first (Quriosity may already have one)
+
+1. Visit https://developer.apple.com/enroll/duns-lookup/.
+2. Enter:
+   - Legal entity name: **Quriosity Pty Ltd** (use the exact name on your ASIC company registration)
+   - Country: **Australia**
+   - Address: registered business address
+3. Submit.
+
+**If found:** note the 9-digit number, skip to subtask 2.
+
+**If not found:** Apple's lookup page offers "Request a D-U-N-S Number" — proceed to step 1.2.
+
+### Step 1.2 — Request a D-U-N-S Number (only if not found)
+
+1. Click "Request a D-U-N-S Number" on the same page — this submits to Dun & Bradstreet for free issuance.
+2. Provide:
+   - Legal name (must match ASIC exactly)
+   - ABN
+   - Registered business address
+   - Registered phone (this matters — see Gotchas below)
+   - Primary contact email
+   - Brief business activity description
+3. Wait **5–14 business days** for D&B to verify and issue the number. D&B may email asking for clarification — respond promptly.
+
+### Why D-U-N-S delay is the long pole
+
+Many users hit "wait 2 weeks for D-U-N-S" and don't realise it until they try to enroll. **Submit this first**, even before reading the rest of this doc.
+
+### Gotchas
+
+- The phone number registered against the D-U-N-S is what Apple may call later. **Make sure it routes to a person who answers in business hours.**
+- The legal name on D-U-N-S **must exactly match** the company name on ASIC and on Apple Developer enrollment. "Quriosity Pty Ltd" ≠ "Quriosity Pty. Ltd." — Apple rejects mismatches.
+- D&B may reach out to verify. Reply within 24h to avoid restarting the queue.
+
+## 2. Apple Developer Program enrollment
+
+Once the D-U-N-S Number is in hand:
+
+### Step 2.1 — Decide the Apple ID
+
+Pick the Apple ID that will own the membership. Recommendations:
+
+- **Use a shared org email**, not a personal one. e.g. `apple-dev@qcut.app` or `support@qcut.app`. Keeps continuity if any individual leaves the team.
+- **Enable 2FA** with multiple trusted phones/devices. Apple absolutely refuses to remove 2FA from a developer account; losing all 2FA factors is a recovery nightmare.
+- **Bookmark the recovery codes** in 1Password.
+
+### Step 2.2 — Submit enrollment
+
+1. Sign into https://developer.apple.com/programs/enroll/ with the chosen Apple ID.
+2. Pick **Organization**.
+3. Fill in:
+   - Legal entity name (must exactly match D-U-N-S record)
+   - D-U-N-S Number
+   - Address, phone, country
+   - Authorized signer information — must be a person legally authorized to bind the company (director, or someone with delegated authority)
+4. Pay USD 99. Apple bills in your local currency — for AU, this is typically around AUD 149.99.
+5. Wait for Apple verification.
+   - Apple may call the phone number on the D-U-N-S record to confirm the authorized signer.
+   - This usually happens within 1–2 business days but can take up to a week.
+   - If Apple cannot reach the number, enrollment stalls until they do.
+
+### Step 2.3 — Confirmation
+
+You receive an email with subject like "Welcome to the Apple Developer Program". Sign into https://developer.apple.com/account and confirm "Apple Developer Program Membership" is listed.
+
+## 3. Developer ID Application certificate
+
+This is the cert that signs `.app` bundles distributed **outside the Mac App Store**. QCut needs **only this cert** — not "Developer ID Installer", "Mac App Distribution", or any of the other cert types listed in the Apple console.
+
+### Step 3.1 — Generate the Certificate Signing Request (CSR) on your Mac
+
+1. Open **Keychain Access** (Applications → Utilities → Keychain Access).
+2. Menu: **Keychain Access → Certificate Assistant → Request a Certificate from a Certificate Authority…**.
+3. Fields:
+   - User Email: the org Apple ID (e.g. `apple-dev@qcut.app`)
+   - Common Name: `Quriosity Apple Developer ID`
+   - CA Email: leave blank
+   - **Saved to disk:** select
+   - **Let me specify key pair information:** select (RSA, 2048-bit)
+4. Save the resulting `.certSigningRequest` file (e.g. to Desktop).
+
+### Step 3.2 — Upload CSR and download the certificate
+
+1. https://developer.apple.com/account → **Certificates, Identifiers & Profiles** → **Certificates** → **+**.
+2. Pick **Developer ID Application**.
+3. Upload the `.certSigningRequest` from step 3.1.
+4. Download the resulting `.cer`.
+5. **Double-click the `.cer`** — it imports into your Keychain. The certificate appears in the **login** keychain with the matching private key (because you generated the CSR locally).
+
+### Step 3.3 — Export as `.p12` (for CI)
+
+GitHub-hosted Mac runners do not have your keychain. They need the cert + private key as a base64-encoded `.p12`.
+
+1. Open Keychain Access.
+2. Find the new certificate. It is named like `Developer ID Application: Quriosity Pty Ltd (TEAMID)`. Open the disclosure triangle — you should see two rows: the certificate, and the matching private key as a child item.
+3. **Select both rows** (cmd-click).
+4. Right-click → **Export 2 items**.
+5. Format: **Personal Information Exchange (.p12)**.
+6. Save as `quriosity-developer-id.p12`.
+7. Set a strong export password — this becomes the `MAC_CSC_KEY_PASSWORD` GitHub secret.
+
+> ⚠️ Common mistake: exporting only the certificate row produces a `.p12` without the private key, which CI cannot use. Always select **both** the cert and the private key child row.
+
+### Step 3.4 — Convert to base64 for CI
+
+```bash
+base64 -i quriosity-developer-id.p12 | pbcopy
+```
+
+The clipboard now contains the base64-encoded form. Paste this as the `MAC_CSC_LINK` GitHub secret.
+
+### Step 3.5 — Backup
+
+Store the original `.p12` and the export password in 1Password (or whatever the team's password manager is) under a "QCut release credentials" item.
+
+If lost, the cert can be revoked and reissued — annoying but not catastrophic. A few hours to rebuild momentum.
+
+## 4. App-Specific Password and Team ID
+
+### Step 4.1 — App-Specific Password (for Notarization)
+
+Apple's notarization service authenticates with your Apple ID + a separate "app-specific password" (you cannot use your real Apple ID password because of 2FA).
+
+1. Sign into https://appleid.apple.com with the org Apple ID.
+2. **Sign-In and Security** → **App-Specific Passwords** → **+**.
+3. Label: `QCut release notarization`.
+4. Generate. **Copy it once** — it is never shown again.
+5. Store as GitHub secret `APPLE_APP_SPECIFIC_PASSWORD`.
+
+### Step 4.2 — Team ID
+
+A 10-character identifier for your Apple Developer team.
+
+1. https://developer.apple.com/account → **Membership Details**.
+2. Copy the 10-character "Team ID" (looks like `ABCDE12345`).
+3. Store as GitHub variable (not secret) `APPLE_TEAM_ID` — it is not sensitive.
+
+### Step 4.3 — Apple ID
+
+The Apple ID you used for enrollment.
+
+- Store as GitHub secret `APPLE_ID` (it is the email address — arguably could be a variable, but secret is safer to avoid feeding reconnaissance).
+
+## Summary: GitHub repo settings
+
+After all four subtasks, the following must be configured in
+**Settings → Secrets and variables → Actions**:
+
+| Name | Type | Value |
+|------|------|-------|
+| `MAC_CSC_LINK` | secret | base64 of `quriosity-developer-id.p12` |
+| `MAC_CSC_KEY_PASSWORD` | secret | the `.p12` export password from §3.3 |
+| `APPLE_ID` | secret | the org Apple ID email |
+| `APPLE_APP_SPECIFIC_PASSWORD` | secret | from §4.1 |
+| `APPLE_TEAM_ID` | variable | 10-char Team ID from §4.2 |
+
+After this section is done, the engineering work in [`IMPLEMENTATION.md`](IMPLEMENTATION.md) can begin.
+
+## Future hardening: App Store Connect API key
+
+Long-term, replace `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` with an **App Store Connect API key** (`.p8` file + key ID + issuer ID). This:
+
+- Decouples notarization from a specific Apple ID account.
+- Survives team-member changes.
+- Can be revoked independently.
+
+Apple's docs: https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api
+
+Track this as a follow-up issue, not part of v1.

--- a/qcut/docs/task/macos-code-signing/PROCUREMENT.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/PROCUREMENT.zh-CN.md
@@ -1,0 +1,210 @@
+# macOS 签名 — 采购步骤
+
+这是用户在 Apple 官网手工完成的、与代码无关的工作。对应
+[`PLAN.zh-CN.md`](PLAN.zh-CN.md) 子任务 1–4。
+
+> **顺序很重要。** D-U-N-S 卡注册，注册卡证书生成，证书卡 CI 集成。
+> **子任务 1 今天就开始。**
+
+## 1. D-U-N-S Number
+
+Apple 要求所有"组织席位"申请人都有 Dun & Bradstreet 的
+**D-U-N-S Number** — 一个免费的 9 位数全球公司唯一编号，证明法人
+实体真实存在。
+
+### 步骤 1.1 — 先查（Quriosity 可能已经有了）
+
+1. 打开 https://developer.apple.com/enroll/duns-lookup/。
+2. 填：
+   - 法人名称：**Quriosity Pty Ltd**（用 ASIC 公司注册时的精确名称）
+   - 国家：**Australia**
+   - 地址：注册营业地址
+3. 提交。
+
+**查到了：** 记下 9 位数字，跳到子任务 2。
+
+**没查到：** Apple 的查询页会显示 "Request a D-U-N-S Number" 按钮，
+继续步骤 1.2。
+
+### 步骤 1.2 — 申请 D-U-N-S Number（仅查不到时执行）
+
+1. 在同一页点 "Request a D-U-N-S Number" — 这会向 Dun & Bradstreet
+   提交免费申请。
+2. 提供：
+   - 法人名称（必须与 ASIC 完全一致）
+   - ABN
+   - 注册营业地址
+   - 注册电话（这点很关键，见下面"陷阱"）
+   - 主要联系邮箱
+   - 简短的业务描述
+3. 等 **5–14 个工作日**让 D&B 验证并签发编号。D&B 可能发邮件让你
+   澄清信息 — 收到要立刻回。
+
+### 为什么 D-U-N-S 是关键路径
+
+很多人到要注册 Apple 账号那一刻才发现"还要等 2 周 D-U-N-S"。
+**先把这步提交了**，再读后面的内容。
+
+### 陷阱
+
+- D-U-N-S 上登记的电话会是 Apple 之后可能拨打的号码。**确保这个
+  号码工作时间会有人接。**
+- D-U-N-S 上的法人名称**必须和** ASIC 上的、Apple Developer 注册时填的
+  **完全一致**。"Quriosity Pty Ltd" ≠ "Quriosity Pty. Ltd." — Apple
+  会拒绝不一致。
+- D&B 可能会主动联系你确认信息。24 小时内回复，避免重新排队。
+
+## 2. Apple Developer Program 注册
+
+D-U-N-S 拿到后：
+
+### 步骤 2.1 — 决定 Apple ID
+
+挑一个会员资格归属的 Apple ID。建议：
+
+- **用组织共享邮箱**，不要用个人邮箱。例如 `apple-dev@qcut.app` 或
+  `support@qcut.app`。任何人离开都不影响。
+- **开启 2FA**，绑定多个可信电话/设备。Apple 绝对不会帮你撤销开发者
+  账号的 2FA — 全部 2FA 因子丢失就是一场恢复噩梦。
+- **把恢复码存到 1Password**。
+
+### 步骤 2.2 — 提交注册
+
+1. 用上一步的 Apple ID 登录 https://developer.apple.com/programs/enroll/。
+2. 选 **Organization**。
+3. 填：
+   - 法人名称（必须和 D-U-N-S 记录一致）
+   - D-U-N-S Number
+   - 地址、电话、国家
+   - 授权签字人信息 — 必须是法律上能代表公司签字的人（董事，或被
+     委托授权的人）
+4. 付 USD 99。Apple 按当地货币计费 — 澳洲一般是 AUD 149.99 左右。
+5. 等 Apple 验证。
+   - Apple 可能会按 D-U-N-S 上的电话给你公司打电话，确认授权签字人。
+   - 一般 1–2 个工作日，最多可能 1 周。
+   - 电话打不通会一直卡住。
+
+### 步骤 2.3 — 确认
+
+收到 Apple 邮件，标题类似 "Welcome to the Apple Developer Program"。
+登录 https://developer.apple.com/account 确认 "Apple Developer
+Program Membership" 已显示。
+
+## 3. Developer ID Application 证书
+
+这是用来签 `.app`、**在 Mac App Store 之外分发**的证书。QCut **只**
+需要这一种 — 不需要 "Developer ID Installer"、"Mac App Distribution"
+等其他类型。
+
+### 步骤 3.1 — 在 Mac 上生成证书签名请求 (CSR)
+
+1. 打开**钥匙串访问**（Applications → Utilities → Keychain Access）。
+2. 菜单：**钥匙串访问 → 证书助理 → 从证书颁发机构请求证书…**。
+3. 填：
+   - 用户邮件地址：组织 Apple ID（例如 `apple-dev@qcut.app`）
+   - 常用名称：`Quriosity Apple Developer ID`
+   - CA 邮件：留空
+   - **存储到磁盘：** 选中
+   - **让我指定密钥对信息：** 选中（RSA，2048-bit）
+4. 保存生成的 `.certSigningRequest` 文件（例如桌面）。
+
+### 步骤 3.2 — 上传 CSR 下载证书
+
+1. https://developer.apple.com/account → **Certificates, Identifiers
+   & Profiles** → **Certificates** → **+**。
+2. 选 **Developer ID Application**。
+3. 上传 3.1 步生成的 `.certSigningRequest`。
+4. 下载得到的 `.cer`。
+5. **双击 `.cer`** — 它会导入钥匙串。证书会出现在**登录**钥匙串里，
+   并带上对应的私钥（因为 CSR 是本地生成的）。
+
+### 步骤 3.3 — 导出 `.p12`（给 CI 用）
+
+GitHub-hosted Mac runner 没有你的钥匙串，需要 base64 编码的 `.p12`
+里同时包含证书和私钥。
+
+1. 打开钥匙串访问。
+2. 找到新证书。它叫类似 `Developer ID Application: Quriosity Pty
+   Ltd (TEAMID)`。展开三角形 — 应该看到两行：证书本身 + 作为子项的
+   匹配私钥。
+3. **选中两行**（cmd-click）。
+4. 右键 → **导出 2 项**。
+5. 格式：**个人信息交换 (.p12)**。
+6. 文件名：`quriosity-developer-id.p12`。
+7. 设一个强导出密码 — 这会成为 GitHub secret `MAC_CSC_KEY_PASSWORD`。
+
+> ⚠️ 常见错误：**只**导出证书那一行，会得到一个**没有私钥**的 `.p12`，
+> CI 用不了。**两行都要选**（证书 + 私钥子行）。
+
+### 步骤 3.4 — 转 base64 给 CI
+
+```bash
+base64 -i quriosity-developer-id.p12 | pbcopy
+```
+
+剪贴板里就是 base64 编码。粘贴到 GitHub secret `MAC_CSC_LINK`。
+
+### 步骤 3.5 — 备份
+
+把原始 `.p12` 文件和导出密码存到 1Password（或团队的密码管理器），
+条目命名 "QCut release credentials"。
+
+丢了的话，可以撤销旧证书重新签发 — 麻烦但不是世界末日，几小时
+追回进度。
+
+## 4. App-Specific Password 和 Team ID
+
+### 步骤 4.1 — App-Specific Password（给公证用）
+
+Apple 的公证服务用 Apple ID + 一个独立的 "app-specific password" 做
+认证（因为 2FA，你不能直接用 Apple ID 主密码）。
+
+1. 用组织 Apple ID 登录 https://appleid.apple.com。
+2. **Sign-In and Security** → **App-Specific Passwords** → **+**。
+3. 名称：`QCut release notarization`。
+4. 生成。**只显示一次** — 立刻复制。
+5. 存到 GitHub secret `APPLE_APP_SPECIFIC_PASSWORD`。
+
+### 步骤 4.2 — Team ID
+
+10 位字符串，是你 Apple Developer team 的标识。
+
+1. https://developer.apple.com/account → **Membership Details**。
+2. 复制 10 位 "Team ID"（形如 `ABCDE12345`）。
+3. 存到 GitHub variable（不是 secret）`APPLE_TEAM_ID` — 不敏感。
+
+### 步骤 4.3 — Apple ID
+
+注册时用的 Apple ID。
+
+- 存到 GitHub secret `APPLE_ID`（是邮箱地址 — 严格说也可以用
+  variable，但 secret 更安全，避免被扫描收集）。
+
+## 总结：GitHub 仓库设置
+
+四个子任务都做完后，**Settings → Secrets and variables → Actions**
+里要有：
+
+| 名称 | 类型 | 内容 |
+|------|------|------|
+| `MAC_CSC_LINK` | secret | `quriosity-developer-id.p12` 的 base64 |
+| `MAC_CSC_KEY_PASSWORD` | secret | §3.3 设的 `.p12` 导出密码 |
+| `APPLE_ID` | secret | 组织 Apple ID 邮箱 |
+| `APPLE_APP_SPECIFIC_PASSWORD` | secret | §4.1 生成的密码 |
+| `APPLE_TEAM_ID` | variable | §4.2 抄的 10 位 Team ID |
+
+这一节做完后就可以开始 [`IMPLEMENTATION.zh-CN.md`](IMPLEMENTATION.zh-CN.md)
+里的工程改动。
+
+## 后续加固：App Store Connect API Key
+
+长远来看，把 `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` 换成 **App
+Store Connect API Key**（`.p8` 文件 + key ID + issuer ID）。优势：
+
+- 公证不再依赖某个具体 Apple ID 账号。
+- 团队成员变动也不影响。
+- 可以独立撤销。
+
+Apple 文档：https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api
+
+单独立 issue 跟踪，不在 v1 范围里。

--- a/qcut/docs/task/macos-code-signing/README.md
+++ b/qcut/docs/task/macos-code-signing/README.md
@@ -1,0 +1,37 @@
+# macOS Code Signing — Task Folder
+
+Plan for signing the macOS `.dmg` / `.zip` / inner `.app` with an Apple
+Developer ID and notarizing them through Apple's notary service.
+
+**Decision context:** QCut may go closed-source in the future, so the
+team is buying a commercial Apple Developer Program membership rather
+than relying on a free OSS path. This makes Mac signing identical
+whether QCut stays open or closes.
+
+Sister task: [`docs/task/windows-code-signing/`](../windows-code-signing/).
+
+## Files in this folder
+
+| File | What it covers |
+|------|----------------|
+| [PLAN.md](PLAN.md) | Overview, subtask map, success criteria, risks. **Start here.** |
+| [PROCUREMENT.md](PROCUREMENT.md) | Apple Developer Program enrollment — D-U-N-S, cert generation, App-Specific Password, Team ID. **The user does this manually.** |
+| [IMPLEMENTATION.md](IMPLEMENTATION.md) | Per-subtask engineering detail with file paths and diffs. |
+| [TESTING.md](TESTING.md) | Unit + workflow + manual VM verification, with target test file paths. |
+| [DOCUMENTATION.md](DOCUMENTATION.md) | Maintainer-facing docs to add/update alongside code. |
+
+Chinese mirrors live alongside as `*.zh-CN.md`.
+
+## Status
+
+- [x] Plan drafted
+- [ ] Subtask 1: Look up / request D-U-N-S Number for Quriosity
+- [ ] Subtask 2: Enroll in Apple Developer Program (Organization, $99/yr)
+- [ ] Subtask 3: Generate Developer ID Application certificate, export .p12
+- [ ] Subtask 4: Generate App-Specific Password, capture Team ID
+- [ ] Subtask 5: Update `electron-builder` mac config (`identity` + `notarize`)
+- [ ] Subtask 6: Update GitHub Actions release workflow (mac job env block)
+- [ ] Subtask 7: Add post-build signature + notarization verifier
+- [ ] Subtask 8: Maintainer documentation
+- [ ] Subtask 9: Tests
+- [ ] Subtask 10: Dry-run release on clean macOS VM

--- a/qcut/docs/task/macos-code-signing/README.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/README.zh-CN.md
@@ -1,0 +1,36 @@
+# macOS 代码签名 — 任务目录
+
+为 QCut 的 macOS 发布产物（`.dmg` / `.zip` / 内层 `.app`）做 Apple
+Developer ID 签名 + Apple 公证服务（notarization）。
+
+**决策背景：** QCut 之后可能闭源，所以买商用 Apple Developer Program
+会员，而不是走开源免费路线。这样无论 QCut 开源或闭源，Mac 签名方案
+都不变。
+
+姊妹任务：[`docs/task/windows-code-signing/`](../windows-code-signing/)。
+
+## 本目录文件说明
+
+| 文件 | 内容 |
+|------|------|
+| [PLAN.zh-CN.md](PLAN.zh-CN.md) | 总体方案、子任务拆分、验收标准、风险。**先看这个。** |
+| [PROCUREMENT.zh-CN.md](PROCUREMENT.zh-CN.md) | Apple Developer Program 注册流程 — D-U-N-S Number、证书生成、App-Specific Password、Team ID。**用户手工操作。** |
+| [IMPLEMENTATION.zh-CN.md](IMPLEMENTATION.zh-CN.md) | 每个子任务的实现细节，含文件路径和 diff。 |
+| [TESTING.zh-CN.md](TESTING.zh-CN.md) | 单元测试、工作流测试、人工 VM 验证。 |
+| [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) | 维护者文档，需随代码一起更新。 |
+
+英文原版位于同目录的 `README.md` / `PLAN.md` / 等等。
+
+## 进度
+
+- [x] 方案已草拟
+- [ ] 子任务 1：查找 / 申请 Quriosity 的 D-U-N-S Number
+- [ ] 子任务 2：注册 Apple Developer Program（组织席位，$99/年）
+- [ ] 子任务 3：生成 Developer ID Application 证书，导出 .p12
+- [ ] 子任务 4：生成 App-Specific Password，记下 Team ID
+- [ ] 子任务 5：改 `electron-builder` mac 配置（`identity` + `notarize`）
+- [ ] 子任务 6：改 GitHub Actions 发布工作流（mac job env 块）
+- [ ] 子任务 7：加构建后签名 + 公证校验脚本
+- [ ] 子任务 8：维护者文档
+- [ ] 子任务 9：测试
+- [ ] 子任务 10：在干净 macOS VM 上做发布演练

--- a/qcut/docs/task/macos-code-signing/TESTING.md
+++ b/qcut/docs/task/macos-code-signing/TESTING.md
@@ -1,0 +1,193 @@
+# macOS Code Signing — Testing
+
+Tests cover the parts of the implementation we own — the verifier
+script, `package.json` shape, and `release.yml` shape. We deliberately
+do **not** unit-test `codesign`, `spctl`, `xcrun stapler`, or Apple's
+notary service — those are integration concerns covered by the dry-run
+release step in [`IMPLEMENTATION.md §4`](IMPLEMENTATION.md#4-dry-run-release-on-clean-macos-vm).
+
+## Test inventory
+
+| # | Type | File path | What it covers |
+|---|------|-----------|----------------|
+| 1 | Unit | `qcut/scripts/__tests__/verify-macos-signature.test.ts` | Verifier behaviour: succeeds on valid output, fails on missing notarization, fails on team ID mismatch, no-ops on non-macOS. |
+| 2 | Unit | `qcut/scripts/__tests__/package-json-mac-signing.test.ts` | `build.mac.identity` set, `build.mac.notarize.teamId` set, `hardenedRuntime: true` preserved. |
+| 3 | Workflow guardrail | `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts` | `build-macos` "Build Electron application" step exposes the five Apple env vars and a verify step exists after build. |
+| 4 | Manual / E2E | [`IMPLEMENTATION.md §4`](IMPLEMENTATION.md#4-dry-run-release-on-clean-macos-vm) | Clean macOS VM, signed/notarized app launches without Gatekeeper warnings. |
+
+## Test 1 — Verifier unit tests
+
+**Path:** `qcut/scripts/__tests__/verify-macos-signature.test.ts`
+
+**Framework:** Vitest. Same pattern as the existing
+`qcut/scripts/__tests__/check-boundaries.test.ts`. Mock
+`child_process.execFileSync`.
+
+### Cases
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("verify-macos-signature", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("no-ops on non-macOS hosts", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    await import("../verify-macos-signature");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("throws when dist-electron is empty", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock fs.readdirSync to return []
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /No QCut.*\.dmg found/,
+    );
+  });
+
+  it("throws when codesign exits non-zero", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock execFileSync to throw on codesign
+    await expect(import("../verify-macos-signature")).rejects.toThrow();
+  });
+
+  it("throws when app is signed but not notarized", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "ABCDE12345");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock spctl output to include "accepted" but NOT "Notarized Developer ID"
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /not notarized/,
+    );
+  });
+
+  it("throws when stapler reports failure", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock stapler output to NOT include "worked"
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /stapler validation failed/,
+    );
+  });
+
+  it("throws on team ID mismatch", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "WRONGT3AM1");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock codesign -dvv to NOT include (WRONGT3AM1)
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /unexpected team/,
+    );
+  });
+
+  it("succeeds when everything is valid", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "ABCDE12345");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock all four tool outputs to be valid
+    await expect(import("../verify-macos-signature")).resolves.not.toThrow();
+  });
+});
+```
+
+> **Refactor note:** the production script runs at module top-level
+> (matching `verify-packaged-*.ts` style). To make tests cleaner,
+> consider wrapping the body in a `main()` and calling it at the bottom
+> — same pattern as the Windows verifier. Either approach works; just
+> be consistent across the two verifiers.
+
+### How to run
+
+```bash
+cd qcut && bun run test scripts/__tests__/verify-macos-signature.test.ts
+```
+
+## Test 2 — `package.json` shape
+
+**Path:** `qcut/scripts/__tests__/package-json-mac-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import pkg from "../../package.json";
+
+describe("package.json macOS signing config", () => {
+  it("sets identity for Developer ID Application", () => {
+    expect(pkg.build.mac.identity).toMatch(/^Developer ID Application: /);
+  });
+
+  it("sets notarize.teamId from env", () => {
+    expect(pkg.build.mac.notarize?.teamId).toBeTruthy();
+  });
+
+  it("keeps hardenedRuntime true", () => {
+    expect(pkg.build.mac.hardenedRuntime).toBe(true);
+  });
+
+  it("keeps entitlements pointing to the existing plist", () => {
+    expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
+    expect(pkg.build.mac.entitlementsInherit).toBe("build/entitlements.mac.plist");
+  });
+});
+```
+
+## Test 3 — Workflow YAML guardrail
+
+**Path:** `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const workflowPath = join(
+  import.meta.dir, "..", "..", "..", ".github", "workflows", "release.yml",
+);
+const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
+
+describe("release.yml build-macos signing", () => {
+  const macJob = wf.jobs["build-macos"];
+  const buildStep = macJob.steps.find(
+    (s: any) => s.name === "Build Electron application",
+  );
+
+  for (const k of [
+    "CSC_LINK",
+    "CSC_KEY_PASSWORD",
+    "APPLE_ID",
+    "APPLE_APP_SPECIFIC_PASSWORD",
+    "APPLE_TEAM_ID",
+  ]) {
+    it(`Build step exposes ${k}`, () => {
+      expect(buildStep.env[k]).toBeDefined();
+    });
+  }
+
+  it("has a 'Verify macOS signature and notarization' step after build", () => {
+    const names = macJob.steps.map((s: any) => s.name);
+    const buildIdx = names.indexOf("Build Electron application");
+    const verifyIdx = names.indexOf("Verify macOS signature and notarization");
+    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  });
+});
+```
+
+> Add `js-yaml` and `@types/js-yaml` as dev dependencies if not already present (the Windows TESTING plan calls for the same).
+
+## Test 4 — Manual VM E2E
+
+See [`IMPLEMENTATION.md §4`](IMPLEMENTATION.md#4-dry-run-release-on-clean-macos-vm). Capture the result in PR description as a checklist:
+
+- [ ] `.dmg` opens without "developer cannot be verified".
+- [ ] App launches from `/Applications` without right-click → Open.
+- [ ] `codesign --verify --deep --strict --verbose=2` exits 0.
+- [ ] `spctl -a -t exec -vv` reports `accepted` with `source=Notarized Developer ID`.
+- [ ] `xcrun stapler validate` reports `The validate action worked!`.
+- [ ] Verified developer name in security prompt is "Quriosity Pty Ltd".
+
+## What we do not test
+
+- **`codesign`, `spctl`, `xcrun stapler` correctness** — Apple-supplied tools.
+- **Apple notary service availability** — Apple-side outages out of our control. The release will fail loudly if notary is down; do not retry blindly.
+- **App-Specific Password expiry** — no test catches this before release; the build itself fails loudly with notary auth errors. The remediation is documented in [`DOCUMENTATION.md`](DOCUMENTATION.md).
+- **Cert expiry** — Apple's Developer ID Application certs are valid 5 years; we will rotate well before expiry.

--- a/qcut/docs/task/macos-code-signing/TESTING.zh-CN.md
+++ b/qcut/docs/task/macos-code-signing/TESTING.zh-CN.md
@@ -1,0 +1,198 @@
+# macOS 代码签名 — 测试方案
+
+测试只覆盖**我们自己拥有的**部分 — 校验脚本、`package.json` 形态、
+`release.yml` 形态。我们故意**不**单元测试 `codesign`、`spctl`、
+`xcrun stapler` 或 Apple 的公证服务 — 这些是集成层面的事，由
+[`IMPLEMENTATION.zh-CN.md §4`](IMPLEMENTATION.zh-CN.md#4-在干净-macos-vm-上做发布演练)
+里的发布演练步骤覆盖。
+
+## 测试清单
+
+| # | 类型 | 文件路径 | 覆盖内容 |
+|---|------|----------|----------|
+| 1 | 单元 | `qcut/scripts/__tests__/verify-macos-signature.test.ts` | 校验脚本：输出正常时通过，缺公证时失败，team ID 不匹配时失败，非 macOS 上 no-op。 |
+| 2 | 单元 | `qcut/scripts/__tests__/package-json-mac-signing.test.ts` | `build.mac.identity` 已设、`build.mac.notarize.teamId` 已设、`hardenedRuntime: true` 保留。 |
+| 3 | 守门 | `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts` | `build-macos` "Build Electron application" 步骤暴露了 5 个 Apple env，且 build 之后存在 verify 步骤。 |
+| 4 | 人工 / E2E | [`IMPLEMENTATION.zh-CN.md §4`](IMPLEMENTATION.zh-CN.md#4-在干净-macos-vm-上做发布演练) | 干净 macOS VM 上签名 + 公证的 app 启动时不弹 Gatekeeper 警告。 |
+
+## 测试 1 — 校验脚本单元测试
+
+**路径：** `qcut/scripts/__tests__/verify-macos-signature.test.ts`
+
+**框架：** Vitest，跟现有 `qcut/scripts/__tests__/check-boundaries.test.ts`
+一致。Mock `child_process.execFileSync`。
+
+### 用例
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("verify-macos-signature", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("非 macOS 主机上 no-op", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    await import("../verify-macos-signature");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("dist-electron 为空时抛错", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock fs.readdirSync 返回 []
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /找不到 QCut.*\.dmg/,
+    );
+  });
+
+  it("codesign 退出非零时抛错", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock execFileSync 在 codesign 时抛
+    await expect(import("../verify-macos-signature")).rejects.toThrow();
+  });
+
+  it("已签名但未公证时抛错", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "ABCDE12345");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock spctl 输出包含 "accepted" 但不含 "Notarized Developer ID"
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /未公证/,
+    );
+  });
+
+  it("stapler 报失败时抛错", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock stapler 输出不含 "worked"
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /stapler 校验失败/,
+    );
+  });
+
+  it("team ID 不匹配时抛错", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "WRONGT3AM1");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock codesign -dvv 输出不含 (WRONGT3AM1)
+    await expect(import("../verify-macos-signature")).rejects.toThrow(
+      /team 不匹配/,
+    );
+  });
+
+  it("全部正常时通过", async () => {
+    vi.stubEnv("APPLE_TEAM_ID", "ABCDE12345");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    // mock 四个工具输出都正常
+    await expect(import("../verify-macos-signature")).resolves.not.toThrow();
+  });
+});
+```
+
+> **重构提示：** 生产脚本是模块顶层立即执行（与 `verify-packaged-*.ts`
+> 风格一致）。为了让测试更干净，考虑把主体包进 `main()`，文件底部
+> 调用 — 跟 Windows 校验脚本同款。两种风格都行，重点是两个校验脚本
+> 保持一致。
+
+### 运行方式
+
+```bash
+cd qcut && bun run test scripts/__tests__/verify-macos-signature.test.ts
+```
+
+## 测试 2 — `package.json` 形态
+
+**路径：** `qcut/scripts/__tests__/package-json-mac-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import pkg from "../../package.json";
+
+describe("package.json macOS 签名配置", () => {
+  it("identity 是 Developer ID Application", () => {
+    expect(pkg.build.mac.identity).toMatch(/^Developer ID Application: /);
+  });
+
+  it("notarize.teamId 已设", () => {
+    expect(pkg.build.mac.notarize?.teamId).toBeTruthy();
+  });
+
+  it("hardenedRuntime 保持 true", () => {
+    expect(pkg.build.mac.hardenedRuntime).toBe(true);
+  });
+
+  it("entitlements 仍指向原 plist", () => {
+    expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
+    expect(pkg.build.mac.entitlementsInherit).toBe("build/entitlements.mac.plist");
+  });
+});
+```
+
+## 测试 3 — 工作流 YAML 守门
+
+**路径：** `qcut/scripts/__tests__/release-workflow-mac-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const workflowPath = join(
+  import.meta.dir, "..", "..", "..", ".github", "workflows", "release.yml",
+);
+const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
+
+describe("release.yml build-macos 签名", () => {
+  const macJob = wf.jobs["build-macos"];
+  const buildStep = macJob.steps.find(
+    (s: any) => s.name === "Build Electron application",
+  );
+
+  for (const k of [
+    "CSC_LINK",
+    "CSC_KEY_PASSWORD",
+    "APPLE_ID",
+    "APPLE_APP_SPECIFIC_PASSWORD",
+    "APPLE_TEAM_ID",
+  ]) {
+    it(`Build 步骤暴露了 ${k}`, () => {
+      expect(buildStep.env[k]).toBeDefined();
+    });
+  }
+
+  it("Build 之后存在 'Verify macOS signature and notarization' 步骤", () => {
+    const names = macJob.steps.map((s: any) => s.name);
+    const buildIdx = names.indexOf("Build Electron application");
+    const verifyIdx = names.indexOf("Verify macOS signature and notarization");
+    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  });
+});
+```
+
+> 如果还没装 `js-yaml` 和 `@types/js-yaml`，需要加到 dev dependency
+> （Windows 那边的 TESTING 也需要这个）。
+
+## 测试 4 — 人工 VM E2E
+
+详见 [`IMPLEMENTATION.zh-CN.md §4`](IMPLEMENTATION.zh-CN.md#4-在干净-macos-vm-上做发布演练)。
+在 PR 描述里把结果作为 checklist 留底：
+
+- [ ] `.dmg` 打开时**不**弹"无法验证开发者"。
+- [ ] App 从 `/Applications` 启动时**不**需要右键 → 打开。
+- [ ] `codesign --verify --deep --strict --verbose=2` 退出 0。
+- [ ] `spctl -a -t exec -vv` 报告 `accepted` 且 `source=Notarized Developer ID`。
+- [ ] `xcrun stapler validate` 报告 `The validate action worked!`。
+- [ ] 安全弹窗里显示的开发者名是 "Quriosity Pty Ltd"。
+
+## 我们故意不测的部分
+
+- **`codesign`、`spctl`、`xcrun stapler` 自身的正确性** — Apple 提供的
+  工具。
+- **Apple 公证服务可用性** — Apple 端故障不在我们控制范围。公证服务
+  挂掉时构建会明确报错；不要盲目重试。
+- **App-Specific Password 过期** — 没有测试能在发布前抓到这个；构建
+  本身会因为 notary 认证失败明确报错。处理方式见
+  [`DOCUMENTATION.zh-CN.md`](DOCUMENTATION.zh-CN.md)。
+- **证书过期** — Apple 的 Developer ID Application 证书有效期 5 年；
+  到期前会主动轮换。

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
@@ -1,0 +1,93 @@
+# Code Signing Certificate Options
+
+This is the "license" the user flagged. Authenticode signing requires a
+commercial certificate; self-signed will not satisfy SmartScreen.
+
+## TL;DR recommendation
+
+**Azure Trusted Signing — Public Trust identity.** ~USD 10/month. Best fit
+for a CI-driven Electron release pipeline. Issue #289 already proposes
+this path.
+
+## Comparison
+
+| Vendor / Product | Cost (USD/yr) | SmartScreen warmup | CI-friendly? | Validation type | Notes |
+|------------------|---------------|--------------------|--------------|-----------------|-------|
+| **Azure Trusted Signing** (Public Trust) | ~$120 ($10/mo) | Standard (builds over time) | ✅ Native via `azureSignOptions` | Org or individual | **Recommended.** Cloud-resident keys, no HSM, MSFT-issued. |
+| **Azure Trusted Signing** (Private Trust) | ~$120 | N/A (internal only) | ✅ | Org | Not useful — Private Trust is for line-of-business apps inside one tenant. |
+| **DigiCert OV** | $400–600 | Slow (weeks–months) | ⚠️ Token shipping or KSP | Org | Traditional. OV = Organization Validation. |
+| **DigiCert EV** | $600–800 | **Instant** SmartScreen reputation | ⚠️ Hardware token / cloud HSM only | Strict org vetting | Best UX, hardest CI integration. EV keys must live in FIPS HSM. |
+| **Sectigo OV** | $200–400 | Slow | ⚠️ Token / KSP | Org | Cheaper OV option. |
+| **Sectigo EV** | $400–600 | Instant | ⚠️ HSM | Strict | Cheaper EV option. |
+| **SSL.com EV (eSigner)** | $300–500 | Instant | ✅ Cloud HSM via REST API | Strict | Good middle ground if EV reputation is required. |
+| **GlobalSign OV/EV** | $250–700 | Slow / Instant | ⚠️ / ✅ | Org / Strict | Comparable to DigiCert. |
+| **Self-signed** | $0 | Never trusted | ✅ | None | **Does not solve the issue.** Listed only to rule it out. |
+
+## Why Azure Trusted Signing wins for QCut
+
+1. **No hardware token** — Hardware tokens cannot be plugged into a
+   GitHub-hosted Windows runner. Either you ship the token to a self-hosted
+   runner (operational burden) or use a cloud HSM. Trusted Signing is cloud
+   HSM by default.
+2. **`electron-builder` first-class support** — `azureSignOptions` is
+   documented and tested.
+3. **Lower price floor** — $10/mo is significantly less than the $400+/yr
+   DigiCert/Sectigo OV options, and dramatically less than EV.
+4. **Microsoft-issued** — signed by a Microsoft root, so the publisher
+   string in SmartScreen is shown without third-party CA chain quirks.
+5. **Aligned with the issue** — issue #289 proposes this exact path; we
+   stay aligned with the reporter's mental model.
+
+## When to upgrade to EV later
+
+EV gives **instant** SmartScreen reputation. Worth the upgrade if:
+
+- Initial Trusted Signing builds still trigger "less common app" warnings
+  beyond ~1,000 cumulative downloads, *and*
+- Those warnings demonstrably hurt install conversion (track via download
+  → first-launch telemetry, if available).
+
+If we go EV later, **SSL.com eSigner** is the recommended provider because
+it exposes a cloud-signing REST API that can replace `azureSignOptions`
+without requiring a self-hosted runner with a USB token.
+
+## Procurement steps (Azure Trusted Signing)
+
+This is the manual, out-of-code work needed before any of the engineering
+subtasks can be merged.
+
+1. Sign in to the [Azure portal](https://portal.azure.com) with the
+   Quriosity org account that will own the cert.
+2. Create a **Trusted Signing Account** resource in a region that supports
+   it (East US, West Central US, etc.).
+3. Create a **Certificate Profile** of type **Public Trust → Public Trust
+   Identity Validation** for an organization, or **Public Trust Individual
+   Validation** for a personal cert.
+4. Submit identity documents to Microsoft for validation. **This step takes
+   1–7 days.** Plan accordingly.
+5. Once validated, note the values needed by `electron-builder`:
+   - **Endpoint** — e.g. `https://eus.codesigning.azure.net/`
+   - **Code Signing Account Name** — the Trusted Signing Account resource name.
+   - **Certificate Profile Name** — the profile created in step 3.
+   - **Publisher Name** — exact subject CN that will appear in
+     `Get-AuthenticodeSignature`. Must match an Azure-issued cert subject.
+6. Create a **service principal** scoped to the Trusted Signing resource
+   with the `Trusted Signing Certificate Profile Signer` role. Capture:
+   - `AZURE_TENANT_ID`
+   - `AZURE_CLIENT_ID`
+   - `AZURE_CLIENT_SECRET` (or use OIDC federation — preferred long-term,
+     see below)
+
+## Long-term: prefer OIDC federation over client secret
+
+For lower long-term maintenance, configure a **federated credential** on
+the service principal so GitHub Actions authenticates via OIDC and no
+`AZURE_CLIENT_SECRET` ever touches a GitHub secret. This is a follow-up
+hardening task once the basic flow works — track in
+[`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-future-hardening).
+
+## Renewal
+
+Trusted Signing certificate profiles auto-rotate certificates; no annual
+renewal task. The **Trusted Signing Account itself** is billed monthly as
+a regular Azure resource — set a billing alert in the Azure subscription.

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
@@ -113,8 +113,8 @@ What this means in practice:
 2. **Provide identity documents** — Certum will email a list. Typical:
    - Quriosity ASIC company registration (you have this)
    - D-U-N-S Number 893394655 (significantly speeds up validation)
-   - Donghao's passport scan + utility bill (for Authorized Representative validation)
-   - Quriosity Pty Ltd address proof (lease agreement or recent utility for 452 Flinders St)
+   - Authorized Representative identity documents (government photo ID + recent proof-of-address utility bill or bank statement)
+   - Registered business address proof (lease agreement or recent utility bill issued to Quriosity Pty Ltd at its registered place of business)
 3. **Identity verification.** Certum reviews documents (3–7 business days, faster with D-U-N-S already done).
 4. **Activate SimplySign account.** Certum emails activation link → installs SimplySign mobile app on Donghao's phone → desktop signing tool on his Mac/Windows machine.
 5. **Issued certificate** lives in Certum's cloud HSM. Each `signtool sign` operation prompts Donghao's phone for approval.

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
@@ -10,7 +10,9 @@ Eligibility for QCut/Quriosity:
 - ✅ Cloud-based (no USB token)
 - ⚠️ Each signing operation requires phone approval via SimplySign mobile app — semi-manual, not full CI automation. See [IMPLEMENTATION.md §architecture](IMPLEMENTATION.md#architecture-decision-where-signing-happens).
 
-If full CI automation matters more than the ~$50/year savings: **Alternative: SSL.com eSigner OV — ~USD 250/year, REST API, fully automated.**
+If full CI automation matters more than the **~$220/year cost difference**: **Alternative: SSL.com eSigner OV — ~USD 439–479/year ($239 cert + $200–240/year eSigner subscription), REST API, fully automated.**
+
+> **Pricing reality (verified 2026-04-25 by viewing SSL.com checkout):** SSL.com is a **dual-cost** product, not a single price. The cert itself is $239/year, but cloud signing requires a separate `eSigner` subscription (Tier 1: $20/mo or $200/year for 20 signings/month). Many secondhand sources only quote the cert price and miss the eSigner fee — earlier drafts of this document made the same mistake.
 
 ## Why every other option was ruled out
 
@@ -46,8 +48,8 @@ The cloud-based exceptions (DigiCert KeyLocker, SSL.com eSigner) are priced at $
 | Vendor | Cost (USD/yr) | CI automation | OSS-eligible | AU eligible | < 3yr eligible | Notes |
 |--------|---------------|----------------|--------------|-------------|----------------|-------|
 | **Certum SimplySign Standard** | **~$200** | ⚠️ Phone approval | ✅ ✅ | ✅ | ✅ | **Recommended for QCut.** Used by Inkdrop and many indie Electron projects. |
-| **SSL.com eSigner OV** | ~$200–250 | ✅ Full REST API | ✅ ✅ | ✅ | ✅ | Better CI fit, similar price. |
-| SSL.com eSigner EV | ~$350–500 | ✅ | ✅ ✅ | ✅ | ✅ | EV no longer worth premium since 2024. |
+| **SSL.com eSigner OV** | **~$439–479** ($239 cert + $200–240 eSigner sub) | ✅ Full REST API | ✅ ✅ | ✅ | ✅ | Full CI automation, but **~2× Certum's price**. Dual-cost structure (cert + mandatory eSigner subscription) is not obvious until checkout. |
+| SSL.com eSigner EV | ~$590–740 ($350–500 cert + $200–240 eSigner sub) | ✅ | ✅ ✅ | ✅ | ✅ | EV no longer worth premium since 2024. |
 | Sectigo OV (resellers) | $170–230 | ⚠️ USB token | ✅ ✅ | ✅ | ✅ | Hostile to GitHub-hosted CI. |
 | DigiCert OV/EV | $400–800 | ⚠️ USB / KSP | ✅ ✅ | ✅ | ✅ | Expensive, not justified. |
 | Azure Artifact Signing | $120 | ✅ | N/A | ❌ | ❌ | **Not available to Quriosity.** |
@@ -128,6 +130,6 @@ Implementation against this credential setup is in [`IMPLEMENTATION.md`](IMPLEME
 ## Future migration paths
 
 If Certum's manual phone approval becomes a bottleneck:
-- **SSL.com eSigner OV** (~$50/year more) — fully automated CI signing via REST API.
-- **Wait for Azure eligibility** in 2027-06 (Quriosity hits 3 years) — may also depend on Microsoft expanding country list to AU.
+- **SSL.com eSigner OV** (~$220+/year more — see comparison table for actual dual-cost structure) — fully automated CI signing via REST API. Worth it only at high release frequency (>1×/week); below that, the manual phone-approval cost is ~minutes/year and not worth $220.
+- **Wait for Azure eligibility** in 2027-06 (Quriosity hits 3 years) — may also depend on Microsoft expanding country list to AU. If both clear, $120/year + full CI automation makes Azure a clear winner.
 - **Move to EV later** if SmartScreen reputation never converges (unlikely now, since EV no longer instant).

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md
@@ -1,93 +1,133 @@
 # Code Signing Certificate Options
 
-This is the "license" the user flagged. Authenticode signing requires a
-commercial certificate; self-signed will not satisfy SmartScreen.
+## TL;DR
 
-## TL;DR recommendation
+**Recommended: [Certum SimplySign Standard Code Signing](https://shop.certum.eu/standard-code-signing-in-cloud.html) — Organization tier, ~USD 200/year (€189/year).**
 
-**Azure Trusted Signing — Public Trust identity.** ~USD 10/month. Best fit
-for a CI-driven Electron release pipeline. Issue #289 already proposes
-this path.
+Eligibility for QCut/Quriosity:
+- ✅ Available in Australia
+- ✅ No company-age requirement
+- ✅ Cloud-based (no USB token)
+- ⚠️ Each signing operation requires phone approval via SimplySign mobile app — semi-manual, not full CI automation. See [IMPLEMENTATION.md §architecture](IMPLEMENTATION.md#architecture-decision-where-signing-happens).
 
-## Comparison
+If full CI automation matters more than the ~$50/year savings: **Alternative: SSL.com eSigner OV — ~USD 250/year, REST API, fully automated.**
 
-| Vendor / Product | Cost (USD/yr) | SmartScreen warmup | CI-friendly? | Validation type | Notes |
-|------------------|---------------|--------------------|--------------|-----------------|-------|
-| **Azure Trusted Signing** (Public Trust) | ~$120 ($10/mo) | Standard (builds over time) | ✅ Native via `azureSignOptions` | Org or individual | **Recommended.** Cloud-resident keys, no HSM, MSFT-issued. |
-| **Azure Trusted Signing** (Private Trust) | ~$120 | N/A (internal only) | ✅ | Org | Not useful — Private Trust is for line-of-business apps inside one tenant. |
-| **DigiCert OV** | $400–600 | Slow (weeks–months) | ⚠️ Token shipping or KSP | Org | Traditional. OV = Organization Validation. |
-| **DigiCert EV** | $600–800 | **Instant** SmartScreen reputation | ⚠️ Hardware token / cloud HSM only | Strict org vetting | Best UX, hardest CI integration. EV keys must live in FIPS HSM. |
-| **Sectigo OV** | $200–400 | Slow | ⚠️ Token / KSP | Org | Cheaper OV option. |
-| **Sectigo EV** | $400–600 | Instant | ⚠️ HSM | Strict | Cheaper EV option. |
-| **SSL.com EV (eSigner)** | $300–500 | Instant | ✅ Cloud HSM via REST API | Strict | Good middle ground if EV reputation is required. |
-| **GlobalSign OV/EV** | $250–700 | Slow / Instant | ⚠️ / ✅ | Org / Strict | Comparable to DigiCert. |
-| **Self-signed** | $0 | Never trusted | ✅ | None | **Does not solve the issue.** Listed only to rule it out. |
+## Why every other option was ruled out
 
-## Why Azure Trusted Signing wins for QCut
+### ❌ Azure Trusted Signing (Microsoft Artifact Signing)
 
-1. **No hardware token** — Hardware tokens cannot be plugged into a
-   GitHub-hosted Windows runner. Either you ship the token to a self-hosted
-   runner (operational burden) or use a cloud HSM. Trusted Signing is cloud
-   HSM by default.
-2. **`electron-builder` first-class support** — `azureSignOptions` is
-   documented and tested.
-3. **Lower price floor** — $10/mo is significantly less than the $400+/yr
-   DigiCert/Sectigo OV options, and dramatically less than EV.
-4. **Microsoft-issued** — signed by a Microsoft root, so the publisher
-   string in SmartScreen is shown without third-party CA chain quirks.
-5. **Aligned with the issue** — issue #289 proposes this exact path; we
-   stay aligned with the reporter's mental model.
+Two **independent** blockers:
 
-## When to upgrade to EV later
+1. **Country eligibility.** Microsoft's official FAQ (Jan 2026): *"For Public Trust certificates, Artifact Signing is currently available to organizations in the USA, Canada, the European Union, and the United Kingdom."* Australia is not listed.
+2. **Organization age.** Microsoft requires *"at least three years of verifiable history."* Quriosity registered 2024-06-10; will not qualify until 2027-06-10.
 
-EV gives **instant** SmartScreen reputation. Worth the upgrade if:
+Microsoft Q&A confirms there is no exception process. Source: [Microsoft Artifact Signing FAQ](https://learn.microsoft.com/en-us/azure/artifact-signing/faq).
 
-- Initial Trusted Signing builds still trigger "less common app" warnings
-  beyond ~1,000 cumulative downloads, *and*
-- Those warnings demonstrably hurt install conversion (track via download
-  → first-launch telemetry, if available).
+### ❌ SignPath Foundation (free for OSS)
 
-If we go EV later, **SSL.com eSigner** is the recommended provider because
-it exposes a cloud-signing REST API that can replace `azureSignOptions`
-without requiring a self-hosted runner with a USB token.
+Requires the project to remain open-source under an OSI-approved license. QCut may close-source in the future. SignPath Foundation eligibility cannot be carried over to a closed-source project.
 
-## Procurement steps (Azure Trusted Signing)
+### ❌ SSL.com EV / DigiCert EV
 
-This is the manual, out-of-code work needed before any of the engineering
-subtasks can be merged.
+Pre-2024, EV certificates granted instant SmartScreen reputation — an EV-signed binary would show no warning even on first download. **Microsoft removed this in 2024** when they updated the Trusted Root Program requirements.
 
-1. Sign in to the [Azure portal](https://portal.azure.com) with the
-   Quriosity org account that will own the cert.
-2. Create a **Trusted Signing Account** resource in a region that supports
-   it (East US, West Central US, etc.).
-3. Create a **Certificate Profile** of type **Public Trust → Public Trust
-   Identity Validation** for an organization, or **Public Trust Individual
-   Validation** for a personal cert.
-4. Submit identity documents to Microsoft for validation. **This step takes
-   1–7 days.** Plan accordingly.
-5. Once validated, note the values needed by `electron-builder`:
-   - **Endpoint** — e.g. `https://eus.codesigning.azure.net/`
-   - **Code Signing Account Name** — the Trusted Signing Account resource name.
-   - **Certificate Profile Name** — the profile created in step 3.
-   - **Publisher Name** — exact subject CN that will appear in
-     `Get-AuthenticodeSignature`. Must match an Azure-issued cert subject.
-6. Create a **service principal** scoped to the Trusted Signing resource
-   with the `Trusted Signing Certificate Profile Signer` role. Capture:
-   - `AZURE_TENANT_ID`
-   - `AZURE_CLIENT_ID`
-   - `AZURE_CLIENT_SECRET` (or use OIDC federation — preferred long-term,
-     see below)
+As of 2026, OV and EV certificates are **functionally identical** for SmartScreen purposes — both must build reputation organically through download volume. The 2× price premium for EV is no longer justified.
 
-## Long-term: prefer OIDC federation over client secret
+Source: [Reputation with OV certificates and are EV certificates still the better option? — Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/417016/reputation-with-ov-certificates-and-are-ev-certifi).
 
-For lower long-term maintenance, configure a **federated credential** on
-the service principal so GitHub Actions authenticates via OIDC and no
-`AZURE_CLIENT_SECRET` ever touches a GitHub secret. This is a follow-up
-hardening task once the basic flow works — track in
-[`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-future-hardening).
+### ❌ Sectigo / DigiCert OV via traditional reseller (~$170–230/yr)
+
+Cheap on paper but most still require a USB hardware token. Hardware tokens cannot be plugged into GitHub-hosted Windows runners, and the operational cost of shipping/managing a token to a self-hosted runner outweighs the certificate savings.
+
+The cloud-based exceptions (DigiCert KeyLocker, SSL.com eSigner) are priced at $400+ for OV, well above Certum.
+
+## Industry comparison (April 2026)
+
+| Vendor | Cost (USD/yr) | CI automation | OSS-eligible | AU eligible | < 3yr eligible | Notes |
+|--------|---------------|----------------|--------------|-------------|----------------|-------|
+| **Certum SimplySign Standard** | **~$200** | ⚠️ Phone approval | ✅ ✅ | ✅ | ✅ | **Recommended for QCut.** Used by Inkdrop and many indie Electron projects. |
+| **SSL.com eSigner OV** | ~$200–250 | ✅ Full REST API | ✅ ✅ | ✅ | ✅ | Better CI fit, similar price. |
+| SSL.com eSigner EV | ~$350–500 | ✅ | ✅ ✅ | ✅ | ✅ | EV no longer worth premium since 2024. |
+| Sectigo OV (resellers) | $170–230 | ⚠️ USB token | ✅ ✅ | ✅ | ✅ | Hostile to GitHub-hosted CI. |
+| DigiCert OV/EV | $400–800 | ⚠️ USB / KSP | ✅ ✅ | ✅ | ✅ | Expensive, not justified. |
+| Azure Artifact Signing | $120 | ✅ | N/A | ❌ | ❌ | **Not available to Quriosity.** |
+| SignPath Foundation | $0 | ✅ | OSS-only | ✅ | ✅ | **Locks project to open-source.** |
+
+## What signing actually changes (vs. doesn't)
+
+Honest disclosure — signing does and doesn't fix specific things. Don't be misled by vendor marketing.
+
+### ✅ Immediate changes (the day you sign)
+
+- **UAC dialog**: yellow "Unknown publisher" → blue "Verified publisher: Quriosity Pty Ltd"
+- **Enterprise IT policies** that block unsigned executables now allow QCut
+- **Antivirus false-positive rate** drops significantly (Kaspersky, 360, Huorong, Avast, Defender heuristics)
+- **Browser download warnings** reduced
+- **winget / Chocolatey / scoop** package managers will accept QCut
+- **Auto-update integrity**: `electron-updater` can verify each update chains to the same publisher
+
+### 📈 Gradual changes (over hundreds–thousands of installs)
+
+- **SmartScreen "Windows protected your PC"** warning becomes less frequent, eventually disappears
+- Reputation accumulates per file hash AND (slowly) per publisher
+
+### ❌ Does NOT change
+
+- **Mark of the Web (MOTW)**: Windows still tags downloaded files. This is browser-side, not signature-side. Users may still see "Open File - Security Warning" dialogs.
+- **First few hundred installs may still trigger SmartScreen** — but with verified publisher name shown ("Quriosity Pty Ltd"), conversion improves significantly.
+- **User trust in unknown brands**: signing proves identity, not reputation. New companies still feel new.
+
+## SmartScreen reputation reality (2026)
+
+**Critical disclosure:** SmartScreen reputation is **per file hash**, not per certificate or per publisher. Each new build (v2026.5.0 → v2026.6.0) starts with zero reputation regardless of past releases.
+
+What this means in practice:
+
+- The very first user who downloads QCut v2026.6.0 will see a SmartScreen warning **even after we sign**.
+- Reputation builds as more users install and don't report problems.
+- After ~hundreds–thousands of installs without negative signals, the warning stops.
+- Frequent versioning resets reputation — release cadence affects this.
+
+### Mitigation strategies
+
+- Don't release for every minor change — batch fixes into versioned drops.
+- Encourage users to keep downloads in their cache (re-running same hash builds reputation).
+- Long-term established publishers do get less aggressive scanning, even on new hashes.
+- Add a Windows-download-page note explaining the warning is expected for new versions.
+
+## Pricing trends (2026 industry context)
+
+- **Effective March 2026:** CA/Browser Forum reduced max code-signing cert validity from 39 months to **460 days (~15 months)**. All issued certs from that date forward are bound to this limit. Renewal cadence is now annual, not multi-year.
+- **EV certificates lost their unique SmartScreen instant-reputation benefit in 2024.** OV and EV now behave identically for SmartScreen.
+- **Azure Trusted Signing eligibility was tightened in 2025** — narrowed to USA/Canada (with 3-year history), then expanded slightly to EU/UK. Australia and other geographies remain excluded as of 2026-Q1.
+- **Cloud-HSM signing** (no USB token) is now the indie default. Certum SimplySign, SSL.com eSigner, DigiCert KeyLocker all support this.
+
+## Certum SimplySign: how to apply
+
+1. **Order the cert** at https://shop.certum.eu/standard-code-signing-in-cloud.html.
+   - Type: Standard Code Signing **in Cloud** (NOT the USB version)
+   - Term: 1 year (max under 2026 CA/B rules)
+   - Validation: **Organization** (cert subject = "Quriosity Pty Ltd")
+2. **Provide identity documents** — Certum will email a list. Typical:
+   - Quriosity ASIC company registration (you have this)
+   - D-U-N-S Number 893394655 (significantly speeds up validation)
+   - Donghao's passport scan + utility bill (for Authorized Representative validation)
+   - Quriosity Pty Ltd address proof (lease agreement or recent utility for 452 Flinders St)
+3. **Identity verification.** Certum reviews documents (3–7 business days, faster with D-U-N-S already done).
+4. **Activate SimplySign account.** Certum emails activation link → installs SimplySign mobile app on Donghao's phone → desktop signing tool on his Mac/Windows machine.
+5. **Issued certificate** lives in Certum's cloud HSM. Each `signtool sign` operation prompts Donghao's phone for approval.
+
+Implementation against this credential setup is in [`IMPLEMENTATION.md`](IMPLEMENTATION.md).
 
 ## Renewal
 
-Trusted Signing certificate profiles auto-rotate certificates; no annual
-renewal task. The **Trusted Signing Account itself** is billed monthly as
-a regular Azure resource — set a billing alert in the Azure subscription.
+- **Annual** (15-month cap by CA/B Forum).
+- Set a calendar reminder 60 days before cert expiry.
+- Renewal does NOT preserve SmartScreen reputation (it's per file hash anyway, and renewing doesn't change builds you've already shipped — those keep their reputation).
+
+## Future migration paths
+
+If Certum's manual phone approval becomes a bottleneck:
+- **SSL.com eSigner OV** (~$50/year more) — fully automated CI signing via REST API.
+- **Wait for Azure eligibility** in 2027-06 (Quriosity hits 3 years) — may also depend on Microsoft expanding country list to AU.
+- **Move to EV later** if SmartScreen reputation never converges (unlikely now, since EV no longer instant).

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
@@ -120,8 +120,8 @@ GitHub-hosted Windows runner 上，自托管 + 寄送/管理 token 的运维成�
 2. **提交身份材料** — Certum 会邮件列出清单。常见包括：
    - Quriosity ASIC 公司注册（你已有）
    - D-U-N-S Number 893394655（明显加快验证）
-   - Donghao 护照扫描 + 居住地证明（用于 Authorized Representative 验证）
-   - Quriosity Pty Ltd 地址证明（452 Flinders St 的租约或近期账单）
+   - 授权代表身份证明（政府签发的带照片身份证件 + 近期住址证明，如水电气账单或银行对账单）
+   - 公司注册地址证明（开具给 Quriosity Pty Ltd、寄送至其注册经营地址的租约或近期账单）
 3. **身份验证。** Certum 审核 3–7 个工作日（已有 D-U-N-S 会更快）。
 4. **激活 SimplySign 账号。** Certum 发激活链接 → 在 Donghao 手机装 SimplySign App → 在他的 Mac/Windows 机器装桌面签名工具。
 5. **签发的证书**存在 Certum 云 HSM 里。每次 `signtool sign` 操作都会让 Donghao 手机弹窗确认。

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
@@ -10,7 +10,9 @@ QCut/Quriosity 资格情况：
 - ✅ 云签名（不需要 USB token）
 - ⚠️ 每次签名都需要在 SimplySign 手机 App 上点确认 — 半手工，**不能完全自动化 CI**。详见 [IMPLEMENTATION.zh-CN.md §架构决策](IMPLEMENTATION.zh-CN.md#架构决策签名在哪里发生)
 
-如果完全自动化 CI 比省 ~$50/年更重要：**备选：SSL.com eSigner OV — 约 USD 250/年，REST API，全自动化。**
+如果完全自动化 CI 比 **~$220/年的差价**更重要：**备选：SSL.com eSigner OV — 约 USD 439–479/年（$239 证书 + $200–240/年 eSigner 订阅），REST API，全自动化。**
+
+> **定价真相（2026-04-25 在 SSL.com 结账页核实）：** SSL.com 是**双重收费**产品，不是单一价格。证书本身 $239/年，但云签名要另外订阅 `eSigner`（Tier 1：$20/月 或 $200/年，20 次签名/月）。很多二手来源只报证书价格，漏掉 eSigner 订阅费 — 本文档早期草稿也犯了同样的错。
 
 ## 其它路径为什么被排除
 
@@ -53,8 +55,8 @@ GitHub-hosted Windows runner 上，自托管 + 寄送/管理 token 的运维成�
 | 厂商 | 价格（USD/年） | CI 自动化 | 开源资格 | 澳洲可买 | 新公司可买 | 备注 |
 |------|---------------|-----------|---------|---------|----------|------|
 | **Certum SimplySign Standard** | **~$200** | ⚠️ 手机确认 | ✅ ✅ | ✅ | ✅ | **QCut 推荐**。Inkdrop 等大量 indie Electron 项目都用。 |
-| **SSL.com eSigner OV** | ~$200–250 | ✅ REST API | ✅ ✅ | ✅ | ✅ | CI 集成更好，价格类似。 |
-| SSL.com eSigner EV | ~$350–500 | ✅ | ✅ ✅ | ✅ | ✅ | EV 自 2024 起不再值溢价。 |
+| **SSL.com eSigner OV** | **~$439–479**（$239 证书 + $200–240 eSigner 订阅） | ✅ REST API | ✅ ✅ | ✅ | ✅ | 全自动 CI，但**比 Certum 贵 ~2 倍**。双重收费（证书 + 强制 eSigner 订阅）在结账前不明显。 |
+| SSL.com eSigner EV | ~$590–740（$350–500 证书 + $200–240 eSigner 订阅） | ✅ | ✅ ✅ | ✅ | ✅ | EV 自 2024 起不再值溢价。 |
 | Sectigo OV（分销商） | $170–230 | ⚠️ USB token | ✅ ✅ | ✅ | ✅ | 不友好 GitHub-hosted CI。 |
 | DigiCert OV/EV | $400–800 | ⚠️ USB / KSP | ✅ ✅ | ✅ | ✅ | 贵，没必要。 |
 | Azure Artifact Signing | $120 | ✅ | 不适用 | ❌ | ❌ | **Quriosity 不能买。** |
@@ -135,6 +137,6 @@ GitHub-hosted Windows runner 上，自托管 + 寄送/管理 token 的运维成�
 ## 未来迁移路径
 
 如果 Certum 的手机确认变成瓶颈：
-- **SSL.com eSigner OV**（每年多 ~$50） — REST API 全自动化 CI 签名。
-- **等到 Azure 资格满足** 2027-06（Quriosity 满 3 年）— 还要看微软是否扩大国家名单到澳洲。
+- **SSL.com eSigner OV**（每年多 ~$220+，详见对比表的双重收费结构） — REST API 全自动化 CI 签名。**只在高频发版（每周 1 次以上）时值得**；低频下手动确认每年总成本只有几分钟，省不下 $220。
+- **等到 Azure 资格满足** 2027-06（Quriosity 满 3 年）— 还要看微软是否扩大国家名单到澳洲。如果都满足，$120/年 + 全自动 CI，Azure 完胜。
 - **以后再升 EV** — 如果 SmartScreen 信誉死活积累不上去（不太可能，因为 EV 现在也不立即了）。

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
@@ -1,87 +1,124 @@
 # 代码签名证书选型
 
-这就是用户提到的"license"。Authenticode 签名必须用商用证书，
+这就是用户提到的"license"。Authenticode 签名必须用受信任 CA 颁发的证书，
 自签证书没法满足 SmartScreen。
+
+> **重要背景（2026-04-25 通过看代码确认）：**
+> `qcut/LICENSE` 是 MIT 类许可证（"Permission is hereby granted, free of
+> charge…"），`qcut/package.json:308` 把自己描述成 "Open-source AI video
+> editor"。两者都满足 **SignPath Foundation** 免费签名计划的资格。本文档
+> 第一版漏了这条 — 现修正。
 
 ## 一句话推荐
 
-**Azure Trusted Signing — Public Trust 身份**。约 USD 10/月。
-最适合 CI 驱动的 Electron 发布流水线。issue #289 推荐的也是这条路。
+1. **先申请 [SignPath Foundation](https://signpath.io/foundation/) — 对开源项目免费，QCut 完全符合资格。** 审批一般 1–2 周。
+2. **如果 SignPath 拒绝（开源项目极少被拒，但有可能） → 退到 Azure Trusted Signing — Public Trust 身份，约 USD 10/月。**
 
-## 对比表
+我们故意**不**推荐 v1 走 DigiCert / Sectigo OV/EV。原因见下文。
 
-| 厂商 / 产品 | 价格（USD/年） | SmartScreen 暖机 | CI 友好？ | 验证方式 | 备注 |
-|------------|----------------|-------------------|-----------|----------|------|
-| **Azure Trusted Signing**（Public Trust） | ~$120（$10/月） | 普通（信誉随时间累积） | ✅ 通过 `azureSignOptions` 原生支持 | 组织或个人 | **推荐**。云端密钥，无 HSM，微软签发。 |
-| **Azure Trusted Signing**（Private Trust） | ~$120 | 不适用（仅内网） | ✅ | 组织 | 没用 — Private Trust 是给单租户内部业务系统用的。 |
-| **DigiCert OV** | $400–600 | 慢（数周到数月） | ⚠️ USB 令牌或 KSP | 组织 | 传统方案。OV = 组织验证。 |
-| **DigiCert EV** | $600–800 | **立即**有 SmartScreen 信誉 | ⚠️ 仅硬件令牌 / 云 HSM | 严格组织验证 | 用户体验最好，CI 集成最难。EV 私钥必须放在 FIPS HSM 里。 |
-| **Sectigo OV** | $200–400 | 慢 | ⚠️ 令牌 / KSP | 组织 | 便宜的 OV 选项。 |
-| **Sectigo EV** | $400–600 | 立即 | ⚠️ HSM | 严格 | 便宜的 EV 选项。 |
-| **SSL.com EV（eSigner）** | $300–500 | 立即 | ✅ 通过 REST API 用云 HSM | 严格 | 如果非 EV 不可，这个折中方案不错。 |
-| **GlobalSign OV/EV** | $250–700 | 慢 / 立即 | ⚠️ / ✅ | 组织 / 严格 | 与 DigiCert 差不多。 |
-| **自签证书** | $0 | 永远不被信任 | ✅ | 无 | **解决不了问题**，列在这里只是为了显式排除。 |
+## 行业对比
 
-## 为什么 QCut 选 Azure Trusted Signing
+| 厂商 / 产品 | 价格（USD/年） | 开源资格？ | SmartScreen 暖机 | CI 友好？ | 验证方式 | 备注 |
+|------------|----------------|------------|-------------------|-----------|----------|------|
+| **SignPath Foundation** | **$0** | ✅ 必须 | 普通 | ✅ 官方 GitHub Action | 人工开源认证 | **QCut 推荐方案。** Blender、OBS Studio、Inkscape、Krita、GIMP、KeePass、Notepad++、Audacity、ImHex 都用它。 |
+| **Azure Trusted Signing**（Public Trust） | ~$120（$10/月） | 不适用 | 普通 | ✅ 通过 `azureSignOptions` 原生支持 | 组织或个人 | 推荐的 fallback。 |
+| **DigiCert OV** | $400–600 | 否 | 慢（数周到数月） | ⚠️ USB 令牌或 KSP | 组织 | 传统方案，CI 不友好。 |
+| **DigiCert EV** | $600–800 | 否 | **立即** | ⚠️ 仅硬件令牌 / 云 HSM | 严格 | 用户体验最好，CI 集成最难。 |
+| **Sectigo OV** | $200–400 | 否 | 慢 | ⚠️ 令牌 / KSP | 组织 | 便宜的传统方案。 |
+| **Sectigo EV** | $400–600 | 否 | 立即 | ⚠️ HSM | 严格 | 便宜的 EV。 |
+| **SSL.com EV（eSigner）** | $300–500 | 否 | 立即 | ✅ 通过 REST API 用云 HSM | 严格 | EV 里 CI 集成最好的。 |
+| **自签证书** | $0 | — | 永远不被信任 | ✅ | 无 | **解决不了问题。** |
 
-1. **不用 USB 硬件令牌** — 硬件令牌没法插进 GitHub-hosted 的 Windows
-   runner。要用就得寄到自托管 runner（运维负担大），或者用云 HSM。
-   Trusted Signing 默认就是云 HSM。
-2. **`electron-builder` 一等支持** — `azureSignOptions` 有官方文档和
-   完整测试。
-3. **价格便宜** — 每月 10 美金远低于 DigiCert/Sectigo OV 的 400+/年，
-   更比 EV 的成本低很多。
-4. **微软直签** — 由微软根证书签发，SmartScreen 显示的发布者字符串
-   不会有第三方 CA 链相关的奇怪问题。
-5. **与 issue 一致** — issue #289 直接推荐了这条路线，跟 reporter 的
-   思路保持一致。
+## 为什么 QCut 选 SignPath Foundation
 
-## 什么时候考虑升级到 EV
+1. **QCut 完全符合资格。** MIT 许可证 + 公开 GitHub 仓库 + CI 驱动构建 =
+   完美贴合 SignPath Foundation 的资格画像。证据已在仓库里：
+   - `qcut/LICENSE` — MIT
+   - `qcut/.github/workflows/release.yml` — CI 构建链
+   - `qcut/package.json:308` — 自描述为 "Open-source AI video editor"
+2. **$0 vs $120/年。** 项目长期能省下持续支出。
+3. **行业验证过。** 几乎所有发布签名 Windows 构建的主要开源桌面应用都
+   用 SignPath Foundation：Blender、OBS Studio、Inkscape、Krita、GIMP、
+   KeePass、Notepad++、Audacity、ImHex 等。风险画像很清楚。
+4. **GitHub Actions 一等集成。** 官方提供
+   `signpath/github-action-submit-signing-request@v1`。
+5. **唯一的卡点是资格** — 实现复杂度跟 Azure 方案差不多。
 
-EV 证书带来**立即生效**的 SmartScreen 信誉。下面情况下值得升级：
+## 为什么 Azure Trusted Signing 是合适的 fallback
 
-- Trusted Signing 的初始版本下载量超过 1000 后还是会触发"不常见的应用"
-  警告；并且
-- 这些警告确实导致安装转化下降（需要"下载 → 首次启动"的 telemetry
-  数据来证实）。
+如果 SignPath 因为构建可复现性、治理或活跃度等原因拒绝 QCut，
+Azure Trusted Signing 仍然是次优解：
 
-如果将来要走 EV，**SSL.com eSigner** 是推荐供应商，因为它提供云签名
-REST API，不用自托管 runner 插 USB 令牌就能替换 `azureSignOptions`。
+1. **不用硬件令牌** — 云 HSM，能在 GitHub-hosted Windows runner 上跑。
+2. **`electron-builder` 一等支持**，通过 `azureSignOptions`。
+3. **商业方案里最便宜** — $10/月 比 DigiCert/Sectigo 便宜 $300+/年。
+4. **微软直签** — 由微软根证书签发。
 
-## 采购步骤（Azure Trusted Signing）
+## 为什么 v1 跳过 DigiCert / Sectigo / EV
 
-下面是工程子任务开始之前需要做的人工操作。
+- **OV 证书** — 必须把 USB 令牌寄到构建机，或额外付费用 KSP 托管签名
+  服务。对 CI 驱动的开源项目来说运维很麻烦。
+- **EV 证书** — 立即有 SmartScreen 信誉，但贵 4–8 倍而且必须用 FIPS
+  HSM。只有在已经签名后**仍然**有信誉问题时再考虑。
 
-1. 用 Quriosity 的组织账号登录
-   [Azure 门户](https://portal.azure.com)。
-2. 在支持 Trusted Signing 的区域（East US、West Central US 等）创建一个
-   **Trusted Signing Account** 资源。
-3. 创建一个 **Certificate Profile**，类型选 **Public Trust → Public Trust
-   Identity Validation**（组织证书）或 **Public Trust Individual
-   Validation**（个人证书）。
-4. 向微软提交身份验证材料。**这一步要 1–7 天**，要早做。
-5. 验证通过后，记下 `electron-builder` 需要的几个值：
-   - **Endpoint** — 例如 `https://eus.codesigning.azure.net/`
-   - **Code Signing Account Name** — 步骤 2 里 Trusted Signing 资源名。
-   - **Certificate Profile Name** — 步骤 3 里创建的 profile 名。
-   - **Publisher Name** — 准确的证书 subject CN，会在
-     `Get-AuthenticodeSignature` 里显示。必须与 Azure 颁发的证书 subject
-     完全一致。
-6. 创建一个**服务主体 (service principal)**，给它授予 Trusted Signing
-   资源上的 `Trusted Signing Certificate Profile Signer` 角色。记下：
+## SignPath Foundation：怎么申请
+
+1. **确认资格：**
+   - OSI 批准的许可证（MIT ✅，见 `qcut/LICENSE`）。
+   - 公开源代码仓库（✅，GitHub 上）。
+   - CI 驱动构建（✅，`qcut/.github/workflows/release.yml`）。
+   - 活跃开发（✅，master 上有近期提交）。
+2. **去 https://signpath.io/foundation/ 提交申请。**
+3. **提供资料：**
+   - 项目名：QCut
+   - 仓库 URL：https://github.com/Quriosity-agent/qcut
+   - 许可证位置：`qcut/LICENSE`（MIT）
+   - 构建流水线位置：`qcut/.github/workflows/release.yml`
+   - 维护者联系方式（例如 `support@qcut.app`，已在
+     `qcut/package.json:290` 出现）
+4. **等 1–2 周审核。** SignPath 可能追问构建可复现性、二进制信任链、
+   发布频率等问题。
+5. **批准后会拿到：**
+   - Organization ID（UUID）。
+   - Project slug（例如 `qcut`）。
+   - Signing policy slug（例如 `release-signing`）。
+   - Artifact configuration slug（例如 `qcut-installer`）。
+   - API Token — 存进 GitHub 仓库 secret `SIGNPATH_API_TOKEN`。
+
+SignPath 路径的实现细节见
+[`IMPLEMENTATION.zh-CN.md` Path A](IMPLEMENTATION.zh-CN.md#path-a-signpath推荐)。
+
+## Azure Trusted Signing：采购步骤（仅 fallback 时执行）
+
+只有 SignPath 拒绝 QCut 后才执行这一节。
+
+1. 用 Quriosity 的组织账号登录 [Azure 门户](https://portal.azure.com)。
+2. 在支持 Trusted Signing 的区域（East US、West Central US 等）创建
+   **Trusted Signing Account**。
+3. 创建 **Certificate Profile**，类型选 **Public Trust → Public Trust
+   Identity Validation**。
+4. 向微软提交身份验证材料。**1–7 天。**
+5. 记下 `electron-builder` 需要的几个值：
+   - Endpoint（例如 `https://eus.codesigning.azure.net/`）
+   - Code Signing Account Name
+   - Certificate Profile Name
+   - Publisher Name（subject CN，会在 `Get-AuthenticodeSignature` 里显示）
+6. 创建一个**服务主体**，授予 `Trusted Signing Certificate Profile
+   Signer` 角色。记下：
    - `AZURE_TENANT_ID`
    - `AZURE_CLIENT_ID`
-   - `AZURE_CLIENT_SECRET`（或者用 OIDC 联邦身份 — 长期更优，见下文）
+   - `AZURE_CLIENT_SECRET`（或用 OIDC 联邦身份 — 长期更优）
 
-## 长期优化：用 OIDC 联邦身份替代客户端密钥
+## 长期优化：用 OIDC 联邦身份替代客户端密钥（Azure 路径）
 
-要降低长期维护成本，建议给服务主体配置**联邦凭据 (federated credential)**，
-让 GitHub Actions 通过 OIDC 认证，这样 GitHub Secret 里就完全不用存
-`AZURE_CLIENT_SECRET`。这是基本流程跑通后的加固任务，跟踪在
+如果最终走 Azure 路径，建议给服务主体配置**联邦凭据**，让 GitHub
+Actions 通过 OIDC 认证，GitHub Secret 里完全不存
+`AZURE_CLIENT_SECRET`。跟踪在
 [`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-后续加固单独跟踪)。
 
 ## 续期
 
-Trusted Signing 的 certificate profile 会自动轮换证书，没有年度续期任务。
-**Trusted Signing Account 本身**按月计费，是普通 Azure 资源 — 在订阅里
-设置一个账单告警就好。
+- **SignPath Foundation**：证书自动轮换，只要项目保持开源 + 活跃就
+  永久免费。
+- **Azure Trusted Signing**：profile 自动轮换；Trusted Signing Account
+  按月计费，是普通 Azure 资源 — 在订阅里设个账单告警。

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
@@ -1,0 +1,87 @@
+# 代码签名证书选型
+
+这就是用户提到的"license"。Authenticode 签名必须用商用证书，
+自签证书没法满足 SmartScreen。
+
+## 一句话推荐
+
+**Azure Trusted Signing — Public Trust 身份**。约 USD 10/月。
+最适合 CI 驱动的 Electron 发布流水线。issue #289 推荐的也是这条路。
+
+## 对比表
+
+| 厂商 / 产品 | 价格（USD/年） | SmartScreen 暖机 | CI 友好？ | 验证方式 | 备注 |
+|------------|----------------|-------------------|-----------|----------|------|
+| **Azure Trusted Signing**（Public Trust） | ~$120（$10/月） | 普通（信誉随时间累积） | ✅ 通过 `azureSignOptions` 原生支持 | 组织或个人 | **推荐**。云端密钥，无 HSM，微软签发。 |
+| **Azure Trusted Signing**（Private Trust） | ~$120 | 不适用（仅内网） | ✅ | 组织 | 没用 — Private Trust 是给单租户内部业务系统用的。 |
+| **DigiCert OV** | $400–600 | 慢（数周到数月） | ⚠️ USB 令牌或 KSP | 组织 | 传统方案。OV = 组织验证。 |
+| **DigiCert EV** | $600–800 | **立即**有 SmartScreen 信誉 | ⚠️ 仅硬件令牌 / 云 HSM | 严格组织验证 | 用户体验最好，CI 集成最难。EV 私钥必须放在 FIPS HSM 里。 |
+| **Sectigo OV** | $200–400 | 慢 | ⚠️ 令牌 / KSP | 组织 | 便宜的 OV 选项。 |
+| **Sectigo EV** | $400–600 | 立即 | ⚠️ HSM | 严格 | 便宜的 EV 选项。 |
+| **SSL.com EV（eSigner）** | $300–500 | 立即 | ✅ 通过 REST API 用云 HSM | 严格 | 如果非 EV 不可，这个折中方案不错。 |
+| **GlobalSign OV/EV** | $250–700 | 慢 / 立即 | ⚠️ / ✅ | 组织 / 严格 | 与 DigiCert 差不多。 |
+| **自签证书** | $0 | 永远不被信任 | ✅ | 无 | **解决不了问题**，列在这里只是为了显式排除。 |
+
+## 为什么 QCut 选 Azure Trusted Signing
+
+1. **不用 USB 硬件令牌** — 硬件令牌没法插进 GitHub-hosted 的 Windows
+   runner。要用就得寄到自托管 runner（运维负担大），或者用云 HSM。
+   Trusted Signing 默认就是云 HSM。
+2. **`electron-builder` 一等支持** — `azureSignOptions` 有官方文档和
+   完整测试。
+3. **价格便宜** — 每月 10 美金远低于 DigiCert/Sectigo OV 的 400+/年，
+   更比 EV 的成本低很多。
+4. **微软直签** — 由微软根证书签发，SmartScreen 显示的发布者字符串
+   不会有第三方 CA 链相关的奇怪问题。
+5. **与 issue 一致** — issue #289 直接推荐了这条路线，跟 reporter 的
+   思路保持一致。
+
+## 什么时候考虑升级到 EV
+
+EV 证书带来**立即生效**的 SmartScreen 信誉。下面情况下值得升级：
+
+- Trusted Signing 的初始版本下载量超过 1000 后还是会触发"不常见的应用"
+  警告；并且
+- 这些警告确实导致安装转化下降（需要"下载 → 首次启动"的 telemetry
+  数据来证实）。
+
+如果将来要走 EV，**SSL.com eSigner** 是推荐供应商，因为它提供云签名
+REST API，不用自托管 runner 插 USB 令牌就能替换 `azureSignOptions`。
+
+## 采购步骤（Azure Trusted Signing）
+
+下面是工程子任务开始之前需要做的人工操作。
+
+1. 用 Quriosity 的组织账号登录
+   [Azure 门户](https://portal.azure.com)。
+2. 在支持 Trusted Signing 的区域（East US、West Central US 等）创建一个
+   **Trusted Signing Account** 资源。
+3. 创建一个 **Certificate Profile**，类型选 **Public Trust → Public Trust
+   Identity Validation**（组织证书）或 **Public Trust Individual
+   Validation**（个人证书）。
+4. 向微软提交身份验证材料。**这一步要 1–7 天**，要早做。
+5. 验证通过后，记下 `electron-builder` 需要的几个值：
+   - **Endpoint** — 例如 `https://eus.codesigning.azure.net/`
+   - **Code Signing Account Name** — 步骤 2 里 Trusted Signing 资源名。
+   - **Certificate Profile Name** — 步骤 3 里创建的 profile 名。
+   - **Publisher Name** — 准确的证书 subject CN，会在
+     `Get-AuthenticodeSignature` 里显示。必须与 Azure 颁发的证书 subject
+     完全一致。
+6. 创建一个**服务主体 (service principal)**，给它授予 Trusted Signing
+   资源上的 `Trusted Signing Certificate Profile Signer` 角色。记下：
+   - `AZURE_TENANT_ID`
+   - `AZURE_CLIENT_ID`
+   - `AZURE_CLIENT_SECRET`（或者用 OIDC 联邦身份 — 长期更优，见下文）
+
+## 长期优化：用 OIDC 联邦身份替代客户端密钥
+
+要降低长期维护成本，建议给服务主体配置**联邦凭据 (federated credential)**，
+让 GitHub Actions 通过 OIDC 认证，这样 GitHub Secret 里就完全不用存
+`AZURE_CLIENT_SECRET`。这是基本流程跑通后的加固任务，跟踪在
+[`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-后续加固单独跟踪)。
+
+## 续期
+
+Trusted Signing 的 certificate profile 会自动轮换证书，没有年度续期任务。
+**Trusted Signing Account 本身**按月计费，是普通 Azure 资源 — 在订阅里
+设置一个账单告警就好。

--- a/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md
@@ -1,124 +1,140 @@
 # 代码签名证书选型
 
-这就是用户提到的"license"。Authenticode 签名必须用受信任 CA 颁发的证书，
-自签证书没法满足 SmartScreen。
-
-> **重要背景（2026-04-25 通过看代码确认）：**
-> `qcut/LICENSE` 是 MIT 类许可证（"Permission is hereby granted, free of
-> charge…"），`qcut/package.json:308` 把自己描述成 "Open-source AI video
-> editor"。两者都满足 **SignPath Foundation** 免费签名计划的资格。本文档
-> 第一版漏了这条 — 现修正。
-
 ## 一句话推荐
 
-1. **先申请 [SignPath Foundation](https://signpath.io/foundation/) — 对开源项目免费，QCut 完全符合资格。** 审批一般 1–2 周。
-2. **如果 SignPath 拒绝（开源项目极少被拒，但有可能） → 退到 Azure Trusted Signing — Public Trust 身份，约 USD 10/月。**
+**[Certum SimplySign Standard Code Signing](https://shop.certum.eu/standard-code-signing-in-cloud.html) — Organization 席位，约 USD 200/年（€189/年）。**
 
-我们故意**不**推荐 v1 走 DigiCert / Sectigo OV/EV。原因见下文。
+QCut/Quriosity 资格情况：
+- ✅ 澳洲可买
+- ✅ 没有公司年限要求
+- ✅ 云签名（不需要 USB token）
+- ⚠️ 每次签名都需要在 SimplySign 手机 App 上点确认 — 半手工，**不能完全自动化 CI**。详见 [IMPLEMENTATION.zh-CN.md §架构决策](IMPLEMENTATION.zh-CN.md#架构决策签名在哪里发生)
 
-## 行业对比
+如果完全自动化 CI 比省 ~$50/年更重要：**备选：SSL.com eSigner OV — 约 USD 250/年，REST API，全自动化。**
 
-| 厂商 / 产品 | 价格（USD/年） | 开源资格？ | SmartScreen 暖机 | CI 友好？ | 验证方式 | 备注 |
-|------------|----------------|------------|-------------------|-----------|----------|------|
-| **SignPath Foundation** | **$0** | ✅ 必须 | 普通 | ✅ 官方 GitHub Action | 人工开源认证 | **QCut 推荐方案。** Blender、OBS Studio、Inkscape、Krita、GIMP、KeePass、Notepad++、Audacity、ImHex 都用它。 |
-| **Azure Trusted Signing**（Public Trust） | ~$120（$10/月） | 不适用 | 普通 | ✅ 通过 `azureSignOptions` 原生支持 | 组织或个人 | 推荐的 fallback。 |
-| **DigiCert OV** | $400–600 | 否 | 慢（数周到数月） | ⚠️ USB 令牌或 KSP | 组织 | 传统方案，CI 不友好。 |
-| **DigiCert EV** | $600–800 | 否 | **立即** | ⚠️ 仅硬件令牌 / 云 HSM | 严格 | 用户体验最好，CI 集成最难。 |
-| **Sectigo OV** | $200–400 | 否 | 慢 | ⚠️ 令牌 / KSP | 组织 | 便宜的传统方案。 |
-| **Sectigo EV** | $400–600 | 否 | 立即 | ⚠️ HSM | 严格 | 便宜的 EV。 |
-| **SSL.com EV（eSigner）** | $300–500 | 否 | 立即 | ✅ 通过 REST API 用云 HSM | 严格 | EV 里 CI 集成最好的。 |
-| **自签证书** | $0 | — | 永远不被信任 | ✅ | 无 | **解决不了问题。** |
+## 其它路径为什么被排除
 
-## 为什么 QCut 选 SignPath Foundation
+### ❌ Azure Trusted Signing（Microsoft Artifact Signing）
 
-1. **QCut 完全符合资格。** MIT 许可证 + 公开 GitHub 仓库 + CI 驱动构建 =
-   完美贴合 SignPath Foundation 的资格画像。证据已在仓库里：
-   - `qcut/LICENSE` — MIT
-   - `qcut/.github/workflows/release.yml` — CI 构建链
-   - `qcut/package.json:308` — 自描述为 "Open-source AI video editor"
-2. **$0 vs $120/年。** 项目长期能省下持续支出。
-3. **行业验证过。** 几乎所有发布签名 Windows 构建的主要开源桌面应用都
-   用 SignPath Foundation：Blender、OBS Studio、Inkscape、Krita、GIMP、
-   KeePass、Notepad++、Audacity、ImHex 等。风险画像很清楚。
-4. **GitHub Actions 一等集成。** 官方提供
-   `signpath/github-action-submit-signing-request@v1`。
-5. **唯一的卡点是资格** — 实现复杂度跟 Azure 方案差不多。
+两个**独立**的拦路石：
 
-## 为什么 Azure Trusted Signing 是合适的 fallback
+1. **国家资格**。微软 2026-01 官方 FAQ：*"For Public Trust certificates, Artifact Signing is currently available to organizations in the USA, Canada, the European Union, and the United Kingdom."* 澳洲不在名单。
+2. **公司年限**。微软要求 *"at least three years of verifiable history"*。Quriosity 注册于 2024-06-10，要到 2027-06-10 才符合。
 
-如果 SignPath 因为构建可复现性、治理或活跃度等原因拒绝 QCut，
-Azure Trusted Signing 仍然是次优解：
+微软 Q&A 里明确说**没有 exception process**。来源：[Microsoft Artifact Signing FAQ](https://learn.microsoft.com/en-us/azure/artifact-signing/faq)。
 
-1. **不用硬件令牌** — 云 HSM，能在 GitHub-hosted Windows runner 上跑。
-2. **`electron-builder` 一等支持**，通过 `azureSignOptions`。
-3. **商业方案里最便宜** — $10/月 比 DigiCert/Sectigo 便宜 $300+/年。
-4. **微软直签** — 由微软根证书签发。
+### ❌ SignPath Foundation（开源免费）
 
-## 为什么 v1 跳过 DigiCert / Sectigo / EV
+要求项目持续保持 OSI 批准的开源许可证。QCut 之后可能闭源，SignPath
+Foundation 资格不能延续到闭源项目。
 
-- **OV 证书** — 必须把 USB 令牌寄到构建机，或额外付费用 KSP 托管签名
-  服务。对 CI 驱动的开源项目来说运维很麻烦。
-- **EV 证书** — 立即有 SmartScreen 信誉，但贵 4–8 倍而且必须用 FIPS
-  HSM。只有在已经签名后**仍然**有信誉问题时再考虑。
+### ❌ SSL.com EV / DigiCert EV
 
-## SignPath Foundation：怎么申请
+2024 年之前，EV 证书有"立即获得 SmartScreen 信誉"的特权 — EV 签名的
+程序首次下载也不弹警告。**微软 2024 年取消了这个特权**，更新了
+Trusted Root Program 要求。
 
-1. **确认资格：**
-   - OSI 批准的许可证（MIT ✅，见 `qcut/LICENSE`）。
-   - 公开源代码仓库（✅，GitHub 上）。
-   - CI 驱动构建（✅，`qcut/.github/workflows/release.yml`）。
-   - 活跃开发（✅，master 上有近期提交）。
-2. **去 https://signpath.io/foundation/ 提交申请。**
-3. **提供资料：**
-   - 项目名：QCut
-   - 仓库 URL：https://github.com/Quriosity-agent/qcut
-   - 许可证位置：`qcut/LICENSE`（MIT）
-   - 构建流水线位置：`qcut/.github/workflows/release.yml`
-   - 维护者联系方式（例如 `support@qcut.app`，已在
-     `qcut/package.json:290` 出现）
-4. **等 1–2 周审核。** SignPath 可能追问构建可复现性、二进制信任链、
-   发布频率等问题。
-5. **批准后会拿到：**
-   - Organization ID（UUID）。
-   - Project slug（例如 `qcut`）。
-   - Signing policy slug（例如 `release-signing`）。
-   - Artifact configuration slug（例如 `qcut-installer`）。
-   - API Token — 存进 GitHub 仓库 secret `SIGNPATH_API_TOKEN`。
+到 2026 年，OV 和 EV 在 SmartScreen 层面**功能完全一样** — 都要靠
+下载量积累信誉。EV 多花 2 倍价钱已经不划算。
 
-SignPath 路径的实现细节见
-[`IMPLEMENTATION.zh-CN.md` Path A](IMPLEMENTATION.zh-CN.md#path-a-signpath推荐)。
+来源：[Reputation with OV certificates and are EV certificates still the better option? — Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/417016/reputation-with-ov-certificates-and-are-ev-certifi)。
 
-## Azure Trusted Signing：采购步骤（仅 fallback 时执行）
+### ❌ Sectigo / DigiCert OV 通过传统分销商（~$170–230/年）
 
-只有 SignPath 拒绝 QCut 后才执行这一节。
+纸面便宜，但多数还是要用 USB 硬件令牌。USB token 没法插到
+GitHub-hosted Windows runner 上，自托管 + 寄送/管理 token 的运维成本
+比省下来的证书钱多。
 
-1. 用 Quriosity 的组织账号登录 [Azure 门户](https://portal.azure.com)。
-2. 在支持 Trusted Signing 的区域（East US、West Central US 等）创建
-   **Trusted Signing Account**。
-3. 创建 **Certificate Profile**，类型选 **Public Trust → Public Trust
-   Identity Validation**。
-4. 向微软提交身份验证材料。**1–7 天。**
-5. 记下 `electron-builder` 需要的几个值：
-   - Endpoint（例如 `https://eus.codesigning.azure.net/`）
-   - Code Signing Account Name
-   - Certificate Profile Name
-   - Publisher Name（subject CN，会在 `Get-AuthenticodeSignature` 里显示）
-6. 创建一个**服务主体**，授予 `Trusted Signing Certificate Profile
-   Signer` 角色。记下：
-   - `AZURE_TENANT_ID`
-   - `AZURE_CLIENT_ID`
-   - `AZURE_CLIENT_SECRET`（或用 OIDC 联邦身份 — 长期更优）
+云签名版本（DigiCert KeyLocker、SSL.com eSigner）的 OV 起价 $400+，
+比 Certum 贵明显。
 
-## 长期优化：用 OIDC 联邦身份替代客户端密钥（Azure 路径）
+## 行业对比（2026-04）
 
-如果最终走 Azure 路径，建议给服务主体配置**联邦凭据**，让 GitHub
-Actions 通过 OIDC 认证，GitHub Secret 里完全不存
-`AZURE_CLIENT_SECRET`。跟踪在
-[`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-后续加固单独跟踪)。
+| 厂商 | 价格（USD/年） | CI 自动化 | 开源资格 | 澳洲可买 | 新公司可买 | 备注 |
+|------|---------------|-----------|---------|---------|----------|------|
+| **Certum SimplySign Standard** | **~$200** | ⚠️ 手机确认 | ✅ ✅ | ✅ | ✅ | **QCut 推荐**。Inkdrop 等大量 indie Electron 项目都用。 |
+| **SSL.com eSigner OV** | ~$200–250 | ✅ REST API | ✅ ✅ | ✅ | ✅ | CI 集成更好，价格类似。 |
+| SSL.com eSigner EV | ~$350–500 | ✅ | ✅ ✅ | ✅ | ✅ | EV 自 2024 起不再值溢价。 |
+| Sectigo OV（分销商） | $170–230 | ⚠️ USB token | ✅ ✅ | ✅ | ✅ | 不友好 GitHub-hosted CI。 |
+| DigiCert OV/EV | $400–800 | ⚠️ USB / KSP | ✅ ✅ | ✅ | ✅ | 贵，没必要。 |
+| Azure Artifact Signing | $120 | ✅ | 不适用 | ❌ | ❌ | **Quriosity 不能买。** |
+| SignPath Foundation | $0 | ✅ | 仅开源 | ✅ | ✅ | **绑死开源。** |
+
+## 签了实际改变什么（vs. 没改变什么）
+
+诚实披露 — 不要被供应商话术骗，签名解决一些事，但不解决另一些。
+
+### ✅ 立即生效（签完当天）
+
+- **UAC 弹窗**：黄色"Unknown publisher" → 蓝色"Verified publisher: Quriosity Pty Ltd"
+- **企业 IT 策略**禁未签名 .exe 的，QCut 现在能装
+- **杀毒软件误报率**显著下降（卡巴斯基、360、火绒、Avast、Defender 启发式）
+- **浏览器下载警告**减少
+- **winget / Chocolatey / scoop** 包管理器愿意收 QCut
+- **自动更新完整性**：`electron-updater` 能校验每个更新都来自同一发布者
+
+### 📈 渐进生效（积累几百到几千次安装）
+
+- **SmartScreen "Windows protected your PC"** 警告频率降低，最终消失
+- 信誉按文件 hash 积累，**也**慢慢按发布者积累
+
+### ❌ 不会改变
+
+- **Mark of the Web (MOTW)**：Windows 仍会给下载文件打标记，**这是浏览器加的，跟签名无关**。用户可能仍会看到"Open File - Security Warning"对话框。
+- **前几百次安装仍可能触发 SmartScreen** — 但有验证过的发布者名（"Quriosity Pty Ltd"）显示，转化率显著提升。
+- **用户对陌生品牌的不信任**：签名只能证明"是 Quriosity"，不能证明"Quriosity 值得信任"。新公司还是会被看作新公司。
+
+## SmartScreen 信誉的现实（2026）
+
+**关键披露：** SmartScreen 信誉是按**文件 hash** 算的，不是按证书也不是按发布者。每次发新版（v2026.5.0 → v2026.6.0），新 `.exe` 哈希不一样，**信誉重头积累**，无视过去发了多少签名版本。
+
+实际意味着：
+
+- QCut v2026.6.0 第一个下载用户**仍会看到** SmartScreen 警告（即使我们签了名）。
+- 信誉随用户安装且无负面反馈而增长。
+- ~几百到几千次无问题安装后，警告停止。
+- 频繁版本更新会重置信誉 — 发布节奏会影响这个。
+
+### 缓解策略
+
+- 不要为每个小改动发新版 — 批量打包成版本化发布。
+- 鼓励用户保留下载缓存（同一 hash 重复运行能积累信誉）。
+- 长期稳定的发布者，新 hash 也会被宽松扫描。
+- 在 Windows 下载页加一段说明，告诉用户新版本警告是预期的。
+
+## 价格趋势（2026 行业现状）
+
+- **2026 年 3 月起：** CA/Browser Forum 把代码签名证书最长有效期从 39 个月缩短到 **460 天（约 15 个月）**。从那以后所有签发的证书都受这个限制。**续期变成年度，不再有多年期。**
+- **EV 证书在 2024 年失去了独有的"SmartScreen 立即信誉"特权。** OV 和 EV 现在 SmartScreen 行为完全一致。
+- **Azure Trusted Signing 在 2025 年收紧资格** — 先窄到美/加（要 3 年公司历史），后稍微扩到 EU/UK。澳洲等地至 2026-Q1 仍被排除。
+- **云 HSM 签名**（不要 USB token）成为 indie 默认选择。Certum SimplySign、SSL.com eSigner、DigiCert KeyLocker 都支持。
+
+## Certum SimplySign：怎么申请
+
+1. **下单** https://shop.certum.eu/standard-code-signing-in-cloud.html
+   - 类型：Standard Code Signing **in Cloud**（**不**是 USB 版）
+   - 期限：1 年（2026 CA/B 规则下最长就 15 个月）
+   - 验证：**Organization**（证书 subject = "Quriosity Pty Ltd"）
+2. **提交身份材料** — Certum 会邮件列出清单。常见包括：
+   - Quriosity ASIC 公司注册（你已有）
+   - D-U-N-S Number 893394655（明显加快验证）
+   - Donghao 护照扫描 + 居住地证明（用于 Authorized Representative 验证）
+   - Quriosity Pty Ltd 地址证明（452 Flinders St 的租约或近期账单）
+3. **身份验证。** Certum 审核 3–7 个工作日（已有 D-U-N-S 会更快）。
+4. **激活 SimplySign 账号。** Certum 发激活链接 → 在 Donghao 手机装 SimplySign App → 在他的 Mac/Windows 机器装桌面签名工具。
+5. **签发的证书**存在 Certum 云 HSM 里。每次 `signtool sign` 操作都会让 Donghao 手机弹窗确认。
+
+针对这套凭据的工程实现见 [`IMPLEMENTATION.zh-CN.md`](IMPLEMENTATION.zh-CN.md)。
 
 ## 续期
 
-- **SignPath Foundation**：证书自动轮换，只要项目保持开源 + 活跃就
-  永久免费。
-- **Azure Trusted Signing**：profile 自动轮换；Trusted Signing Account
-  按月计费，是普通 Azure 资源 — 在订阅里设个账单告警。
+- **每年**（CA/B 强制 15 个月上限）。
+- 提前 60 天设日历提醒。
+- 续期**不**保留 SmartScreen 信誉（信誉本来就是按文件 hash 算的；续期也不会改变已发出去的旧版本，那些保留它们自己的信誉）。
+
+## 未来迁移路径
+
+如果 Certum 的手机确认变成瓶颈：
+- **SSL.com eSigner OV**（每年多 ~$50） — REST API 全自动化 CI 签名。
+- **等到 Azure 资格满足** 2027-06（Quriosity 满 3 年）— 还要看微软是否扩大国家名单到澳洲。
+- **以后再升 EV** — 如果 SmartScreen 信誉死活积累不上去（不太可能，因为 EV 现在也不立即了）。

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
@@ -1,156 +1,191 @@
 # Windows Code Signing — Documentation Tasks
 
-To meet the issue's "Documentation explains required signing secrets and
-release setup" criterion, the following docs land alongside the code
-changes. These are written for the **maintainer** (release operator),
-not end users.
+Maintainer-facing docs to land alongside the code, plus user-facing
+download-page copy to mitigate first-run SmartScreen friction.
 
 ## New file: `qcut/docs/setup/windows-code-signing.md`
 
-**Audience:** anyone bringing up a new release runner, debugging a failing
-release, or rotating signing credentials.
-
-**Path-aware:** the file should cover both Path A (SignPath Foundation,
-preferred) and Path B (Azure Trusted Signing, fallback). The deployed
-release stack uses exactly one — keep both sections so a future
-maintainer can switch paths if eligibility changes.
-
-### Path A — SignPath Foundation secrets
-
-Required GitHub Actions secrets / variables:
-
-| Name | Type | Source |
-|------|------|--------|
-| SIGNPATH_API_TOKEN | secret | SignPath user settings → API tokens |
-| SIGNPATH_ORGANIZATION_ID | variable | SignPath organization page (UUID) |
-| SIGNPATH_PROJECT_SLUG | variable | SignPath project page |
-| SIGNPATH_SIGNING_POLICY_SLUG | variable | SignPath project → Policies |
-| SIGNPATH_ARTIFACT_SLUG | variable | SignPath project → Artifact configurations |
-| WINDOWS_PUBLISHER_NAME | variable | Subject CN issued by SignPath |
-
-Local signing is **not supported** by SignPath Foundation — signing
-happens server-side via the GitHub Action. Maintainers needing a signed
-local build should ask SignPath about a manual signing flow or just use
-the CI artifact.
-
-### Path B — Azure Trusted Signing secrets
+**Audience:** anyone bringing up a new release machine, debugging a
+failing release, or rotating Certum credentials.
 
 **Outline:**
 
 ```markdown
 # Windows Code Signing — Setup Guide
 
-## Prerequisites
-- Azure subscription owned by Quriosity.
-- A Trusted Signing Account + Certificate Profile (see
-  docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md for the procurement
-  walkthrough — once procurement is done, that doc becomes a historical
-  record and this file is the operational reference).
-- A service principal with the
-  `Trusted Signing Certificate Profile Signer` role.
+## Certificate Vendor
+- Provider: **Certum SimplySign** (https://shop.certum.eu/)
+- Product: Standard Code Signing in Cloud (NOT the USB token version)
+- Tier: Organization
+- Cert subject: `Quriosity Pty Ltd`
+- Cost: ~USD 200/year (€189/year). Annual renewal mandatory under 2026 CA/B Forum rules (max 460-day validity).
 
-## GitHub Actions secrets
-The following repository secrets must exist:
+## GitHub repo settings
+We do NOT store any signing credentials in GitHub Actions. Signing happens
+on a maintainer's local Windows machine after CI builds an unsigned
+artifact. See `docs/task/windows-code-signing/IMPLEMENTATION.md` for the
+architecture rationale.
 
-| Secret | Source | Example |
-|--------|--------|---------|
-| AZURE_TENANT_ID | Azure AD tenant of the SP | 00000000-0000-0000-0000-000000000000 |
-| AZURE_CLIENT_ID | Service principal app ID | 00000000-0000-0000-0000-000000000000 |
-| AZURE_CLIENT_SECRET | Service principal client secret | (rotate every 6 months) |
-| AZURE_TRUSTED_SIGNING_ENDPOINT | Region endpoint | https://eus.codesigning.azure.net/ |
-| AZURE_TRUSTED_SIGNING_ACCOUNT | Trusted Signing Account name | qcut-signing |
-| AZURE_CERTIFICATE_PROFILE | Profile name | qcut-public-trust |
-| WINDOWS_PUBLISHER_NAME | Subject CN of the issued cert | Quriosity Pty Ltd |
+The only Windows-related repo setting:
 
-## Local signed builds
-Maintainers with access to the Azure SP can produce a signed installer
-locally:
+| Name | Type | Value |
+|------|------|-------|
+| WINDOWS_PUBLISHER_NAME | variable | "Quriosity Pty Ltd" — used by `verify:win-signature` to assert the cert subject |
 
-\`\`\`powershell
-$env:AZURE_TENANT_ID="..."
-$env:AZURE_CLIENT_ID="..."
-$env:AZURE_CLIENT_SECRET="..."
-$env:AZURE_TRUSTED_SIGNING_ENDPOINT="..."
-$env:AZURE_TRUSTED_SIGNING_ACCOUNT="..."
-$env:AZURE_CERTIFICATE_PROFILE="..."
-$env:WINDOWS_PUBLISHER_NAME="..."
-cd qcut
-bun run dist:win:release
-\`\`\`
+## Local signing machine setup
+On the dedicated Windows signing machine (or a Windows VM if maintainer is on macOS):
 
-For an unsigned local build (no Azure access required), use:
+1. **Install SimplySign mobile app** on phone (iOS/Android) and pair with Certum account.
+2. **Install SimplySign desktop signing tool** from https://www.certum.eu/en/cert_expert_simply_sign/.
+3. **Install Windows SDK signtool** via `winget install --id Microsoft.WindowsSDK`.
+4. **Authenticate desktop tool** by scanning QR code on phone.
+5. **Find the cert SHA1 thumbprint** in Keychain Access / certutil:
+   \`\`\`powershell
+   certutil -store -user My
+   \`\`\`
+   Look for "Developer ID Application: Quriosity Pty Ltd" — copy the SHA1 thumbprint (40 hex chars).
+6. **Set environment variable**:
+   \`\`\`powershell
+   [Environment]::SetEnvironmentVariable("QCUT_WIN_CERT_THUMBPRINT", "<thumbprint>", "User")
+   \`\`\`
+
+## Per-release signing workflow
+
 \`\`\`bash
-bun run dist:win:unsigned
+# 1. Wait for CI to finish (build-windows job)
+# 2. Download the windows-build-unsigned artifact
+# 3. Place QCut*Setup*.exe and latest.yml into qcut/dist-electron/
+cd qcut
+bun run sign:win
+# 4. Approve signing on your phone (SimplySign app push notification, ~30 sec)
+# 5. Verify
+bun run verify:win-signature
+# 6. Manually upload signed .exe + latest.yml to the GitHub Release page
 \`\`\`
 
 ## Verifying a signed installer
+
 \`\`\`powershell
-signtool verify /pa /v .\dist-electron\QCut*Setup*.exe
-Get-AuthenticodeSignature .\dist-electron\QCut*Setup*.exe
+# On any Windows machine:
+signtool verify /pa /v .\QCut*Setup*.exe
+Get-AuthenticodeSignature .\QCut*Setup*.exe
 \`\`\`
 
+Expected:
+- `signtool verify` exits 0 with "Successfully verified".
+- `Get-AuthenticodeSignature` reports `Status: Valid` and `SignerCertificate.Subject` containing "CN=Quriosity Pty Ltd".
+
 ## Troubleshooting
-- "Sign error 0x80070002" → Azure SP missing role, re-run role assignment.
-- "Publisher mismatch" from verify-windows-signature.ts → WINDOWS_PUBLISHER_NAME
-  drifted from the cert subject; update the secret.
-- Workflow hangs on signing for >5 min → Trusted Signing endpoint outage,
-  check Azure status page; do not bypass signing.
 
-## Rotating the service principal secret
-1. Generate a new client secret in Azure portal (App registrations →
-   <SP name> → Certificates & secrets).
-2. Update `AZURE_CLIENT_SECRET` in repo secrets.
-3. Trigger a `*-rc.N` release tag and confirm the workflow succeeds.
-4. Delete the old client secret in Azure portal.
+### `signtool: error 0x80092004 — Cannot find object or property`
+The cert thumbprint is not findable in the user's certificate store. Check:
+- SimplySign desktop tool is running and authenticated (the cert appears only when the tool exposes the Cloud HSM identity).
+- `QCUT_WIN_CERT_THUMBPRINT` matches the actual thumbprint from `certutil -store -user My`.
 
-## Renewal
-Public Trust certificate profiles auto-rotate; no manual renewal. Set a
-billing alert in Azure for the Trusted Signing resource.
+### Phone never receives push notification
+- SimplySign app needs internet on phone.
+- Re-authenticate the desktop tool — sometimes the SimplySign session expires after hours of inactivity.
+
+### `signtool sign` succeeds but `signtool verify` fails
+- Timestamp service may have failed silently. Re-sign with a different `/tr` URL (alternatives: `http://timestamp.digicert.com`, `http://timestamp.sectigo.com`).
+
+### SmartScreen still warns users on signed installer
+This is **expected** for the first hundreds-thousands of downloads of a new build. SmartScreen reputation is per file hash and accumulates over time. See `docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md` § "SmartScreen reputation reality" for full context.
+
+## Rotating credentials
+
+### Cert renewal (annual)
+1. Pay renewal at shop.certum.eu before expiry.
+2. Re-do identity validation (Certum may shortcut this if nothing changed).
+3. New cert is issued under same SimplySign account; new thumbprint.
+4. Update `QCUT_WIN_CERT_THUMBPRINT` on signing machine.
+5. Old signed builds remain valid (timestamp counter-signed).
+
+### Adding a second team member
+1. Add new user under Certum organization.
+2. They install SimplySign app + desktop tool with their own credentials.
+3. Both Donghao and the new member can now approve signings — useful for vacation coverage.
+
+## Renewal calendar
+Set a calendar reminder **60 days before cert expiry**. The Certum dashboard shows expiry date.
 ```
 
 ## Modified: `qcut/docs/release.md`
 
-If this file does not exist yet, create it. Add a section near the top:
+Add (or merge with the macOS signing section):
 
 ```markdown
 ## Prerequisites for Windows releases
-Windows release builds **must** be Authenticode-signed. The release
-workflow will fail if signing is misconfigured; this is intentional —
-do **not** bypass signing to push a release. See
-`docs/setup/windows-code-signing.md` for setup and troubleshooting.
+Windows releases must be signed by Quriosity's Certum-issued Authenticode
+certificate. **Signing is a manual step** that happens on a maintainer's
+local machine after CI builds the unsigned artifact — see
+`docs/setup/windows-code-signing.md` for the per-release workflow.
+
+This is intentional: Certum SimplySign requires phone-based approval per
+signing operation, which cannot be automated in GitHub Actions. The
+tradeoff was deliberate (cost vs. automation); see
+`docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md`.
 ```
 
 ## Modified: `qcut/CLAUDE.md`
 
-Append a small section under "Architecture Guidelines → DON'T":
+Append under "Architecture Guidelines → DON'T":
 
 ```markdown
-- Disable Windows code signing in the release workflow (`forceCodeSigning=false`).
-  See `docs/setup/windows-code-signing.md`. Local-dev unsigned builds use
-  `bun run dist:win:unsigned`.
+- Auto-attach unsigned Windows `.exe` to GitHub Releases. Windows artifacts
+  must be signed manually before publishing — see
+  `docs/setup/windows-code-signing.md`. The Windows job intentionally
+  produces a `windows-build-unsigned` artifact, NOT a published Release file.
 ```
 
-This makes the rule visible to future Claude Code sessions so we do not
-silently regress.
+This makes the constraint visible to future Claude Code sessions.
 
-## Issue / PR template note (optional, low priority)
+## Windows download-page user-facing copy
 
-If `qcut/.github/PULL_REQUEST_TEMPLATE.md` exists, add a checkbox:
+QCut's Windows download page (whatever route, e.g. `qcut.app/download`)
+should include this paragraph near the Windows download button. This is
+**user-facing**, written for end users, not maintainers.
 
-```markdown
-- [ ] If touching `release.yml` or `package.json` `build.win`, I have not
-      disabled code signing.
-```
+### English version
 
-Skip if the template does not already exist — do not create one just for
-this.
+> 💡 **First time installing? You may see a Windows security warning.**
+>
+> When you run `QCut.AI.Video.Editor-Setup.exe`, Windows SmartScreen may
+> show "Windows protected your PC" — this is normal for new software
+> versions, even after we've signed our installer.
+>
+> 1. Click **More info** in the warning dialog.
+> 2. Confirm the publisher shown is **Quriosity Pty Ltd** — that's us.
+> 3. Click **Run anyway**.
+>
+> The Windows User Account Control prompt that follows should also show
+> **"Verified publisher: Quriosity Pty Ltd"** — you can safely click Yes.
+
+### Chinese version
+
+> 💡 **首次安装时可能出现 Windows 安全警告。**
+>
+> 运行 `QCut.AI.Video.Editor-Setup.exe` 时，Windows SmartScreen 可能弹
+> "Windows protected your PC" — 这对新版本软件是正常现象，即使我们已签名。
+>
+> 1. 点弹窗里的 **More info（更多信息）**。
+> 2. 确认发布者显示为 **Quriosity Pty Ltd** — 就是我们。
+> 3. 点 **Run anyway（仍然运行）**。
+>
+> 接下来的 Windows 用户账户控制弹窗会显示 **"Verified publisher: Quriosity Pty Ltd"** — 可以放心点"是"。
+
+### Why this copy matters
+
+Without this guidance, the user from the Unblock-File screenshot
+(captured 2026-04 — see conversation history) had to use a separate AI
+agent to figure out PowerShell to install QCut. Each user who hits this
+without guidance is likely to abandon. The copy is free to add and
+immediately reduces abandonment in the SmartScreen-warning window
+(roughly the first ~hundreds of installs after each release).
 
 ## What NOT to document
 
-- **The actual Azure secret values.** Never commit secrets, never include
-  example values that look real.
-- **End-user "this app is signed" messaging.** SmartScreen rendering is
-  Microsoft's surface; we do not control it. Documenting it as a feature
-  invites false promises if MSFT changes the dialog.
-- **A separate user-facing FAQ entry.** The change is invisible-by-design
-  for end users; only release-engineering docs need updates.
+- Actual SHA1 thumbprint of the cert — sensitive, lives only in `QCUT_WIN_CERT_THUMBPRINT` on signing machine and Certum dashboard.
+- Step-by-step "how SmartScreen works internally" — Microsoft's docs cover this.
+- Microsoft Store submission — different cert path, separate task.
+- iOS / mobile distribution — out of scope.

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
@@ -8,7 +8,32 @@ not end users.
 ## New file: `qcut/docs/setup/windows-code-signing.md`
 
 **Audience:** anyone bringing up a new release runner, debugging a failing
-release, or rotating Azure credentials.
+release, or rotating signing credentials.
+
+**Path-aware:** the file should cover both Path A (SignPath Foundation,
+preferred) and Path B (Azure Trusted Signing, fallback). The deployed
+release stack uses exactly one — keep both sections so a future
+maintainer can switch paths if eligibility changes.
+
+### Path A — SignPath Foundation secrets
+
+Required GitHub Actions secrets / variables:
+
+| Name | Type | Source |
+|------|------|--------|
+| SIGNPATH_API_TOKEN | secret | SignPath user settings → API tokens |
+| SIGNPATH_ORGANIZATION_ID | variable | SignPath organization page (UUID) |
+| SIGNPATH_PROJECT_SLUG | variable | SignPath project page |
+| SIGNPATH_SIGNING_POLICY_SLUG | variable | SignPath project → Policies |
+| SIGNPATH_ARTIFACT_SLUG | variable | SignPath project → Artifact configurations |
+| WINDOWS_PUBLISHER_NAME | variable | Subject CN issued by SignPath |
+
+Local signing is **not supported** by SignPath Foundation — signing
+happens server-side via the GitHub Action. Maintainers needing a signed
+local build should ask SignPath about a manual signing flow or just use
+the CI artifact.
+
+### Path B — Azure Trusted Signing secrets
 
 **Outline:**
 

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
@@ -87,7 +87,7 @@ The cert thumbprint is not findable in the user's certificate store. Check:
 - Re-authenticate the desktop tool — sometimes the SimplySign session expires after hours of inactivity.
 
 ### `signtool sign` succeeds but `signtool verify` fails
-- Timestamp service may have failed silently. Re-sign with a different `/tr` URL (alternatives: `http://timestamp.digicert.com`, `http://timestamp.sectigo.com`).
+- Timestamp service may have failed silently. Re-sign with a different `/tr` URL (alternatives: `http://timestamp.digicert.com`, `http://timestamp.sectigo.com` — HTTP-only per vendor specification; DigiCert and Sectigo do not offer HTTPS endpoints for the RFC3161 `/tr` interface, and signtool accepts both for the response-signed timestamp protocol).
 
 ### SmartScreen still warns users on signed installer
 This is **expected** for the first hundreds-thousands of downloads of a new build. SmartScreen reputation is per file hash and accumulates over time. See `docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md` § "SmartScreen reputation reality" for full context.

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
@@ -1,0 +1,131 @@
+# Windows Code Signing — Documentation Tasks
+
+To meet the issue's "Documentation explains required signing secrets and
+release setup" criterion, the following docs land alongside the code
+changes. These are written for the **maintainer** (release operator),
+not end users.
+
+## New file: `qcut/docs/setup/windows-code-signing.md`
+
+**Audience:** anyone bringing up a new release runner, debugging a failing
+release, or rotating Azure credentials.
+
+**Outline:**
+
+```markdown
+# Windows Code Signing — Setup Guide
+
+## Prerequisites
+- Azure subscription owned by Quriosity.
+- A Trusted Signing Account + Certificate Profile (see
+  docs/task/windows-code-signing/CERTIFICATE-OPTIONS.md for the procurement
+  walkthrough — once procurement is done, that doc becomes a historical
+  record and this file is the operational reference).
+- A service principal with the
+  `Trusted Signing Certificate Profile Signer` role.
+
+## GitHub Actions secrets
+The following repository secrets must exist:
+
+| Secret | Source | Example |
+|--------|--------|---------|
+| AZURE_TENANT_ID | Azure AD tenant of the SP | 00000000-0000-0000-0000-000000000000 |
+| AZURE_CLIENT_ID | Service principal app ID | 00000000-0000-0000-0000-000000000000 |
+| AZURE_CLIENT_SECRET | Service principal client secret | (rotate every 6 months) |
+| AZURE_TRUSTED_SIGNING_ENDPOINT | Region endpoint | https://eus.codesigning.azure.net/ |
+| AZURE_TRUSTED_SIGNING_ACCOUNT | Trusted Signing Account name | qcut-signing |
+| AZURE_CERTIFICATE_PROFILE | Profile name | qcut-public-trust |
+| WINDOWS_PUBLISHER_NAME | Subject CN of the issued cert | Quriosity Pty Ltd |
+
+## Local signed builds
+Maintainers with access to the Azure SP can produce a signed installer
+locally:
+
+\`\`\`powershell
+$env:AZURE_TENANT_ID="..."
+$env:AZURE_CLIENT_ID="..."
+$env:AZURE_CLIENT_SECRET="..."
+$env:AZURE_TRUSTED_SIGNING_ENDPOINT="..."
+$env:AZURE_TRUSTED_SIGNING_ACCOUNT="..."
+$env:AZURE_CERTIFICATE_PROFILE="..."
+$env:WINDOWS_PUBLISHER_NAME="..."
+cd qcut
+bun run dist:win:release
+\`\`\`
+
+For an unsigned local build (no Azure access required), use:
+\`\`\`bash
+bun run dist:win:unsigned
+\`\`\`
+
+## Verifying a signed installer
+\`\`\`powershell
+signtool verify /pa /v .\dist-electron\QCut*Setup*.exe
+Get-AuthenticodeSignature .\dist-electron\QCut*Setup*.exe
+\`\`\`
+
+## Troubleshooting
+- "Sign error 0x80070002" → Azure SP missing role, re-run role assignment.
+- "Publisher mismatch" from verify-windows-signature.ts → WINDOWS_PUBLISHER_NAME
+  drifted from the cert subject; update the secret.
+- Workflow hangs on signing for >5 min → Trusted Signing endpoint outage,
+  check Azure status page; do not bypass signing.
+
+## Rotating the service principal secret
+1. Generate a new client secret in Azure portal (App registrations →
+   <SP name> → Certificates & secrets).
+2. Update `AZURE_CLIENT_SECRET` in repo secrets.
+3. Trigger a `*-rc.N` release tag and confirm the workflow succeeds.
+4. Delete the old client secret in Azure portal.
+
+## Renewal
+Public Trust certificate profiles auto-rotate; no manual renewal. Set a
+billing alert in Azure for the Trusted Signing resource.
+```
+
+## Modified: `qcut/docs/release.md`
+
+If this file does not exist yet, create it. Add a section near the top:
+
+```markdown
+## Prerequisites for Windows releases
+Windows release builds **must** be Authenticode-signed. The release
+workflow will fail if signing is misconfigured; this is intentional —
+do **not** bypass signing to push a release. See
+`docs/setup/windows-code-signing.md` for setup and troubleshooting.
+```
+
+## Modified: `qcut/CLAUDE.md`
+
+Append a small section under "Architecture Guidelines → DON'T":
+
+```markdown
+- Disable Windows code signing in the release workflow (`forceCodeSigning=false`).
+  See `docs/setup/windows-code-signing.md`. Local-dev unsigned builds use
+  `bun run dist:win:unsigned`.
+```
+
+This makes the rule visible to future Claude Code sessions so we do not
+silently regress.
+
+## Issue / PR template note (optional, low priority)
+
+If `qcut/.github/PULL_REQUEST_TEMPLATE.md` exists, add a checkbox:
+
+```markdown
+- [ ] If touching `release.yml` or `package.json` `build.win`, I have not
+      disabled code signing.
+```
+
+Skip if the template does not already exist — do not create one just for
+this.
+
+## What NOT to document
+
+- **The actual Azure secret values.** Never commit secrets, never include
+  example values that look real.
+- **End-user "this app is signed" messaging.** SmartScreen rendering is
+  Microsoft's surface; we do not control it. Documenting it as a feature
+  invites false promises if MSFT changes the dialog.
+- **A separate user-facing FAQ entry.** The change is invisible-by-design
+  for end users; only release-engineering docs need updates.

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.md
@@ -39,11 +39,11 @@ On the dedicated Windows signing machine (or a Windows VM if maintainer is on ma
 2. **Install SimplySign desktop signing tool** from https://www.certum.eu/en/cert_expert_simply_sign/.
 3. **Install Windows SDK signtool** via `winget install --id Microsoft.WindowsSDK`.
 4. **Authenticate desktop tool** by scanning QR code on phone.
-5. **Find the cert SHA1 thumbprint** in Keychain Access / certutil:
+5. **Find the cert SHA1 thumbprint** with `certutil`:
    \`\`\`powershell
    certutil -store -user My
    \`\`\`
-   Look for "Developer ID Application: Quriosity Pty Ltd" — copy the SHA1 thumbprint (40 hex chars).
+   Look for the Windows Authenticode code-signing entry whose `Subject` (CN) is `Quriosity Pty Ltd` — copy the SHA1 thumbprint (40 hex chars). (`Developer ID Application` is the Apple naming convention; do not look for it on Windows.)
 6. **Set environment variable**:
    \`\`\`powershell
    [Environment]::SetEnvironmentVariable("QCUT_WIN_CERT_THUMBPRINT", "<thumbprint>", "User")

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
@@ -1,117 +1,127 @@
 # Windows 代码签名 — 文档任务
 
-为了满足 issue 中"文档需说明所需签名机密和发布配置"这一项验收标准，
-下面这些文档要随代码改动一起提交。文档面向**维护者**（执行发布的人），
-不是终端用户。
+随代码一起提交的、面向维护者的文档；以及面向用户的下载页文案，
+缓解首次运行 SmartScreen 摩擦。
 
 ## 新增文件：`qcut/docs/setup/windows-code-signing.md`
 
-**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换签名凭据
-的人。
-
-**路径相关：** 文档要同时覆盖 Path A（SignPath Foundation，首选）
-和 Path B（Azure Trusted Signing，fallback）。线上发布栈只用其中一条，
-但两节都保留，方便将来维护者在资格变化时切换。
-
-### Path A — SignPath Foundation 凭据
-
-需要的 GitHub Actions secret / variable：
-
-| 名称 | 类型 | 来源 |
-|------|------|------|
-| SIGNPATH_API_TOKEN | secret | SignPath 用户设置 → API tokens |
-| SIGNPATH_ORGANIZATION_ID | variable | SignPath 组织页（UUID） |
-| SIGNPATH_PROJECT_SLUG | variable | SignPath 项目页 |
-| SIGNPATH_SIGNING_POLICY_SLUG | variable | SignPath 项目 → Policies |
-| SIGNPATH_ARTIFACT_SLUG | variable | SignPath 项目 → Artifact configurations |
-| WINDOWS_PUBLISHER_NAME | variable | SignPath 颁发的 subject CN |
-
-SignPath Foundation **不支持本地签名** — 签名发生在服务端，通过
-GitHub Action 完成。需要本地签名构建的维护者要么向 SignPath 申请
-人工签名流程，要么直接用 CI 产物。
-
-### Path B — Azure Trusted Signing 凭据
+**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换 Certum
+凭据的人。
 
 **大纲：**
 
 ```markdown
 # Windows 代码签名 — 设置指南
 
-## 前置条件
-- Quriosity 名下的 Azure 订阅。
-- Trusted Signing Account + Certificate Profile（采购流程见
-  docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md；采购完成
-  后那份文档作为历史记录留档，运营时以本文件为准）。
-- 一个被授予 `Trusted Signing Certificate Profile Signer` 角色的服务主体。
+## 证书供应商
+- 提供商：**Certum SimplySign**（https://shop.certum.eu/）
+- 产品：Standard Code Signing in Cloud（**不**是 USB 版）
+- 席位：Organization
+- 证书 subject：`Quriosity Pty Ltd`
+- 价格：约 USD 200/年（€189/年）。2026 CA/B Forum 规则下必须每年续期（最长 460 天有效期）。
 
-## GitHub Actions secret
-仓库下面这些 secret 必须存在：
+## GitHub 仓库设置
+我们**不**在 GitHub Actions 里存任何签名凭据。签名在维护者本地 Windows
+机器上进行（CI 出未签名 artifact 之后）。架构原因见
+`docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md`。
 
-| Secret | 来源 | 示例 |
-|--------|------|------|
-| AZURE_TENANT_ID | 服务主体所在的 Azure AD 租户 | 00000000-0000-0000-0000-000000000000 |
-| AZURE_CLIENT_ID | 服务主体 App ID | 00000000-0000-0000-0000-000000000000 |
-| AZURE_CLIENT_SECRET | 服务主体客户端密钥 | （每 6 个月轮换） |
-| AZURE_TRUSTED_SIGNING_ENDPOINT | 区域端点 | https://eus.codesigning.azure.net/ |
-| AZURE_TRUSTED_SIGNING_ACCOUNT | Trusted Signing Account 名称 | qcut-signing |
-| AZURE_CERTIFICATE_PROFILE | Profile 名称 | qcut-public-trust |
-| WINDOWS_PUBLISHER_NAME | 颁发证书的 Subject CN | Quriosity Pty Ltd |
+唯一的 Windows 相关仓库设置：
 
-## 本地签名构建
-有 Azure 服务主体访问权限的维护者可以本地构建签名安装包：
+| 名称 | 类型 | 内容 |
+|------|------|------|
+| WINDOWS_PUBLISHER_NAME | variable | "Quriosity Pty Ltd" — `verify:win-signature` 用它断言证书 subject |
 
-\`\`\`powershell
-$env:AZURE_TENANT_ID="..."
-$env:AZURE_CLIENT_ID="..."
-$env:AZURE_CLIENT_SECRET="..."
-$env:AZURE_TRUSTED_SIGNING_ENDPOINT="..."
-$env:AZURE_TRUSTED_SIGNING_ACCOUNT="..."
-$env:AZURE_CERTIFICATE_PROFILE="..."
-$env:WINDOWS_PUBLISHER_NAME="..."
-cd qcut
-bun run dist:win:release
-\`\`\`
+## 本地签名机配置
+在专门的 Windows 签名机上（如果维护者主用 macOS 就在 Windows VM 里）：
 
-如果只想做本地未签名构建（不需要 Azure 权限）：
+1. **手机装 SimplySign App**（iOS/Android），与 Certum 账号配对。
+2. **桌面装 SimplySign 签名工具**，从 https://www.certum.eu/en/cert_expert_simply_sign/ 下载。
+3. **装 Windows SDK signtool**：`winget install --id Microsoft.WindowsSDK`。
+4. **认证桌面工具**，用手机扫二维码。
+5. **找证书 SHA1 thumbprint**：
+   \`\`\`powershell
+   certutil -store -user My
+   \`\`\`
+   找 "Developer ID Application: Quriosity Pty Ltd" — 抄 SHA1 thumbprint（40 位 hex）。
+6. **设环境变量**：
+   \`\`\`powershell
+   [Environment]::SetEnvironmentVariable("QCUT_WIN_CERT_THUMBPRINT", "<thumbprint>", "User")
+   \`\`\`
+
+## 每次发布的签名流程
 
 \`\`\`bash
-bun run dist:win:unsigned
+# 1. 等 CI 跑完（build-windows 任务）
+# 2. 下载 windows-build-unsigned artifact
+# 3. 把 QCut*Setup*.exe 和 latest.yml 放到 qcut/dist-electron/
+cd qcut
+bun run sign:win
+# 4. 在手机上批准签名（SimplySign App 推送，约 30 秒）
+# 5. 校验
+bun run verify:win-signature
+# 6. 手工把签名后的 .exe 和 latest.yml 上传到 GitHub Release 页面
 \`\`\`
 
 ## 校验签名安装包
+
 \`\`\`powershell
-signtool verify /pa /v .\dist-electron\QCut*Setup*.exe
-Get-AuthenticodeSignature .\dist-electron\QCut*Setup*.exe
+# 任何 Windows 机器上：
+signtool verify /pa /v .\QCut*Setup*.exe
+Get-AuthenticodeSignature .\QCut*Setup*.exe
 \`\`\`
 
+预期：
+- `signtool verify` 退出 0，输出 "Successfully verified"。
+- `Get-AuthenticodeSignature` 报告 `Status: Valid`，`SignerCertificate.Subject` 包含 "CN=Quriosity Pty Ltd"。
+
 ## 故障排查
-- "Sign error 0x80070002" → Azure 服务主体角色缺失，重新分配角色。
-- verify-windows-signature.ts 报 "发布者不一致" → WINDOWS_PUBLISHER_NAME
-  和实际证书 subject 不一致；更新 secret。
-- 工作流签名步骤卡住超过 5 分钟 → Trusted Signing 端点可能故障，
-  查 Azure 状态页；**不要**绕过签名。
 
-## 轮换服务主体密钥
-1. 在 Azure 门户生成新的客户端密钥（App registrations → <SP 名> →
-   Certificates & secrets）。
-2. 更新仓库 secret 中的 `AZURE_CLIENT_SECRET`。
-3. 推一个 `*-rc.N` tag 触发发布，确认工作流成功。
-4. 在 Azure 门户删掉旧的客户端密钥。
+### `signtool: error 0x80092004 — Cannot find object or property`
+证书 thumbprint 在用户证书库找不到。检查：
+- SimplySign 桌面工具有没有运行 + 已认证（证书只在工具暴露 Cloud HSM 身份时才出现）。
+- `QCUT_WIN_CERT_THUMBPRINT` 是否与 `certutil -store -user My` 里的 thumbprint 一致。
 
-## 续期
-Public Trust 证书 profile 自动轮换证书，没有人工续期任务。在 Azure
-里给 Trusted Signing 资源设个账单告警就行。
+### 手机收不到推送通知
+- SimplySign App 需要手机有网。
+- 重新认证桌面工具 — SimplySign 会话有时空闲几小时后过期。
+
+### `signtool sign` 成功但 `signtool verify` 失败
+- 时间戳服务可能悄悄失败了。换一个 `/tr` URL 重签（备选：`http://timestamp.digicert.com`、`http://timestamp.sectigo.com`）。
+
+### 签名后用户仍看到 SmartScreen 警告
+这对**每个新版本**的前几百到几千次下载都是**预期的**。SmartScreen 信誉按文件 hash 算，需要时间积累。完整背景见 `docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md` § "SmartScreen 信誉的现实"。
+
+## 凭据轮换
+
+### 证书续期（每年）
+1. 到期前在 shop.certum.eu 付续费。
+2. 重做身份验证（如果资料没变 Certum 可能简化）。
+3. 同一 SimplySign 账号下签发新证书；新 thumbprint。
+4. 更新签名机上的 `QCUT_WIN_CERT_THUMBPRINT`。
+5. 旧签名版本仍然有效（时间戳反签名了）。
+
+### 添加第二个团队成员
+1. 在 Certum 组织下添加新用户。
+2. 他用自己的凭据装 SimplySign App + 桌面工具。
+3. 现在 Donghao 和新成员都可以批准签名 — 休假覆盖有用。
+
+## 续期日历提醒
+**到期前 60 天**设日历提醒。Certum 控制台显示到期日期。
 ```
 
 ## 修改：`qcut/docs/release.md`
 
-如果文件还不存在就新建。在文件靠前位置加一节：
+加（或与 macOS 签名章节合并）：
 
 ```markdown
 ## Windows 发布前置条件
-Windows 发布构建**必须**做 Authenticode 签名。如果签名配置错了，
-发布工作流会失败 — 这是设计如此，**不要**为了发布绕过签名。
-设置和故障排查见 `docs/setup/windows-code-signing.md`。
+Windows 发布产物**必须**用 Quriosity 的 Certum 签发的 Authenticode
+证书签名。**签名是手工步骤**，CI build 出未签名 artifact 之后在维护者
+本地机器上完成 — 详见 `docs/setup/windows-code-signing.md`。
+
+这是有意为之：Certum SimplySign 要求每次签名操作都通过手机批准，
+GitHub Actions 不能自动化。这个权衡是经过考虑的（成本 vs. 自动化）；
+见 `docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md`。
 ```
 
 ## 修改：`qcut/CLAUDE.md`
@@ -119,30 +129,57 @@ Windows 发布构建**必须**做 Authenticode 签名。如果签名配置错了
 在 "Architecture Guidelines → DON'T" 一节下追加一条：
 
 ```markdown
-- 不要在发布工作流里禁用 Windows 代码签名（`forceCodeSigning=false`）。
-  详见 `docs/setup/windows-code-signing.md`。本地未签名开发构建用
-  `bun run dist:win:unsigned`。
+- 不要把未签名 Windows `.exe` 自动挂到 GitHub Release。Windows artifact
+  必须先手工签名再发布 — 见 `docs/setup/windows-code-signing.md`。
+  Windows 任务故意产出 `windows-build-unsigned` artifact，**不**直接发到 Release。
 ```
 
-这样将来 Claude Code 会话能看到这条规则，避免悄悄退化。
+这样将来 Claude Code 会话能看到这条约束。
 
-## 可选低优先级：PR 模板
+## Windows 下载页面向用户的文案
 
-如果 `qcut/.github/PULL_REQUEST_TEMPLATE.md` 已经存在，加一个 checkbox：
+QCut 的 Windows 下载页面（不管是哪条路由，例如 `qcut.app/download`）
+应该在 Windows 下载按钮附近放下面这段。这是**面向终端用户**的文案，
+不是给维护者看的。
 
-```markdown
-- [ ] 如果改动了 `release.yml` 或 `package.json` 的 `build.win`，
-      我没有禁用代码签名。
-```
+### 英文版
 
-如果 PR 模板还不存在，**不要**专门为这个新建一个。
+> 💡 **First time installing? You may see a Windows security warning.**
+>
+> When you run `QCut.AI.Video.Editor-Setup.exe`, Windows SmartScreen may
+> show "Windows protected your PC" — this is normal for new software
+> versions, even after we've signed our installer.
+>
+> 1. Click **More info** in the warning dialog.
+> 2. Confirm the publisher shown is **Quriosity Pty Ltd** — that's us.
+> 3. Click **Run anyway**.
+>
+> The Windows User Account Control prompt that follows should also show
+> **"Verified publisher: Quriosity Pty Ltd"** — you can safely click Yes.
+
+### 中文版
+
+> 💡 **首次安装时可能出现 Windows 安全警告。**
+>
+> 运行 `QCut.AI.Video.Editor-Setup.exe` 时，Windows SmartScreen 可能弹
+> "Windows protected your PC" — 这对新版本软件是正常现象，即使我们已签名。
+>
+> 1. 点弹窗里的 **More info（更多信息）**。
+> 2. 确认发布者显示为 **Quriosity Pty Ltd** — 就是我们。
+> 3. 点 **Run anyway（仍然运行）**。
+>
+> 接下来的 Windows 用户账户控制弹窗会显示 **"Verified publisher: Quriosity Pty Ltd"** — 可以放心点"是"。
+
+### 这段文案为什么重要
+
+没这段引导，那个 Unblock-File 截图里的用户（2026-04 抓到的，对话历史
+里有）只能用另一个 AI agent 帮他写 PowerShell 才能装 QCut。每个碰到
+这个问题没人引导的用户多半放弃。这段文案免费、立即生效，能显著降低
+SmartScreen 警告窗口期（每次发版后约前几百次安装）的流失率。
 
 ## 不需要写的内容
 
-- **真实的 Azure secret 值。**永远不要把密钥提交进库，也不要写让人
-  误以为是真值的"示例"。
-- **面向终端用户的"本程序已签名"宣传。** SmartScreen 弹窗是微软的
-  界面，我们控制不了。如果当作 feature 写进文档，万一微软改弹窗就
-  变成了空头承诺。
-- **单独的用户 FAQ 条目。** 这次改动对用户来说应该是无感的；只需要
-  发布工程相关的文档更新。
+- 证书的真实 SHA1 thumbprint — 敏感，只存在签名机的 `QCUT_WIN_CERT_THUMBPRINT` 和 Certum 控制台里。
+- "SmartScreen 内部怎么工作"逐步说明 — 微软文档已有。
+- Microsoft Store 提交 — 不同证书路径，单独立任务。
+- iOS / 移动端分发 — 不在范围内。

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
@@ -86,7 +86,7 @@ Get-AuthenticodeSignature .\QCut*Setup*.exe
 - 重新认证桌面工具 — SimplySign 会话有时空闲几小时后过期。
 
 ### `signtool sign` 成功但 `signtool verify` 失败
-- 时间戳服务可能悄悄失败了。换一个 `/tr` URL 重签（备选：`http://timestamp.digicert.com`、`http://timestamp.sectigo.com`）。
+- 时间戳服务可能悄悄失败了。换一个 `/tr` URL 重签（备选：`http://timestamp.digicert.com`、`http://timestamp.sectigo.com` — 厂商规范要求 HTTP；DigiCert 和 Sectigo 的 RFC3161 `/tr` 接口都不提供 HTTPS 端点，signtool 对响应已签名的时间戳协议本身也接受 HTTP）。
 
 ### 签名后用户仍看到 SmartScreen 警告
 这对**每个新版本**的前几百到几千次下载都是**预期的**。SmartScreen 信誉按文件 hash 算，需要时间积累。完整背景见 `docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md` § "SmartScreen 信誉的现实"。

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
@@ -42,7 +42,7 @@
    \`\`\`powershell
    certutil -store -user My
    \`\`\`
-   找 "Developer ID Application: Quriosity Pty Ltd" — 抄 SHA1 thumbprint（40 位 hex）。
+   找 `Subject`（CN）为 `Quriosity Pty Ltd` 的 Windows Authenticode 代码签名证书条目 — 抄 SHA1 thumbprint（40 位 hex）。（`Developer ID Application` 是 Apple 命名约定，Windows 上不要找它。）
 6. **设环境变量**：
    \`\`\`powershell
    [Environment]::SetEnvironmentVariable("QCUT_WIN_CERT_THUMBPRINT", "<thumbprint>", "User")

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
@@ -6,8 +6,31 @@
 
 ## 新增文件：`qcut/docs/setup/windows-code-signing.md`
 
-**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换 Azure 密钥
+**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换签名凭据
 的人。
+
+**路径相关：** 文档要同时覆盖 Path A（SignPath Foundation，首选）
+和 Path B（Azure Trusted Signing，fallback）。线上发布栈只用其中一条，
+但两节都保留，方便将来维护者在资格变化时切换。
+
+### Path A — SignPath Foundation 凭据
+
+需要的 GitHub Actions secret / variable：
+
+| 名称 | 类型 | 来源 |
+|------|------|------|
+| SIGNPATH_API_TOKEN | secret | SignPath 用户设置 → API tokens |
+| SIGNPATH_ORGANIZATION_ID | variable | SignPath 组织页（UUID） |
+| SIGNPATH_PROJECT_SLUG | variable | SignPath 项目页 |
+| SIGNPATH_SIGNING_POLICY_SLUG | variable | SignPath 项目 → Policies |
+| SIGNPATH_ARTIFACT_SLUG | variable | SignPath 项目 → Artifact configurations |
+| WINDOWS_PUBLISHER_NAME | variable | SignPath 颁发的 subject CN |
+
+SignPath Foundation **不支持本地签名** — 签名发生在服务端，通过
+GitHub Action 完成。需要本地签名构建的维护者要么向 SignPath 申请
+人工签名流程，要么直接用 CI 产物。
+
+### Path B — Azure Trusted Signing 凭据
 
 **大纲：**
 

--- a/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/DOCUMENTATION.zh-CN.md
@@ -1,0 +1,125 @@
+# Windows 代码签名 — 文档任务
+
+为了满足 issue 中"文档需说明所需签名机密和发布配置"这一项验收标准，
+下面这些文档要随代码改动一起提交。文档面向**维护者**（执行发布的人），
+不是终端用户。
+
+## 新增文件：`qcut/docs/setup/windows-code-signing.md`
+
+**读者：** 任何要搭建一台新的发布机、排查发布失败、或轮换 Azure 密钥
+的人。
+
+**大纲：**
+
+```markdown
+# Windows 代码签名 — 设置指南
+
+## 前置条件
+- Quriosity 名下的 Azure 订阅。
+- Trusted Signing Account + Certificate Profile（采购流程见
+  docs/task/windows-code-signing/CERTIFICATE-OPTIONS.zh-CN.md；采购完成
+  后那份文档作为历史记录留档，运营时以本文件为准）。
+- 一个被授予 `Trusted Signing Certificate Profile Signer` 角色的服务主体。
+
+## GitHub Actions secret
+仓库下面这些 secret 必须存在：
+
+| Secret | 来源 | 示例 |
+|--------|------|------|
+| AZURE_TENANT_ID | 服务主体所在的 Azure AD 租户 | 00000000-0000-0000-0000-000000000000 |
+| AZURE_CLIENT_ID | 服务主体 App ID | 00000000-0000-0000-0000-000000000000 |
+| AZURE_CLIENT_SECRET | 服务主体客户端密钥 | （每 6 个月轮换） |
+| AZURE_TRUSTED_SIGNING_ENDPOINT | 区域端点 | https://eus.codesigning.azure.net/ |
+| AZURE_TRUSTED_SIGNING_ACCOUNT | Trusted Signing Account 名称 | qcut-signing |
+| AZURE_CERTIFICATE_PROFILE | Profile 名称 | qcut-public-trust |
+| WINDOWS_PUBLISHER_NAME | 颁发证书的 Subject CN | Quriosity Pty Ltd |
+
+## 本地签名构建
+有 Azure 服务主体访问权限的维护者可以本地构建签名安装包：
+
+\`\`\`powershell
+$env:AZURE_TENANT_ID="..."
+$env:AZURE_CLIENT_ID="..."
+$env:AZURE_CLIENT_SECRET="..."
+$env:AZURE_TRUSTED_SIGNING_ENDPOINT="..."
+$env:AZURE_TRUSTED_SIGNING_ACCOUNT="..."
+$env:AZURE_CERTIFICATE_PROFILE="..."
+$env:WINDOWS_PUBLISHER_NAME="..."
+cd qcut
+bun run dist:win:release
+\`\`\`
+
+如果只想做本地未签名构建（不需要 Azure 权限）：
+
+\`\`\`bash
+bun run dist:win:unsigned
+\`\`\`
+
+## 校验签名安装包
+\`\`\`powershell
+signtool verify /pa /v .\dist-electron\QCut*Setup*.exe
+Get-AuthenticodeSignature .\dist-electron\QCut*Setup*.exe
+\`\`\`
+
+## 故障排查
+- "Sign error 0x80070002" → Azure 服务主体角色缺失，重新分配角色。
+- verify-windows-signature.ts 报 "发布者不一致" → WINDOWS_PUBLISHER_NAME
+  和实际证书 subject 不一致；更新 secret。
+- 工作流签名步骤卡住超过 5 分钟 → Trusted Signing 端点可能故障，
+  查 Azure 状态页；**不要**绕过签名。
+
+## 轮换服务主体密钥
+1. 在 Azure 门户生成新的客户端密钥（App registrations → <SP 名> →
+   Certificates & secrets）。
+2. 更新仓库 secret 中的 `AZURE_CLIENT_SECRET`。
+3. 推一个 `*-rc.N` tag 触发发布，确认工作流成功。
+4. 在 Azure 门户删掉旧的客户端密钥。
+
+## 续期
+Public Trust 证书 profile 自动轮换证书，没有人工续期任务。在 Azure
+里给 Trusted Signing 资源设个账单告警就行。
+```
+
+## 修改：`qcut/docs/release.md`
+
+如果文件还不存在就新建。在文件靠前位置加一节：
+
+```markdown
+## Windows 发布前置条件
+Windows 发布构建**必须**做 Authenticode 签名。如果签名配置错了，
+发布工作流会失败 — 这是设计如此，**不要**为了发布绕过签名。
+设置和故障排查见 `docs/setup/windows-code-signing.md`。
+```
+
+## 修改：`qcut/CLAUDE.md`
+
+在 "Architecture Guidelines → DON'T" 一节下追加一条：
+
+```markdown
+- 不要在发布工作流里禁用 Windows 代码签名（`forceCodeSigning=false`）。
+  详见 `docs/setup/windows-code-signing.md`。本地未签名开发构建用
+  `bun run dist:win:unsigned`。
+```
+
+这样将来 Claude Code 会话能看到这条规则，避免悄悄退化。
+
+## 可选低优先级：PR 模板
+
+如果 `qcut/.github/PULL_REQUEST_TEMPLATE.md` 已经存在，加一个 checkbox：
+
+```markdown
+- [ ] 如果改动了 `release.yml` 或 `package.json` 的 `build.win`，
+      我没有禁用代码签名。
+```
+
+如果 PR 模板还不存在，**不要**专门为这个新建一个。
+
+## 不需要写的内容
+
+- **真实的 Azure secret 值。**永远不要把密钥提交进库，也不要写让人
+  误以为是真值的"示例"。
+- **面向终端用户的"本程序已签名"宣传。** SmartScreen 弹窗是微软的
+  界面，我们控制不了。如果当作 feature 写进文档，万一微软改弹窗就
+  变成了空头承诺。
+- **单独的用户 FAQ 条目。** 这次改动对用户来说应该是无感的；只需要
+  发布工程相关的文档更新。

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -91,7 +91,7 @@ If any of these steps fail, the rest of this implementation cannot proceed.
 
 - **`forceCodeSigning: false`** — kept `false` because signing happens **after** electron-builder finishes (in our local sign step). If we set this to `true`, electron-builder would try to sign during build and fail because no cert is available in the runner's keychain.
 - **`verifyUpdateCodeSignature: true`** — flipped from `false`. Auto-updater will refuse updates whose signature does not chain to the same publisher. Defends against compromised update-server scenarios.
-- **`signAndEditExecutable: false`** — kept `false` because we sign the outer installer .exe in our local step. The inner `app.exe` inside the installer is also signed there.
+- **`signAndEditExecutable: false`** — kept `false` because **we run `signtool` only on the outer NSIS `Setup.exe` in our local step**. The inner `app.exe` is signed by electron-builder during the **unpacked stage** (before NSIS bundles it) when `signtool.exe` and a cert are present in the build environment; `signtool` invoked on the already-built `Setup.exe` does **not** re-sign nested binaries. If a future change requires CI builds to skip the unpacked-stage sign (e.g., no cert on the runner), the local sign script must be extended to unpack → sign `app.exe` → repack → sign `Setup.exe`. Auto-update signature verification (`verifyUpdateCodeSignature: true`) only checks the signature of the file electron-updater downloads — for QCut that's the `Setup.exe`, so this two-stage subtlety doesn't affect updater behavior, but it matters for SmartScreen reputation on the inner binary.
 - **No `azureSignOptions`** — Azure path is ruled out (see [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md#-azure-trusted-signing-microsoft-artifact-signing)).
 
 ### Update local `dist:win*` npm scripts
@@ -118,7 +118,7 @@ Add to `scripts`:
 
 ## 2. Update GitHub Actions release workflow
 
-**File:** `qcut/.github/workflows/release.yml` (Windows job, lines 56–108).
+**File:** `.github/workflows/release.yml` (Windows job, lines 56–108).
 
 The Windows CI build produces an **unsigned** `.exe` and uploads it as an artifact. The maintainer downloads, signs locally, and uploads the signed `.exe` back to the Release.
 
@@ -329,7 +329,7 @@ After all PRs land, do a manual end-to-end test:
 3. Run `bun run sign:win`. Approve on phone. Confirm script outputs "done".
 4. Run `bun run verify:win-signature`. Expect "OK".
 5. Manually upload signed `.exe` + `latest.yml` to the GitHub Release page.
-6. On a **clean** Windows Sequoia/11 VM (no developer tools, fresh user):
+6. On a **clean** Windows 11 VM (or Windows 10/11, no developer tools, fresh user):
    - Download the `.exe` from the Release page.
    - Double-click. SmartScreen may pop the warning ("Windows protected your PC"). Click "More info" → confirm "Quriosity Pty Ltd" appears. Click "Run anyway".
    - **Expected UAC dialog:** blue background, "Verified publisher: Quriosity Pty Ltd". Click "Yes".

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -1,31 +1,78 @@
-# Windows Code Signing — Implementation
+# Windows Code Signing — Implementation (Certum SimplySign)
 
-Detailed engineering subtasks. Sequenced so each can be a single PR.
-File paths are relative to the repository root unless noted.
+Engineering subtasks. Each is independently mergeable. Path: Certum
+SimplySign Standard Code Signing (Cloud). See
+[CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) for why other paths
+were ruled out.
 
-> **Pick the path before reading further.** Subtask 1 in
-> [`PLAN.md`](PLAN.md) decides between **Path A (SignPath, free, OSS)**
-> and **Path B (Azure Trusted Signing, paid, fallback)**. Sections §A*
-> apply to Path A, §B* to Path B, §4–§6 to both. Implement only one path.
+> **Prerequisite:** [PROCUREMENT subtasks 1–2](PLAN.md#subtask-map)
+> complete — Certum order paid, identity validation approved, certificate
+> issued and bound to a SimplySign Cloud HSM identity.
 
 ---
 
-## Path A — SignPath (recommended)
+## Architecture decision: where signing happens
 
-**Prerequisite:** Subtask 1a complete and the following are stored as
-GitHub Actions secrets / variables:
+Certum SimplySign requires phone-based confirmation for **every**
+`signtool` invocation — Donghao's phone gets a push notification, he
+taps "Approve", and signing proceeds. This is the security model of the
+Cloud HSM and **cannot be disabled**.
 
-- `SIGNPATH_API_TOKEN` (secret)
-- `SIGNPATH_ORGANIZATION_ID` (variable, UUID)
-- `SIGNPATH_PROJECT_SLUG` (variable, e.g. `qcut`)
-- `SIGNPATH_SIGNING_POLICY_SLUG` (variable, e.g. `release-signing`)
-- `SIGNPATH_ARTIFACT_SLUG` (variable, e.g. `qcut-installer`)
-- `WINDOWS_PUBLISHER_NAME` (variable, expected subject CN — SignPath
-  tells you this when the project is approved)
+Implication: GitHub Actions cannot fully automate the signing step.
+Three architecturally clean options:
 
-### A1. Update `electron-builder` Windows config
+| Option | Where signing happens | Tradeoff |
+|--------|----------------------|----------|
+| **A (chosen): Build unsigned in CI, sign locally before publish** | CI produces an unsigned `.exe` artifact; maintainer downloads it, signs on local Windows machine, uploads signed artifact to GitHub Release | Manual ~5 min per release. Same workflow Inkdrop uses. |
+| B: Self-hosted Windows runner with SimplySign installed | Runner triggers signing; Donghao still gets phone push and approves | Adds runner hosting cost and SimplySign always-running operational overhead. Phone confirmation still required — saves nothing. |
+| C: Switch to SSL.com eSigner OV | CI signs with REST API token | ~$50/year more, full automation. Migration path if Option A becomes painful. |
 
-**File:** `qcut/package.json` (lines 231–240, the `build.win` block).
+**Option A is the chosen path.** It matches industry norms for indie
+Electron projects and keeps the cost low. Migration to Option C is
+preserved as a future-hardening track.
+
+---
+
+## 0. Tooling setup
+
+**One-time setup on Donghao's machine** (Windows VM if Donghao primarily uses macOS — see Risk #2 in [PLAN.md](PLAN.md#risks--open-questions)).
+
+1. **Install SimplySign mobile app** — iOS/Android. Pair with Certum account using the activation code emailed after identity validation.
+2. **Install SimplySign desktop signing tool** — `proCertumCardManager` or the newer SimplySign desktop app. Download from https://www.certum.eu/en/cert_expert_simply_sign/.
+3. **Install Windows SDK signtool** — needed for `signtool.exe`. Either:
+   - Standalone via `winget install --id Microsoft.WindowsSDK` and use `signtool.exe` from `C:\Program Files (x86)\Windows Kits\10\bin\<version>\x64\`, or
+   - Install Visual Studio Build Tools.
+4. **Authenticate SimplySign desktop tool** — open it, enter Certum login, scan SimplySign QR code on phone. The tool now exposes the Cloud HSM identity to Windows CryptoAPI / signtool via PKCS#11.
+5. **Verify** — run from PowerShell:
+   ```powershell
+   certutil -store -user My
+   ```
+   The Quriosity Pty Ltd Developer ID Application certificate should appear, with a private-key reference pointing to SimplySign's CSP.
+
+If any of these steps fail, the rest of this implementation cannot proceed.
+
+---
+
+## 1. Update `electron-builder` Windows config
+
+**File:** `qcut/package.json` (the `build.win` block, lines 231–240).
+
+### Before
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": false,
+  "verifyUpdateCodeSignature": false,
+  "signAndEditExecutable": false,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store"
+}
+```
+
+### After
 
 ```json
 "win": {
@@ -40,236 +87,128 @@ GitHub Actions secrets / variables:
 }
 ```
 
-**Why these values for Path A:**
+### Why these values
 
-- `forceCodeSigning: false` — SignPath signs **after** `electron-builder`
-  finishes, so the builder must not block on inline signing.
-- `verifyUpdateCodeSignature: true` — auto-updater still verifies that
-  future updates chain to the same publisher.
-- `signAndEditExecutable: false` — same reason as `forceCodeSigning`.
-  SignPath's signing policy can be configured to sign both the inner
-  `app.exe` and the installer wrapper; that happens server-side.
+- **`forceCodeSigning: false`** — kept `false` because signing happens **after** electron-builder finishes (in our local sign step). If we set this to `true`, electron-builder would try to sign during build and fail because no cert is available in the runner's keychain.
+- **`verifyUpdateCodeSignature: true`** — flipped from `false`. Auto-updater will refuse updates whose signature does not chain to the same publisher. Defends against compromised update-server scenarios.
+- **`signAndEditExecutable: false`** — kept `false` because we sign the outer installer .exe in our local step. The inner `app.exe` inside the installer is also signed there.
+- **No `azureSignOptions`** — Azure path is ruled out (see [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md#-azure-trusted-signing-microsoft-artifact-signing)).
 
-### A2. Update local `dist:win*` npm scripts
+### Update local `dist:win*` npm scripts
 
 **File:** `qcut/package.json` (lines 84, 86, 88, 89).
 
-`forceCodeSigning=false` overrides should still be **removed** from
-`dist:win` and `dist:win:release` (they are redundant with the new
-config). `dist:win:unsigned` and `dist:win:fast` keep their explicit
-`forceCodeSigning=false` for clarity (those scripts deliberately produce
-unsigned artifacts for local dev).
+Strip the `forceCodeSigning=false` overrides — they are redundant with the new `build.win.forceCodeSigning: false` and confusing if a future maintainer wonders why both are set.
 
-| Script | New value |
-|--------|-----------|
-| `dist:win` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | unchanged |
-| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp` (no `verify:windows-signature` here — that runs in CI **after** SignPath returns the signed artifact, see §A3) |
-| `dist:win:fast` | unchanged |
+| Script | Old | New |
+|--------|-----|-----|
+| `dist:win` | `… -c.win.forceCodeSigning=false` | `… --publish never` (drop the override) |
+| `dist:win:unsigned` | unchanged | unchanged — explicit alias for "build without intent to sign" |
+| `dist:win:release` | `… --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false …` | `… --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp` |
+| `dist:win:fast` | unchanged | unchanged — local fast-iteration variant |
 
-Also add to the `scripts` block:
+Add to `scripts`:
 
 ```json
-"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+"sign:win": "bun scripts/sign-windows-release.ts",
+"verify:win-signature": "bun scripts/verify-windows-signature.ts"
 ```
 
-(used by CI in §A3 step 3.)
+---
 
-### A3. Update GitHub Actions release workflow
+## 2. Update GitHub Actions release workflow
 
 **File:** `qcut/.github/workflows/release.yml` (Windows job, lines 56–108).
 
-**Step 1 — modify** "Build Electron application" (line 94–98) to drop
-the `forceCodeSigning=false` overrides:
+The Windows CI build produces an **unsigned** `.exe` and uploads it as an artifact. The maintainer downloads, signs locally, and uploads the signed `.exe` back to the Release.
+
+### 2.1 — Modify "Build Electron application" step
 
 ```yaml
-- name: Build Electron application
+- name: Build Electron application (unsigned — sign locally per release)
   run: |
     npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-**Step 2 — add** "Submit signing request to SignPath" after the build
-and **before** "Upload artifacts":
+(Removed the `--config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false` overrides — `package.json` already provides the right defaults.)
+
+### 2.2 — Update artifact upload
+
+The Windows job continues to upload the unsigned `.exe`. The release publish step does NOT auto-attach Windows artifacts to the GitHub Release until they have been signed.
 
 ```yaml
-- name: Upload unsigned artifact for signing
-  id: upload-unsigned
+- name: Upload unsigned Windows artifact
   uses: actions/upload-artifact@v7
   with:
-    name: windows-unsigned
-    path: qcut/dist-electron/QCut*Setup*.exe
+    name: windows-build-unsigned
+    path: |
+      qcut/dist-electron/QCut*Setup*.exe
+      qcut/dist-electron/latest.yml
     if-no-files-found: error
-
-- name: Submit signing request to SignPath
-  id: signpath
-  uses: signpath/github-action-submit-signing-request@v1
-  with:
-    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-    organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-    project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-    signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
-    artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_SLUG }}
-    github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
-    wait-for-completion: true
-    output-artifact-directory: qcut/dist-electron-signed
-
-- name: Replace unsigned artifact with signed
-  shell: pwsh
-  run: |
-    Remove-Item qcut/dist-electron/QCut*Setup*.exe
-    Move-Item qcut/dist-electron-signed/QCut*Setup*.exe qcut/dist-electron/
 ```
 
-**Step 3 — add** signature verification (this is §4 below; same step on
-both paths):
+(Renamed `windows-build` → `windows-build-unsigned` to make the artifact's status visible in the Actions UI.)
 
-```yaml
-- name: Verify Windows signature
-  shell: pwsh
-  env:
-    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
-  run: |
-    cd qcut
-    bun run verify:windows-signature
-```
+### 2.3 — Modify the release-publish step
 
-**Step 4 — modify** "Upload artifacts" (line 100) so it uploads the
-*signed* file (path is unchanged, since we moved the signed file to
-`dist-electron/`).
+The aggregated release job (`release` near line 277) currently downloads `windows-build` and attaches `.exe` files to the release. Update it to:
 
-> **Note on `latest.yml`:** `latest.yml` in `dist-electron/` was
-> generated by electron-builder against the *unsigned* file's hash.
-> After SignPath replaces the file, the SHA512 in `latest.yml` is wrong
-> and auto-update will reject the artifact. Fix: regenerate `latest.yml`
-> after the SignPath replace step. SignPath's docs cover this — common
-> approach is a small post-replace script that recomputes the SHA512 and
-> rewrites `latest.yml`. Track this as a separate sub-PR if it's not in
-> the official action by the time we implement.
+- Stop auto-attaching unsigned Windows files. Either:
+  - **(2.3a)** Skip Windows files in the release-publish step entirely — maintainer manually uploads signed `.exe` to the Release after running `bun run sign:win` locally. Simpler.
+  - **(2.3b)** Add a "wait for signed-windows artifact" step that polls for a maintainer-uploaded signed artifact, then publishes. More automation but more complexity.
+
+Choose **2.3a** for v1. Document the manual step clearly:
+
+> 📋 **Release operator runbook:**
+> 1. Wait for `build-windows` job to succeed.
+> 2. Download `windows-build-unsigned` artifact.
+> 3. Run `bun run sign:win` (with SimplySign desktop app authenticated).
+> 4. Approve signing on phone (~30 seconds).
+> 5. Upload signed `.exe` and updated `latest.yml` to the GitHub Release manually.
+
+### 2.4 — `latest.yml` integrity
+
+`latest.yml` contains a SHA512 of the `.exe`. Signing changes the bytes, so the SHA512 in `latest.yml` becomes wrong. The local sign script (next section) regenerates `latest.yml`.
 
 ---
 
-## Path B — Azure Trusted Signing (fallback)
+## 3. Add local signing helper script
 
-**Prerequisite:** Subtask 1b complete and the following are GitHub
-Actions secrets / variables:
-
-- `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` (secrets)
-- `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`,
-  `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME` (variables)
-
-### B1. Update `electron-builder` Windows config
-
-**File:** `qcut/package.json` (lines 231–240).
-
-```json
-"win": {
-  "target": "nsis",
-  "icon": "build/icon.ico",
-  "forceCodeSigning": true,
-  "verifyUpdateCodeSignature": true,
-  "signAndEditExecutable": true,
-  "requestedExecutionLevel": "asInvoker",
-  "artifactName": "${productName}-Setup-${version}.${ext}",
-  "compression": "store",
-  "azureSignOptions": {
-    "publisherName": "${env.WINDOWS_PUBLISHER_NAME}",
-    "endpoint": "${env.AZURE_TRUSTED_SIGNING_ENDPOINT}",
-    "certificateProfileName": "${env.AZURE_CERTIFICATE_PROFILE}",
-    "codeSigningAccountName": "${env.AZURE_TRUSTED_SIGNING_ACCOUNT}"
-  }
-}
-```
-
-**Why every flag matters:**
-
-- `forceCodeSigning: true` — fails the build if signing is misconfigured
-  instead of silently shipping unsigned bytes.
-- `verifyUpdateCodeSignature: true` — auto-updater refuses updates whose
-  signature doesn't chain to the same publisher.
-- `signAndEditExecutable: true` — signs the inner `app.exe` too.
-- `${env.*}` references keep secrets out of `package.json`.
-
-### B2. Update local `dist:win*` npm scripts
-
-Same shape as §A2 but the unsigned scripts (`dist:win:unsigned`,
-`dist:win:fast`) are still useful for developers without Azure access.
-
-| Script | New value |
-|--------|-----------|
-| `dist:win` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | unchanged (keeps `forceCodeSigning=false` override for unsigned local dev) |
-| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
-| `dist:win:fast` | unchanged |
-
-Also add the `verify:windows-signature` script entry as in §A2.
-
-### B3. Update GitHub Actions release workflow
-
-**File:** `qcut/.github/workflows/release.yml`.
-
-Modify "Build Electron application" (line 94–98):
-
-```yaml
-- name: Build Electron application
-  run: |
-    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-    AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-    AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
-    AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
-    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
-```
-
-Add the verification step (same as §A3 step 3) **after** build, **before**
-"Upload artifacts".
-
-`latest.yml` is correct out of the box because signing is inline.
-
----
-
-## 4. Add post-build signature verification (shared)
-
-Path-agnostic. Used by both Path A and Path B.
-
-**New files:**
-
-- `qcut/scripts/verify-windows-signature.ts` — implementation.
-- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — see
-  [`TESTING.md`](TESTING.md).
+**New file:** `qcut/scripts/sign-windows-release.ts`.
 
 ### Behaviour spec
 
-1. Locate the release artifact (`qcut/dist-electron/QCut*Setup*.exe`,
-   first match by mtime).
-2. On Windows, run `signtool verify /pa /v <path>`. On non-Windows,
-   warn-and-skip (the script is only authoritative on Windows runners).
-3. Parse output. Require:
-   - Exit code 0.
-   - Subject CN matches `process.env.WINDOWS_PUBLISHER_NAME` if set.
-4. Exit non-zero with a clear message on failure.
-5. No silent fallbacks. If the artifact does not exist, fail loudly.
+1. Find the latest unsigned `QCut*Setup*.exe` in `qcut/dist-electron/`.
+2. Run `signtool sign /tr http://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`.
+   - `sha1 <thumbprint>` — selects the Quriosity cert from SimplySign's exposed identity store.
+   - `tr` is the RFC 3161 timestamp authority. Microsoft's is recommended for SmartScreen reputation alignment.
+   - `td sha256` and `fd sha256` — modern SHA-256 algorithms (CA/B Forum requires post-2024).
+3. SimplySign mobile app prompts for approval. Donghao taps Approve.
+4. After signing, run `signtool verify /pa /v <exe>` to confirm.
+5. Update `latest.yml`:
+   - Recompute SHA512 of the signed `.exe`.
+   - Recompute file size.
+   - Rewrite `latest.yml`.
+6. Print summary with paths.
 
 ### Sketch
 
 ```ts
-// qcut/scripts/verify-windows-signature.ts
+// qcut/scripts/sign-windows-release.ts
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 const distDir = join(import.meta.dir, "..", "dist-electron");
-const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME;
+const certThumbprint = process.env.QCUT_WIN_CERT_THUMBPRINT;
+if (!certThumbprint) {
+  throw new Error("Set QCUT_WIN_CERT_THUMBPRINT to the SHA1 of the Quriosity cert");
+}
 
-function findInstaller(): string {
-  if (!existsSync(distDir)) {
-    throw new Error(`dist-electron not found at ${distDir}`);
-  }
+function findUnsignedInstaller(): string {
   const candidates = readdirSync(distDir)
     .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
     .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
@@ -280,78 +219,125 @@ function findInstaller(): string {
   return join(distDir, candidates[0].f);
 }
 
-function verify(installer: string): void {
-  if (process.platform !== "win32") {
-    console.warn("[verify-windows-signature] non-Windows host, skipping");
-    return;
+const exe = findUnsignedInstaller();
+console.log(`[sign-windows-release] signing ${exe}`);
+console.log("[sign-windows-release] approve on your phone via SimplySign app...");
+
+execFileSync("signtool", [
+  "sign",
+  "/tr", "http://timestamp.acs.microsoft.com",
+  "/td", "sha256",
+  "/fd", "sha256",
+  "/sha1", certThumbprint,
+  "/sm",
+  exe,
+], { stdio: "inherit" });
+
+execFileSync("signtool", ["verify", "/pa", "/v", exe], { stdio: "inherit" });
+
+// Update latest.yml
+const latestYmlPath = join(distDir, "latest.yml");
+if (existsSync(latestYmlPath)) {
+  const buffer = readFileSync(exe);
+  const sha512 = createHash("sha512").update(buffer).digest("base64");
+  const size = buffer.length;
+  let yml = readFileSync(latestYmlPath, "utf8");
+  yml = yml.replace(/sha512: .+/g, `sha512: ${sha512}`);
+  yml = yml.replace(/size: \d+/g, `size: ${size}`);
+  writeFileSync(latestYmlPath, yml);
+  console.log("[sign-windows-release] updated latest.yml SHA512 + size");
+}
+
+console.log("[sign-windows-release] done");
+```
+
+### Why a `.ts` script (not raw `.ps1`)
+
+- Matches existing convention — see `qcut/scripts/verify-packaged-ffmpeg.ts` and `verify-packaged-aicp.ts` (confirmed present).
+- Easier to unit-test with Vitest.
+- Cross-platform path handling.
+
+---
+
+## 4. Add post-signing signature verifier
+
+**New file:** `qcut/scripts/verify-windows-signature.ts`.
+
+Same behaviour as the verifier sketched in earlier iterations of this
+plan — runs `signtool verify /pa /v` and asserts the publisher subject
+matches the expected `WINDOWS_PUBLISHER_NAME` env var (set to `"Quriosity Pty Ltd"`).
+
+### Sketch
+
+```ts
+// qcut/scripts/verify-windows-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME ?? "Quriosity Pty Ltd";
+
+function findInstaller(): string {
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`No QCut*Setup*.exe found in ${distDir}`);
   }
-  const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], {
-    encoding: "utf8",
-  });
-  console.log(out);
-  if (expectedPublisher && !out.includes(expectedPublisher)) {
-    throw new Error(
-      `Signed by unexpected publisher; expected "${expectedPublisher}" in signtool output`,
-    );
-  }
+  return join(distDir, candidates[0].f);
+}
+
+if (process.platform !== "win32") {
+  console.warn("[verify-windows-signature] non-Windows host, skipping");
+  process.exit(0);
 }
 
 const installer = findInstaller();
-console.log(`[verify-windows-signature] verifying ${installer}`);
-verify(installer);
+const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], { encoding: "utf8" });
+console.log(out);
+
+if (!out.includes(expectedPublisher)) {
+  throw new Error(`Signed by unexpected publisher; expected "${expectedPublisher}" in signtool output`);
+}
+
 console.log("[verify-windows-signature] OK");
 ```
 
-### Why a `.ts` script (not a raw `.ps1`)
-
-- Matches existing convention — see `qcut/scripts/verify-packaged-ffmpeg.ts`
-  and `qcut/scripts/verify-packaged-aicp.ts` (both confirmed present).
-- Easier to unit-test (Vitest can mock `child_process`).
-- Cross-platform-safe: no-ops on macOS/Linux dev machines.
+This script runs in two places:
+- After `bun run sign:win` (sanity check before uploading to Release).
+- Manually on the published `.exe` from the GitHub Release page (smoke test).
 
 ---
 
-## 5. Dry-run release & manual verification (shared)
+## 5. Future hardening (track separately)
 
-Manual smoke test on a clean Windows VM (no developer tools, fresh
-profile):
+- **Migrate to SSL.com eSigner OV** if manual signing becomes a bottleneck. Adds full CI automation; adds ~$50/year.
+- **Add team member to Certum account** so signing is not blocked when Donghao is offline.
+- **Reputation acceleration**: keep release frequency moderate (don't release weekly), encourage downloads to flow through stable URLs that aggregate hash reputation faster.
+- **Re-evaluate Azure Artifact Signing in 2027-06** once Quriosity hits 3-year mark — and if Microsoft has expanded country eligibility to AU. If both are true, $120/year + full CI automation makes Azure attractive again.
 
-1. Push a tag like `v2026.5.0-rc.1` to trigger the release workflow.
-2. Wait for `build-windows` to succeed; download the `windows-build`
-   artifact.
-3. On the VM, double-click the `.exe`.
-4. **Expected:** Windows shows `Publisher: <WINDOWS_PUBLISHER_NAME>`
-   (not "Unknown publisher"). SmartScreen may still display "Windows
-   protected your PC" until reputation builds — see "Risks" in
-   [`PLAN.md`](PLAN.md).
-5. Open PowerShell on the VM:
+---
+
+## 6. Dry-run release on clean Windows VM
+
+After all PRs land, do a manual end-to-end test:
+
+1. CI: tag `v2026.5.0-rc.1`, wait for `build-windows` to produce `windows-build-unsigned` artifact.
+2. Download artifact to local Windows machine where SimplySign is set up.
+3. Run `bun run sign:win`. Approve on phone. Confirm script outputs "done".
+4. Run `bun run verify:win-signature`. Expect "OK".
+5. Manually upload signed `.exe` + `latest.yml` to the GitHub Release page.
+6. On a **clean** Windows Sequoia/11 VM (no developer tools, fresh user):
+   - Download the `.exe` from the Release page.
+   - Double-click. SmartScreen may pop the warning ("Windows protected your PC"). Click "More info" → confirm "Quriosity Pty Ltd" appears. Click "Run anyway".
+   - **Expected UAC dialog:** blue background, "Verified publisher: Quriosity Pty Ltd". Click "Yes".
+   - QCut installs normally.
+7. From PowerShell on the VM:
    ```powershell
-   Get-AuthenticodeSignature .\QCut*Setup*.exe
+   Get-AuthenticodeSignature "C:\Users\<you>\Downloads\QCut*Setup*.exe"
    ```
-   Expect `Status: Valid` and a non-empty `SignerCertificate.Subject`.
-6. `signtool verify /pa /v .\QCut*Setup*.exe` → exit 0, "Successfully
-   verified".
+   Expect `Status: Valid` and `SignerCertificate.Subject` containing "Quriosity Pty Ltd".
 
-If any step fails, **do not promote** the rc tag to a release. Roll back
-the workflow change and investigate.
-
----
-
-## 6. Future hardening (track separately)
-
-Out of scope for the v1 implementation but worth filing follow-up issues:
-
-- **(Path B only) OIDC federation for Azure auth** — replace
-  `AZURE_CLIENT_SECRET` with `azure/login@v2` + workload identity
-  federation. No rotating secrets to manage.
-- **(Path A only) `latest.yml` integrity** — once SignPath replaces the
-  signed installer, ensure `latest.yml` SHA512 is recomputed before
-  upload, or auto-update will reject the artifact.
-- **EV cert evaluation** — six months after v1 ships, review SmartScreen
-  warning rate and decide whether to upgrade to EV.
-- **Microsoft Store distribution** — separate channel, separate
-  certificate, separate review process. Issue #289 mentions it as a
-  reputation booster but it is not part of this plan.
-- **macOS signing** — currently *also* unconfigured in CI (no
-  `mac.identity`, no Apple secrets in `release.yml`). File a separate
-  task; do not bundle with the Windows work.
+If any step fails, **do not promote** the rc tag. Roll back and investigate.

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -25,7 +25,7 @@ Three architecturally clean options:
 |--------|----------------------|----------|
 | **A (chosen): Build unsigned in CI, sign locally before publish** | CI produces an unsigned `.exe` artifact; maintainer downloads it, signs on local Windows machine, uploads signed artifact to GitHub Release | Manual ~5 min per release. Same workflow Inkdrop uses. |
 | B: Self-hosted Windows runner with SimplySign installed | Runner triggers signing; Donghao still gets phone push and approves | Adds runner hosting cost and SimplySign always-running operational overhead. Phone confirmation still required — saves nothing. |
-| C: Switch to SSL.com eSigner OV | CI signs with REST API token | ~$50/year more, full automation. Migration path if Option A becomes painful. |
+| C: Switch to SSL.com eSigner OV | CI signs with REST API token | ~$220+/year more (dual cost: ~$239/year cert + ~$200–240/year eSigner Cloud Signing — see §5), full automation. Migration path if Option A becomes painful. |
 
 **Option A is the chosen path.** It matches industry norms for indie
 Electron projects and keeps the cost low. Migration to Option C is
@@ -47,7 +47,7 @@ preserved as a future-hardening track.
    ```powershell
    certutil -store -user My
    ```
-   The Quriosity Pty Ltd Developer ID Application certificate should appear, with a private-key reference pointing to SimplySign's CSP.
+   The Windows Authenticode code-signing certificate issued to `Quriosity Pty Ltd` (subject CN `Quriosity Pty Ltd`) should appear, with a private-key reference pointing to SimplySign's CSP. (`Developer ID Application` is the Apple naming convention and does not apply on Windows.)
 
 If any of these steps fail, the rest of this implementation cannot proceed.
 
@@ -181,7 +181,7 @@ Choose **2.3a** for v1. Document the manual step clearly:
 ### Behaviour spec
 
 1. Find the latest unsigned `QCut*Setup*.exe` in `qcut/dist-electron/`.
-2. Run `signtool sign /tr http://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`.
+2. Run `signtool sign /tr https://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`.
    - `sha1 <thumbprint>` — selects the Quriosity cert from SimplySign's exposed identity store.
    - `tr` is the RFC 3161 timestamp authority. Microsoft's is recommended for SmartScreen reputation alignment.
    - `td sha256` and `fd sha256` — modern SHA-256 algorithms (CA/B Forum requires post-2024).
@@ -225,7 +225,7 @@ console.log("[sign-windows-release] approve on your phone via SimplySign app..."
 
 execFileSync("signtool", [
   "sign",
-  "/tr", "http://timestamp.acs.microsoft.com",
+  "/tr", "https://timestamp.acs.microsoft.com",
   "/td", "sha256",
   "/fd", "sha256",
   "/sha1", certThumbprint,

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -3,27 +3,36 @@
 Detailed engineering subtasks. Sequenced so each can be a single PR.
 File paths are relative to the repository root unless noted.
 
-> **Prerequisite:** Subtask 1 (cert procurement, see
-> [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)) is complete and the
-> following values are known and stored as GitHub Actions secrets:
-> `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
-> `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`,
-> `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME`.
+> **Pick the path before reading further.** Subtask 1 in
+> [`PLAN.md`](PLAN.md) decides between **Path A (SignPath, free, OSS)**
+> and **Path B (Azure Trusted Signing, paid, fallback)**. Sections §A*
+> apply to Path A, §B* to Path B, §4–§6 to both. Implement only one path.
 
 ---
 
-## 1. Update `electron-builder` Windows config
+## Path A — SignPath (recommended)
 
-**Files:** `qcut/package.json` (lines 231–240, the `build.win` block).
+**Prerequisite:** Subtask 1a complete and the following are stored as
+GitHub Actions secrets / variables:
 
-### Before
+- `SIGNPATH_API_TOKEN` (secret)
+- `SIGNPATH_ORGANIZATION_ID` (variable, UUID)
+- `SIGNPATH_PROJECT_SLUG` (variable, e.g. `qcut`)
+- `SIGNPATH_SIGNING_POLICY_SLUG` (variable, e.g. `release-signing`)
+- `SIGNPATH_ARTIFACT_SLUG` (variable, e.g. `qcut-installer`)
+- `WINDOWS_PUBLISHER_NAME` (variable, expected subject CN — SignPath
+  tells you this when the project is approved)
+
+### A1. Update `electron-builder` Windows config
+
+**File:** `qcut/package.json` (lines 231–240, the `build.win` block).
 
 ```json
 "win": {
   "target": "nsis",
   "icon": "build/icon.ico",
   "forceCodeSigning": false,
-  "verifyUpdateCodeSignature": false,
+  "verifyUpdateCodeSignature": true,
   "signAndEditExecutable": false,
   "requestedExecutionLevel": "asInvoker",
   "artifactName": "${productName}-Setup-${version}.${ext}",
@@ -31,7 +40,128 @@ File paths are relative to the repository root unless noted.
 }
 ```
 
-### After
+**Why these values for Path A:**
+
+- `forceCodeSigning: false` — SignPath signs **after** `electron-builder`
+  finishes, so the builder must not block on inline signing.
+- `verifyUpdateCodeSignature: true` — auto-updater still verifies that
+  future updates chain to the same publisher.
+- `signAndEditExecutable: false` — same reason as `forceCodeSigning`.
+  SignPath's signing policy can be configured to sign both the inner
+  `app.exe` and the installer wrapper; that happens server-side.
+
+### A2. Update local `dist:win*` npm scripts
+
+**File:** `qcut/package.json` (lines 84, 86, 88, 89).
+
+`forceCodeSigning=false` overrides should still be **removed** from
+`dist:win` and `dist:win:release` (they are redundant with the new
+config). `dist:win:unsigned` and `dist:win:fast` keep their explicit
+`forceCodeSigning=false` for clarity (those scripts deliberately produce
+unsigned artifacts for local dev).
+
+| Script | New value |
+|--------|-----------|
+| `dist:win` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | unchanged |
+| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp` (no `verify:windows-signature` here — that runs in CI **after** SignPath returns the signed artifact, see §A3) |
+| `dist:win:fast` | unchanged |
+
+Also add to the `scripts` block:
+
+```json
+"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+```
+
+(used by CI in §A3 step 3.)
+
+### A3. Update GitHub Actions release workflow
+
+**File:** `qcut/.github/workflows/release.yml` (Windows job, lines 56–108).
+
+**Step 1 — modify** "Build Electron application" (line 94–98) to drop
+the `forceCodeSigning=false` overrides:
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Step 2 — add** "Submit signing request to SignPath" after the build
+and **before** "Upload artifacts":
+
+```yaml
+- name: Upload unsigned artifact for signing
+  id: upload-unsigned
+  uses: actions/upload-artifact@v7
+  with:
+    name: windows-unsigned
+    path: qcut/dist-electron/QCut*Setup*.exe
+    if-no-files-found: error
+
+- name: Submit signing request to SignPath
+  id: signpath
+  uses: signpath/github-action-submit-signing-request@v1
+  with:
+    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+    organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+    project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+    signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+    artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_SLUG }}
+    github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+    wait-for-completion: true
+    output-artifact-directory: qcut/dist-electron-signed
+
+- name: Replace unsigned artifact with signed
+  shell: pwsh
+  run: |
+    Remove-Item qcut/dist-electron/QCut*Setup*.exe
+    Move-Item qcut/dist-electron-signed/QCut*Setup*.exe qcut/dist-electron/
+```
+
+**Step 3 — add** signature verification (this is §4 below; same step on
+both paths):
+
+```yaml
+- name: Verify Windows signature
+  shell: pwsh
+  env:
+    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
+  run: |
+    cd qcut
+    bun run verify:windows-signature
+```
+
+**Step 4 — modify** "Upload artifacts" (line 100) so it uploads the
+*signed* file (path is unchanged, since we moved the signed file to
+`dist-electron/`).
+
+> **Note on `latest.yml`:** `latest.yml` in `dist-electron/` was
+> generated by electron-builder against the *unsigned* file's hash.
+> After SignPath replaces the file, the SHA512 in `latest.yml` is wrong
+> and auto-update will reject the artifact. Fix: regenerate `latest.yml`
+> after the SignPath replace step. SignPath's docs cover this — common
+> approach is a small post-replace script that recomputes the SHA512 and
+> rewrites `latest.yml`. Track this as a separate sub-PR if it's not in
+> the official action by the time we implement.
+
+---
+
+## Path B — Azure Trusted Signing (fallback)
+
+**Prerequisite:** Subtask 1b complete and the following are GitHub
+Actions secrets / variables:
+
+- `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` (secrets)
+- `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`,
+  `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME` (variables)
+
+### B1. Update `electron-builder` Windows config
+
+**File:** `qcut/package.json` (lines 231–240).
 
 ```json
 "win": {
@@ -52,90 +182,34 @@ File paths are relative to the repository root unless noted.
 }
 ```
 
-### Why every flag matters
+**Why every flag matters:**
 
 - `forceCodeSigning: true` — fails the build if signing is misconfigured
-  instead of silently shipping unsigned bytes. Required by the issue's
-  acceptance criteria.
-- `verifyUpdateCodeSignature: true` — the auto-updater will refuse to
-  apply an update whose signature does not chain to the same publisher.
-  Defends against compromised update-server scenarios.
-- `signAndEditExecutable: true` — signs the `app.exe` inside the installer
-  too, not just the installer wrapper. Otherwise the *installed* app still
-  appears unsigned to the OS.
-- Values reference `${env.*}` so the same `package.json` works in CI and
-  locally without committing secrets.
+  instead of silently shipping unsigned bytes.
+- `verifyUpdateCodeSignature: true` — auto-updater refuses updates whose
+  signature doesn't chain to the same publisher.
+- `signAndEditExecutable: true` — signs the inner `app.exe` too.
+- `${env.*}` references keep secrets out of `package.json`.
 
-### Verification
+### B2. Update local `dist:win*` npm scripts
 
-- `bun check-types` — config is JSON, no type impact, but run anyway.
-- `cd qcut && npx electron-builder --help | grep -i azure` — confirm the
-  installed `electron-builder` version supports `azureSignOptions`.
+Same shape as §A2 but the unsigned scripts (`dist:win:unsigned`,
+`dist:win:fast`) are still useful for developers without Azure access.
 
----
+| Script | New value |
+|--------|-----------|
+| `dist:win` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | unchanged (keeps `forceCodeSigning=false` override for unsigned local dev) |
+| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
+| `dist:win:fast` | unchanged |
 
-## 2. Update local `dist:win*` npm scripts
+Also add the `verify:windows-signature` script entry as in §A2.
 
-**File:** `qcut/package.json` (lines 84, 86, 88, 89).
+### B3. Update GitHub Actions release workflow
 
-The current scripts hard-code `--config.win.forceCodeSigning=false` and
-`--config.win.verifyUpdateCodeSignature=false`. Once subtask 1 lands,
-these overrides will *prevent* signing even on machines that have the
-Azure secrets exported.
+**File:** `qcut/.github/workflows/release.yml`.
 
-### Changes
-
-| Script | Old | New |
-|--------|-----|-----|
-| `dist:win` | `electron-builder --win --publish never -c.win.forceCodeSigning=false` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | (same as before) | **Keep as-is** — explicitly unsigned local-dev variant. Rename intent in script comment if helpful. |
-| `dist:win:release` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && …` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
-| `dist:win:fast` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` (**unchanged**) |
-
-### Rationale
-
-- `dist:win:unsigned` and `dist:win:fast` are deliberately kept unsigned —
-  developers without Azure access still need a way to build a working
-  installer for local smoke tests. They are not used by the release
-  pipeline.
-- `dist:win:release` is the canonical signed release script; it now runs
-  the new `verify:windows-signature` script (added in subtask 5) as a
-  belt-and-braces check.
-- Script `verify:windows-signature` will be added in `package.json`
-  `scripts` block alongside the other `verify:*` entries:
-
-```json
-"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
-```
-
-### Verification
-
-- Run `cd qcut && bun run dist:win:unsigned` on a Windows machine — should
-  still produce an unsigned installer for local dev.
-- Run `cd qcut && bun run dist:win:release` with Azure secrets exported —
-  should produce a signed installer and exit 0.
-
----
-
-## 3. Update GitHub Actions release workflow
-
-**File:** `qcut/.github/workflows/release.yml` (Windows job, lines 56–108).
-
-### Changes
-
-Step "Build Electron application" at line 94–98:
-
-**Before:**
-
-```yaml
-- name: Build Electron application
-  run: |
-    npx electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false --config.publish.channel=${{ needs.prepare.outputs.channel }}
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**After:**
+Modify "Build Electron application" (line 94–98):
 
 ```yaml
 - name: Build Electron application
@@ -146,45 +220,22 @@ Step "Build Electron application" at line 94–98:
     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
     AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
-    AZURE_CERTIFICATE_PROFILE: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
-    WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+    AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
 ```
 
-Add a new step **after** "Build Electron application" and **before**
-"Upload artifacts":
+Add the verification step (same as §A3 step 3) **after** build, **before**
+"Upload artifacts".
 
-```yaml
-- name: Verify Windows signature
-  shell: pwsh
-  run: |
-    cd qcut
-    bun run verify:windows-signature
-```
-
-### Why a separate verify step
-
-`forceCodeSigning: true` already aborts the build on signing failure, but
-a separate verify step:
-
-1. Runs `signtool verify /pa /v` against the *final* artifact path that
-   uploads to the release — catches any post-build mutation.
-2. Produces explicit log output that humans (and `prtaskit`) can scan
-   when investigating "why is this release showing unknown publisher" in
-   the future.
-3. Costs ~2 seconds; the value-to-cost ratio is excellent.
-
-### Verification
-
-- `actionlint qcut/.github/workflows/release.yml` (or
-  `npx @action-validator/cli`) — YAML syntax + secret-reference sanity.
-- Tag a `vX.Y.Z-rc.1` release and watch the workflow — signing should
-  succeed, the verify step should print `Successfully verified`.
+`latest.yml` is correct out of the box because signing is inline.
 
 ---
 
-## 4. Add post-build signature verification
+## 4. Add post-build signature verification (shared)
+
+Path-agnostic. Used by both Path A and Path B.
 
 **New files:**
 
@@ -196,16 +247,15 @@ a separate verify step:
 
 1. Locate the release artifact (`qcut/dist-electron/QCut*Setup*.exe`,
    first match by mtime).
-2. On Windows, run `signtool verify /pa /v <path>`. On non-Windows, run
-   `osslsigncode verify <path>` if available; otherwise log a warning
-   and exit 0 (the script is only authoritative on Windows runners).
+2. On Windows, run `signtool verify /pa /v <path>`. On non-Windows,
+   warn-and-skip (the script is only authoritative on Windows runners).
 3. Parse output. Require:
    - Exit code 0.
    - Subject CN matches `process.env.WINDOWS_PUBLISHER_NAME` if set.
 4. Exit non-zero with a clear message on failure.
 5. No silent fallbacks. If the artifact does not exist, fail loudly.
 
-### Sketch (final code lives in the new file)
+### Sketch
 
 ```ts
 // qcut/scripts/verify-windows-signature.ts
@@ -255,20 +305,13 @@ console.log("[verify-windows-signature] OK");
 ### Why a `.ts` script (not a raw `.ps1`)
 
 - Matches existing convention — see `qcut/scripts/verify-packaged-ffmpeg.ts`
-  and `qcut/scripts/verify-packaged-aicp.ts`.
-- Easier to unit test (Vitest can mock `child_process`).
-- Cross-platform-safe: it can no-op on macOS/Linux dev machines without
-  blowing up the script chain in `dist:win:release`.
-
-### Verification
-
-- `cd qcut && bun run verify:windows-signature` after a signed local
-  build → exits 0.
-- Same command after a `dist:win:unsigned` build → exits non-zero.
+  and `qcut/scripts/verify-packaged-aicp.ts` (both confirmed present).
+- Easier to unit-test (Vitest can mock `child_process`).
+- Cross-platform-safe: no-ops on macOS/Linux dev machines.
 
 ---
 
-## 5. Dry-run release & manual verification
+## 5. Dry-run release & manual verification (shared)
 
 Manual smoke test on a clean Windows VM (no developer tools, fresh
 profile):
@@ -298,16 +341,17 @@ the workflow change and investigate.
 
 Out of scope for the v1 implementation but worth filing follow-up issues:
 
-- **OIDC federation for Azure auth** — replace `AZURE_CLIENT_SECRET` in
-  GitHub Actions with `azure/login@v2` + workload identity federation. No
-  rotating secrets to manage. See
-  [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md) §"Long-term: prefer
-  OIDC federation".
+- **(Path B only) OIDC federation for Azure auth** — replace
+  `AZURE_CLIENT_SECRET` with `azure/login@v2` + workload identity
+  federation. No rotating secrets to manage.
+- **(Path A only) `latest.yml` integrity** — once SignPath replaces the
+  signed installer, ensure `latest.yml` SHA512 is recomputed before
+  upload, or auto-update will reject the artifact.
 - **EV cert evaluation** — six months after v1 ships, review SmartScreen
-  warning rate and decide whether to upgrade to EV (see
-  [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)).
+  warning rate and decide whether to upgrade to EV.
 - **Microsoft Store distribution** — separate channel, separate
   certificate, separate review process. Issue #289 mentions it as a
   reputation booster but it is not part of this plan.
-- **Reproducible artifacts** — sign-in-place vs. sign-then-archive can
-  affect reproducibility; revisit if QCut adopts SLSA-style attestations.
+- **macOS signing** — currently *also* unconfigured in CI (no
+  `mac.identity`, no Apple secrets in `release.yml`). File a separate
+  task; do not bundle with the Windows work.

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -1,0 +1,313 @@
+# Windows Code Signing — Implementation
+
+Detailed engineering subtasks. Sequenced so each can be a single PR.
+File paths are relative to the repository root unless noted.
+
+> **Prerequisite:** Subtask 1 (cert procurement, see
+> [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)) is complete and the
+> following values are known and stored as GitHub Actions secrets:
+> `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
+> `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`,
+> `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME`.
+
+---
+
+## 1. Update `electron-builder` Windows config
+
+**Files:** `qcut/package.json` (lines 231–240, the `build.win` block).
+
+### Before
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": false,
+  "verifyUpdateCodeSignature": false,
+  "signAndEditExecutable": false,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store"
+}
+```
+
+### After
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": true,
+  "verifyUpdateCodeSignature": true,
+  "signAndEditExecutable": true,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store",
+  "azureSignOptions": {
+    "publisherName": "${env.WINDOWS_PUBLISHER_NAME}",
+    "endpoint": "${env.AZURE_TRUSTED_SIGNING_ENDPOINT}",
+    "certificateProfileName": "${env.AZURE_CERTIFICATE_PROFILE}",
+    "codeSigningAccountName": "${env.AZURE_TRUSTED_SIGNING_ACCOUNT}"
+  }
+}
+```
+
+### Why every flag matters
+
+- `forceCodeSigning: true` — fails the build if signing is misconfigured
+  instead of silently shipping unsigned bytes. Required by the issue's
+  acceptance criteria.
+- `verifyUpdateCodeSignature: true` — the auto-updater will refuse to
+  apply an update whose signature does not chain to the same publisher.
+  Defends against compromised update-server scenarios.
+- `signAndEditExecutable: true` — signs the `app.exe` inside the installer
+  too, not just the installer wrapper. Otherwise the *installed* app still
+  appears unsigned to the OS.
+- Values reference `${env.*}` so the same `package.json` works in CI and
+  locally without committing secrets.
+
+### Verification
+
+- `bun check-types` — config is JSON, no type impact, but run anyway.
+- `cd qcut && npx electron-builder --help | grep -i azure` — confirm the
+  installed `electron-builder` version supports `azureSignOptions`.
+
+---
+
+## 2. Update local `dist:win*` npm scripts
+
+**File:** `qcut/package.json` (lines 84, 86, 88, 89).
+
+The current scripts hard-code `--config.win.forceCodeSigning=false` and
+`--config.win.verifyUpdateCodeSignature=false`. Once subtask 1 lands,
+these overrides will *prevent* signing even on machines that have the
+Azure secrets exported.
+
+### Changes
+
+| Script | Old | New |
+|--------|-----|-----|
+| `dist:win` | `electron-builder --win --publish never -c.win.forceCodeSigning=false` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | (same as before) | **Keep as-is** — explicitly unsigned local-dev variant. Rename intent in script comment if helpful. |
+| `dist:win:release` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && …` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
+| `dist:win:fast` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` (**unchanged**) |
+
+### Rationale
+
+- `dist:win:unsigned` and `dist:win:fast` are deliberately kept unsigned —
+  developers without Azure access still need a way to build a working
+  installer for local smoke tests. They are not used by the release
+  pipeline.
+- `dist:win:release` is the canonical signed release script; it now runs
+  the new `verify:windows-signature` script (added in subtask 5) as a
+  belt-and-braces check.
+- Script `verify:windows-signature` will be added in `package.json`
+  `scripts` block alongside the other `verify:*` entries:
+
+```json
+"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+```
+
+### Verification
+
+- Run `cd qcut && bun run dist:win:unsigned` on a Windows machine — should
+  still produce an unsigned installer for local dev.
+- Run `cd qcut && bun run dist:win:release` with Azure secrets exported —
+  should produce a signed installer and exit 0.
+
+---
+
+## 3. Update GitHub Actions release workflow
+
+**File:** `qcut/.github/workflows/release.yml` (Windows job, lines 56–108).
+
+### Changes
+
+Step "Build Electron application" at line 94–98:
+
+**Before:**
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**After:**
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+    AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+    AZURE_CERTIFICATE_PROFILE: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
+    WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+```
+
+Add a new step **after** "Build Electron application" and **before**
+"Upload artifacts":
+
+```yaml
+- name: Verify Windows signature
+  shell: pwsh
+  run: |
+    cd qcut
+    bun run verify:windows-signature
+```
+
+### Why a separate verify step
+
+`forceCodeSigning: true` already aborts the build on signing failure, but
+a separate verify step:
+
+1. Runs `signtool verify /pa /v` against the *final* artifact path that
+   uploads to the release — catches any post-build mutation.
+2. Produces explicit log output that humans (and `prtaskit`) can scan
+   when investigating "why is this release showing unknown publisher" in
+   the future.
+3. Costs ~2 seconds; the value-to-cost ratio is excellent.
+
+### Verification
+
+- `actionlint qcut/.github/workflows/release.yml` (or
+  `npx @action-validator/cli`) — YAML syntax + secret-reference sanity.
+- Tag a `vX.Y.Z-rc.1` release and watch the workflow — signing should
+  succeed, the verify step should print `Successfully verified`.
+
+---
+
+## 4. Add post-build signature verification
+
+**New files:**
+
+- `qcut/scripts/verify-windows-signature.ts` — implementation.
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — see
+  [`TESTING.md`](TESTING.md).
+
+### Behaviour spec
+
+1. Locate the release artifact (`qcut/dist-electron/QCut*Setup*.exe`,
+   first match by mtime).
+2. On Windows, run `signtool verify /pa /v <path>`. On non-Windows, run
+   `osslsigncode verify <path>` if available; otherwise log a warning
+   and exit 0 (the script is only authoritative on Windows runners).
+3. Parse output. Require:
+   - Exit code 0.
+   - Subject CN matches `process.env.WINDOWS_PUBLISHER_NAME` if set.
+4. Exit non-zero with a clear message on failure.
+5. No silent fallbacks. If the artifact does not exist, fail loudly.
+
+### Sketch (final code lives in the new file)
+
+```ts
+// qcut/scripts/verify-windows-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME;
+
+function findInstaller(): string {
+  if (!existsSync(distDir)) {
+    throw new Error(`dist-electron not found at ${distDir}`);
+  }
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`No QCut*Setup*.exe found in ${distDir}`);
+  }
+  return join(distDir, candidates[0].f);
+}
+
+function verify(installer: string): void {
+  if (process.platform !== "win32") {
+    console.warn("[verify-windows-signature] non-Windows host, skipping");
+    return;
+  }
+  const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], {
+    encoding: "utf8",
+  });
+  console.log(out);
+  if (expectedPublisher && !out.includes(expectedPublisher)) {
+    throw new Error(
+      `Signed by unexpected publisher; expected "${expectedPublisher}" in signtool output`,
+    );
+  }
+}
+
+const installer = findInstaller();
+console.log(`[verify-windows-signature] verifying ${installer}`);
+verify(installer);
+console.log("[verify-windows-signature] OK");
+```
+
+### Why a `.ts` script (not a raw `.ps1`)
+
+- Matches existing convention — see `qcut/scripts/verify-packaged-ffmpeg.ts`
+  and `qcut/scripts/verify-packaged-aicp.ts`.
+- Easier to unit test (Vitest can mock `child_process`).
+- Cross-platform-safe: it can no-op on macOS/Linux dev machines without
+  blowing up the script chain in `dist:win:release`.
+
+### Verification
+
+- `cd qcut && bun run verify:windows-signature` after a signed local
+  build → exits 0.
+- Same command after a `dist:win:unsigned` build → exits non-zero.
+
+---
+
+## 5. Dry-run release & manual verification
+
+Manual smoke test on a clean Windows VM (no developer tools, fresh
+profile):
+
+1. Push a tag like `v2026.5.0-rc.1` to trigger the release workflow.
+2. Wait for `build-windows` to succeed; download the `windows-build`
+   artifact.
+3. On the VM, double-click the `.exe`.
+4. **Expected:** Windows shows `Publisher: <WINDOWS_PUBLISHER_NAME>`
+   (not "Unknown publisher"). SmartScreen may still display "Windows
+   protected your PC" until reputation builds — see "Risks" in
+   [`PLAN.md`](PLAN.md).
+5. Open PowerShell on the VM:
+   ```powershell
+   Get-AuthenticodeSignature .\QCut*Setup*.exe
+   ```
+   Expect `Status: Valid` and a non-empty `SignerCertificate.Subject`.
+6. `signtool verify /pa /v .\QCut*Setup*.exe` → exit 0, "Successfully
+   verified".
+
+If any step fails, **do not promote** the rc tag to a release. Roll back
+the workflow change and investigate.
+
+---
+
+## 6. Future hardening (track separately)
+
+Out of scope for the v1 implementation but worth filing follow-up issues:
+
+- **OIDC federation for Azure auth** — replace `AZURE_CLIENT_SECRET` in
+  GitHub Actions with `azure/login@v2` + workload identity federation. No
+  rotating secrets to manage. See
+  [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md) §"Long-term: prefer
+  OIDC federation".
+- **EV cert evaluation** — six months after v1 ships, review SmartScreen
+  warning rate and decide whether to upgrade to EV (see
+  [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)).
+- **Microsoft Store distribution** — separate channel, separate
+  certificate, separate review process. Issue #289 mentions it as a
+  reputation booster but it is not part of this plan.
+- **Reproducible artifacts** — sign-in-place vs. sign-then-archive can
+  affect reproducibility; revisit if QCut adopts SLSA-style attestations.

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.md
@@ -313,7 +313,7 @@ This script runs in two places:
 
 ## 5. Future hardening (track separately)
 
-- **Migrate to SSL.com eSigner OV** if manual signing becomes a bottleneck. Adds full CI automation; adds ~$50/year.
+- **Migrate to SSL.com eSigner OV** if manual signing becomes a bottleneck. Adds full CI automation. Adds **~$220+/year** ($239/year cert + $200–240/year eSigner Cloud Signing subscription, dual cost — earlier drafts erroneously claimed "~$50 more"). Justified only at >1 release/week — at QCut's current cadence the manual phone-approval cost is ~minutes/year, not worth $220.
 - **Add team member to Certum account** so signing is not blocked when Donghao is offline.
 - **Reputation acceleration**: keep release frequency moderate (don't release weekly), encourage downloads to flow through stable URLs that aggregate hash reputation faster.
 - **Re-evaluate Azure Artifact Signing in 2027-06** once Quriosity hits 3-year mark — and if Microsoft has expanded country eligibility to AU. If both are true, $120/year + full CI automation makes Azure attractive again.

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -1,31 +1,74 @@
-# Windows 代码签名 — 实现细节
+# Windows 代码签名 — 实现细节（Certum SimplySign）
 
-每个工程子任务的具体步骤。子任务按顺序排列，每个都是一个独立 PR。
-所有路径如无特别说明，均相对于仓库根目录。
+工程子任务。每个都能独立合并。路径：Certum SimplySign Standard
+Code Signing（Cloud）。其他路径为什么排除见
+[CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md)。
 
-> **看下面之前先选路径。** [`PLAN.zh-CN.md`](PLAN.zh-CN.md) 里子任务 1
-> 的结果决定走 **Path A（SignPath，免费，开源）** 还是 **Path B
-> （Azure Trusted Signing，付费，fallback）**。§A* 节适用于 Path A，
-> §B* 节适用于 Path B，§4–§6 是共享的。**只实现一条路径。**
+> **前置条件：** [PROCUREMENT 子任务 1–2](PLAN.zh-CN.md#子任务拆分)
+> 已完成 — Certum 订单已付款、身份验证通过、证书已签发并绑定到
+> SimplySign Cloud HSM 身份。
 
 ---
 
-## Path A — SignPath（推荐）
+## 架构决策：签名在哪里发生
 
-**前置条件：** 子任务 1a 完成，下面这些已存进 GitHub Actions 的
-secret / variables：
+Certum SimplySign 要求**每次** `signtool` 调用都通过手机确认 — 推送
+到 Donghao 的手机，他点 "Approve"，签名才进行。这是 Cloud HSM 的
+安全模型，**无法关闭**。
 
-- `SIGNPATH_API_TOKEN`（secret）
-- `SIGNPATH_ORGANIZATION_ID`（variable，UUID）
-- `SIGNPATH_PROJECT_SLUG`（variable，例如 `qcut`）
-- `SIGNPATH_SIGNING_POLICY_SLUG`（variable，例如 `release-signing`）
-- `SIGNPATH_ARTIFACT_SLUG`（variable，例如 `qcut-installer`）
-- `WINDOWS_PUBLISHER_NAME`（variable，期望的 subject CN — SignPath
-  审批通过时会告诉你）
+意味着：GitHub Actions 不能完全自动化签名步骤。三种架构干净的选项：
 
-### A1. 修改 `electron-builder` Windows 配置
+| 方案 | 签名在哪里发生 | 权衡 |
+|------|--------------|------|
+| **A（采用）：CI 出未签名包，本地签后再发布** | CI 出未签名 `.exe` artifact；维护者下载、本地 Windows 机签、把签好的 artifact 上传到 GitHub Release | 每次发布人工 ~5 分钟。Inkdrop 也是这个工作流。 |
+| B：自托管 Windows runner 装 SimplySign | runner 触发签名；Donghao 仍然要在手机上点确认 | 增加 runner 托管成本和 SimplySign 常驻运维。手机确认还是要 — 没省什么。 |
+| C：换成 SSL.com eSigner OV | CI 用 REST API token 签 | 每年多 ~$50，全自动。如果 A 变痛点的迁移路径。 |
 
-**文件：** `qcut/package.json`（第 231–240 行的 `build.win` 块）。
+**采用方案 A。** 这是 indie Electron 圈的行业惯例，而且最便宜。
+迁移到 C 作为未来加固保留。
+
+---
+
+## 0. 工具链准备
+
+**Donghao 的电脑上一次性配置**（如果他主用 macOS，需要在 Windows VM 里配 — 见 [PLAN.zh-CN.md 风险 #2](PLAN.zh-CN.md#风险与待定问题)）。
+
+1. **装 SimplySign 手机 App** — iOS/Android。用身份验证通过后 Certum 邮件里的激活码配对。
+2. **装 SimplySign 桌面签名工具** — `proCertumCardManager` 或新版 SimplySign desktop。下载地址：https://www.certum.eu/en/cert_expert_simply_sign/。
+3. **装 Windows SDK signtool** — 需要 `signtool.exe`。两种方式：
+   - 单独装：`winget install --id Microsoft.WindowsSDK`，然后用 `C:\Program Files (x86)\Windows Kits\10\bin\<version>\x64\signtool.exe`，或
+   - 装 Visual Studio Build Tools。
+4. **认证 SimplySign 桌面工具** — 打开它，输 Certum 登录信息，用手机扫 SimplySign 二维码。工具会通过 PKCS#11 把 Cloud HSM 身份暴露给 Windows CryptoAPI / signtool。
+5. **验证** — PowerShell 跑：
+   ```powershell
+   certutil -store -user My
+   ```
+   应该能看到 Quriosity Pty Ltd 的 Developer ID Application 证书，私钥引用指向 SimplySign 的 CSP。
+
+任何一步失败，后面的实现都做不了。
+
+---
+
+## 1. 修改 `electron-builder` Windows 配置
+
+**文件：** `qcut/package.json`（`build.win` 块，第 231–240 行）。
+
+### 修改前
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": false,
+  "verifyUpdateCodeSignature": false,
+  "signAndEditExecutable": false,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store"
+}
+```
+
+### 修改后
 
 ```json
 "win": {
@@ -40,229 +83,128 @@ secret / variables：
 }
 ```
 
-**为什么 Path A 选这些值：**
+### 为什么这些值
 
-- `forceCodeSigning: false` — SignPath 在 `electron-builder` **完成之后**
-  才签名，所以 builder 不能在内联签名上卡住。
-- `verifyUpdateCodeSignature: true` — 自动更新仍然要校验后续更新链到
-  同一发布者。
-- `signAndEditExecutable: false` — 同 `forceCodeSigning` 的原因。
-  SignPath 的 signing policy 可以配置成同时签内层 `app.exe` 和外层
-  安装包，那是服务端的事。
+- **`forceCodeSigning: false`** — 仍然 `false`，因为签名发生在 electron-builder **完成之后**（我们的本地签名步骤里）。如果设成 `true`，electron-builder 会在 build 期间想签，但 runner 钥匙串里没证书，构建会失败。
+- **`verifyUpdateCodeSignature: true`** — 从 `false` 翻成 `true`。自动更新会拒绝签名链不匹配同一发布者的更新。防御更新服务器被入侵的场景。
+- **`signAndEditExecutable: false`** — 仍然 `false`，因为我们在本地签名步骤里签**外层**安装包 `.exe`。安装包内的 `app.exe` 也在那一步签。
+- **没有 `azureSignOptions`** — Azure 路径已排除（见 [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md#-azure-trusted-signingmicrosoft-artifact-signing)）。
 
-### A2. 修改本地 `dist:win*` 脚本
+### 改本地 `dist:win*` npm 脚本
 
 **文件：** `qcut/package.json`（第 84、86、88、89 行）。
 
-`dist:win` 和 `dist:win:release` 里的 `forceCodeSigning=false` 覆盖
-**还是要去掉**（与新配置重复）。`dist:win:unsigned` 和 `dist:win:fast`
-保留显式 `forceCodeSigning=false`，方便本地开发故意做未签名构建。
+去掉 `forceCodeSigning=false` 覆盖 — 跟新的 `build.win.forceCodeSigning: false` 重复，将来维护者会困惑两边为什么都设。
 
-| 脚本 | 新值 |
-|------|-----|
-| `dist:win` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | 不变 |
-| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp`（这里**不**跑 `verify:windows-signature` — 那个在 CI 里 SignPath 返回签名产物**之后**才跑，见 §A3） |
-| `dist:win:fast` | 不变 |
+| 脚本 | 旧 | 新 |
+|------|----|----|
+| `dist:win` | `… -c.win.forceCodeSigning=false` | `… --publish never`（去掉覆盖） |
+| `dist:win:unsigned` | 不变 | 不变 — 显式表示"不打算签的构建" |
+| `dist:win:release` | `… --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false …` | `… --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp` |
+| `dist:win:fast` | 不变 | 不变 — 本地快速迭代变体 |
 
-`scripts` 块还要新加：
+加到 `scripts`：
 
 ```json
-"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+"sign:win": "bun scripts/sign-windows-release.ts",
+"verify:win-signature": "bun scripts/verify-windows-signature.ts"
 ```
 
-（CI 在 §A3 第 3 步会调它。）
+---
 
-### A3. 修改 GitHub Actions 发布工作流
+## 2. 修改 GitHub Actions 发布工作流
 
-**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，
-第 56–108 行）。
+**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，第 56–108 行）。
 
-**第 1 步 — 修改** "Build Electron application"（第 94–98 行），
-去掉 `forceCodeSigning=false` 覆盖：
+Windows CI build 出**未签名**的 `.exe` 并上传作为 artifact。维护者下载、本地签、把签好的 `.exe` 手工上传回 Release。
+
+### 2.1 — 改 "Build Electron application" 步骤
 
 ```yaml
-- name: Build Electron application
+- name: Build Electron application（unsigned — sign locally per release）
   run: |
     npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-**第 2 步 — 新增** "Submit signing request to SignPath"，放在
-build 之后、"Upload artifacts" 之前：
+（删了 `--config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false` 覆盖 — `package.json` 已经给了正确的默认值。）
+
+### 2.2 — 调整 artifact 上传
+
+Windows 任务继续上传未签名 `.exe`。release publish 步骤**不**自动把 Windows artifact 挂到 GitHub Release 上，要等签好。
 
 ```yaml
-- name: Upload unsigned artifact for signing
-  id: upload-unsigned
+- name: Upload unsigned Windows artifact
   uses: actions/upload-artifact@v7
   with:
-    name: windows-unsigned
-    path: qcut/dist-electron/QCut*Setup*.exe
+    name: windows-build-unsigned
+    path: |
+      qcut/dist-electron/QCut*Setup*.exe
+      qcut/dist-electron/latest.yml
     if-no-files-found: error
-
-- name: Submit signing request to SignPath
-  id: signpath
-  uses: signpath/github-action-submit-signing-request@v1
-  with:
-    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-    organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-    project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-    signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
-    artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_SLUG }}
-    github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
-    wait-for-completion: true
-    output-artifact-directory: qcut/dist-electron-signed
-
-- name: Replace unsigned artifact with signed
-  shell: pwsh
-  run: |
-    Remove-Item qcut/dist-electron/QCut*Setup*.exe
-    Move-Item qcut/dist-electron-signed/QCut*Setup*.exe qcut/dist-electron/
 ```
 
-**第 3 步 — 新增**签名校验（与 §4 / §B3 同一步）：
+（artifact 重命名为 `windows-build-unsigned`，让 Actions UI 上能看出状态。）
 
-```yaml
-- name: Verify Windows signature
-  shell: pwsh
-  env:
-    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
-  run: |
-    cd qcut
-    bun run verify:windows-signature
-```
+### 2.3 — 改 release-publish 步骤
 
-**第 4 步 — 调整** "Upload artifacts"（第 100 行）使其上传**已签名**的
-文件（路径不变，因为我们把签名文件移回了 `dist-electron/`）。
+聚合的 `release` job（约第 277 行附近）当前下载 `windows-build` 并把 `.exe` 挂到 Release。改成：
 
-> **`latest.yml` 注意事项：** `dist-electron/` 里的 `latest.yml` 是
-> electron-builder 基于*未签名*文件的哈希生成的。SignPath 替换文件后，
-> `latest.yml` 里的 SHA512 就错了，自动更新会拒绝产物。修复方法：
-> 在替换步骤之后重新生成 `latest.yml`。SignPath 的文档有覆盖这个，
-> 常见做法是写个小脚本重新计算 SHA512 并改写 `latest.yml`。如果到
-> 实施时 SignPath 官方 action 还没内置，单独立一个子 PR 跟踪。
+- 不再自动挂未签名的 Windows 文件。两种做法：
+  - **(2.3a)** 在 release-publish 步骤里**完全跳过** Windows 文件 — 维护者本地跑 `bun run sign:win` 后手工上传签名 `.exe` 到 Release。简单。
+  - **(2.3b)** 加一个 "等待签名 Windows artifact" 的步骤，轮询维护者上传的签名 artifact，然后再发布。自动化更好但复杂度高。
+
+v1 选 **2.3a**。把手工步骤写清楚：
+
+> 📋 **发布操作员手册：**
+> 1. 等 `build-windows` 任务成功。
+> 2. 下载 `windows-build-unsigned` artifact。
+> 3. 跑 `bun run sign:win`（前提是 SimplySign 桌面工具已认证）。
+> 4. 在手机上批准签名（约 30 秒）。
+> 5. 把签好的 `.exe` 和更新过的 `latest.yml` 手工上传到 GitHub Release。
+
+### 2.4 — `latest.yml` 完整性
+
+`latest.yml` 里有 `.exe` 的 SHA512。签名改了字节，所以 `latest.yml` 里的 SHA512 就错了。本地签名脚本（下一节）会重新计算并写回 `latest.yml`。
 
 ---
 
-## Path B — Azure Trusted Signing（fallback）
+## 3. 加本地签名辅助脚本
 
-**前置条件：** 子任务 1b 完成，下面这些是 GitHub Actions
-secret / variables：
-
-- `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`（secret）
-- `AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、
-  `AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME`（variable）
-
-### B1. 修改 `electron-builder` Windows 配置
-
-**文件：** `qcut/package.json`（第 231–240 行）。
-
-```json
-"win": {
-  "target": "nsis",
-  "icon": "build/icon.ico",
-  "forceCodeSigning": true,
-  "verifyUpdateCodeSignature": true,
-  "signAndEditExecutable": true,
-  "requestedExecutionLevel": "asInvoker",
-  "artifactName": "${productName}-Setup-${version}.${ext}",
-  "compression": "store",
-  "azureSignOptions": {
-    "publisherName": "${env.WINDOWS_PUBLISHER_NAME}",
-    "endpoint": "${env.AZURE_TRUSTED_SIGNING_ENDPOINT}",
-    "certificateProfileName": "${env.AZURE_CERTIFICATE_PROFILE}",
-    "codeSigningAccountName": "${env.AZURE_TRUSTED_SIGNING_ACCOUNT}"
-  }
-}
-```
-
-**每个 flag 的意义：**
-
-- `forceCodeSigning: true` — 签名配置错误时构建立即失败，避免悄悄发出
-  未签名版本。
-- `verifyUpdateCodeSignature: true` — 自动更新拒绝签名链不匹配的更新。
-- `signAndEditExecutable: true` — 顺带给内层 `app.exe` 签名。
-- `${env.*}` 占位让密钥不进 `package.json`。
-
-### B2. 修改本地 `dist:win*` 脚本
-
-形式与 §A2 一致，但未签名脚本（`dist:win:unsigned`、`dist:win:fast`）
-对没有 Azure 权限的开发者仍然有用。
-
-| 脚本 | 新值 |
-|------|-----|
-| `dist:win` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | 不变（`forceCodeSigning=false` 覆盖保留，给本地未签名构建用） |
-| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
-| `dist:win:fast` | 不变 |
-
-也要按 §A2 加 `verify:windows-signature` 脚本条目。
-
-### B3. 修改 GitHub Actions 发布工作流
-
-**文件：** `qcut/.github/workflows/release.yml`。
-
-修改 "Build Electron application"（第 94–98 行）：
-
-```yaml
-- name: Build Electron application
-  run: |
-    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-    AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-    AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
-    AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
-    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
-```
-
-加签名校验步骤（与 §A3 第 3 步相同），放在 build **之后**、
-"Upload artifacts" **之前**。
-
-`latest.yml` 在这条路径下是天然正确的，因为签名是内联完成。
-
----
-
-## 4. 增加构建后签名校验（共享）
-
-与路径无关。Path A 和 Path B 都用。
-
-**新增文件：**
-
-- `qcut/scripts/verify-windows-signature.ts` — 实现。
-- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — 见
-  [`TESTING.zh-CN.md`](TESTING.zh-CN.md)。
+**新增文件：** `qcut/scripts/sign-windows-release.ts`。
 
 ### 行为规范
 
-1. 在 `qcut/dist-electron/QCut*Setup*.exe` 里找发布产物（取最新修改时间）。
-2. Windows 上跑 `signtool verify /pa /v <path>`。非 Windows 上打 warn
-   然后跳过（这个脚本只在 Windows runner 上是权威校验）。
-3. 解析输出。要求：
-   - 退出码为 0。
-   - 如果设置了 `process.env.WINDOWS_PUBLISHER_NAME`，subject CN 必须匹配。
-4. 失败时退出非零，并输出明确信息。
-5. 不做静默 fallback。文件不存在就立即报错。
+1. 在 `qcut/dist-electron/` 找最新的未签名 `QCut*Setup*.exe`。
+2. 跑 `signtool sign /tr http://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`。
+   - `sha1 <thumbprint>` — 从 SimplySign 暴露的身份库选 Quriosity 证书。
+   - `tr` — RFC 3161 时间戳服务。微软的对 SmartScreen 信誉对齐最好。
+   - `td sha256` 和 `fd sha256` — 现代 SHA-256 算法（CA/B Forum 2024 后强制要求）。
+3. SimplySign 手机 App 弹窗确认。Donghao 点批准。
+4. 签完跑 `signtool verify /pa /v <exe>` 确认。
+5. 更新 `latest.yml`：
+   - 重新计算签名后 `.exe` 的 SHA512。
+   - 重新计算文件大小。
+   - 写回 `latest.yml`。
+6. 输出汇总。
 
 ### 代码草稿
 
 ```ts
-// qcut/scripts/verify-windows-signature.ts
+// qcut/scripts/sign-windows-release.ts
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 const distDir = join(import.meta.dir, "..", "dist-electron");
-const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME;
+const certThumbprint = process.env.QCUT_WIN_CERT_THUMBPRINT;
+if (!certThumbprint) {
+  throw new Error("设置 QCUT_WIN_CERT_THUMBPRINT 为 Quriosity 证书的 SHA1");
+}
 
-function findInstaller(): string {
-  if (!existsSync(distDir)) {
-    throw new Error(`找不到 dist-electron：${distDir}`);
-  }
+function findUnsignedInstaller(): string {
   const candidates = readdirSync(distDir)
     .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
     .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
@@ -273,74 +215,123 @@ function findInstaller(): string {
   return join(distDir, candidates[0].f);
 }
 
-function verify(installer: string): void {
-  if (process.platform !== "win32") {
-    console.warn("[verify-windows-signature] 非 Windows 主机，跳过");
-    return;
-  }
-  const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], {
-    encoding: "utf8",
-  });
-  console.log(out);
-  if (expectedPublisher && !out.includes(expectedPublisher)) {
-    throw new Error(
-      `发布者不一致；期望在 signtool 输出里看到 "${expectedPublisher}"`,
-    );
-  }
+const exe = findUnsignedInstaller();
+console.log(`[sign-windows-release] 签名 ${exe}`);
+console.log("[sign-windows-release] 在手机的 SimplySign App 上批准...");
+
+execFileSync("signtool", [
+  "sign",
+  "/tr", "http://timestamp.acs.microsoft.com",
+  "/td", "sha256",
+  "/fd", "sha256",
+  "/sha1", certThumbprint,
+  "/sm",
+  exe,
+], { stdio: "inherit" });
+
+execFileSync("signtool", ["verify", "/pa", "/v", exe], { stdio: "inherit" });
+
+// 更新 latest.yml
+const latestYmlPath = join(distDir, "latest.yml");
+if (existsSync(latestYmlPath)) {
+  const buffer = readFileSync(exe);
+  const sha512 = createHash("sha512").update(buffer).digest("base64");
+  const size = buffer.length;
+  let yml = readFileSync(latestYmlPath, "utf8");
+  yml = yml.replace(/sha512: .+/g, `sha512: ${sha512}`);
+  yml = yml.replace(/size: \d+/g, `size: ${size}`);
+  writeFileSync(latestYmlPath, yml);
+  console.log("[sign-windows-release] 更新了 latest.yml 的 SHA512 + size");
 }
 
-const installer = findInstaller();
-console.log(`[verify-windows-signature] 校验 ${installer}`);
-verify(installer);
-console.log("[verify-windows-signature] OK");
+console.log("[sign-windows-release] 完成");
 ```
 
 ### 为什么用 `.ts` 脚本（不直接写 `.ps1`）
 
-- 与现有约定一致 — 见 `qcut/scripts/verify-packaged-ffmpeg.ts` 和
-  `qcut/scripts/verify-packaged-aicp.ts`（已确认存在）。
-- 单元测试更容易（Vitest 可以 mock `child_process`）。
-- 跨平台安全 — 在 macOS/Linux 开发机上能 no-op，不会让
-  `dist:win:release` 链断掉。
+- 与现有约定一致 — 见 `qcut/scripts/verify-packaged-ffmpeg.ts` 和 `verify-packaged-aicp.ts`（已确认存在）。
+- Vitest 单测好写。
+- 跨平台路径处理。
 
 ---
 
-## 5. 发布演练（人工验证，共享）
+## 4. 加签名后的校验脚本
 
-在干净 Windows 虚拟机（无开发工具、新用户配置）上做冒烟测试：
+**新增文件：** `qcut/scripts/verify-windows-signature.ts`。
 
-1. 推一个 `v2026.5.0-rc.1` tag，触发 release 工作流。
-2. 等 `build-windows` 成功，下载 `windows-build` artifact。
-3. 在 VM 上双击 `.exe`。
-4. **预期：** Windows 显示 `发布者：<WINDOWS_PUBLISHER_NAME>`
-   （不是"未知发布者"）。SmartScreen 仍可能显示"Windows protected
-   your PC"，要等信誉积累 — 见 [`PLAN.zh-CN.md`](PLAN.zh-CN.md) 风险章节。
-5. 在 VM 里打开 PowerShell：
+行为跟之前几版方案里那个校验脚本一样 — 跑 `signtool verify /pa /v`，断言发布者 subject 匹配期望的 `WINDOWS_PUBLISHER_NAME` 环境变量（设为 `"Quriosity Pty Ltd"`）。
+
+### 代码草稿
+
+```ts
+// qcut/scripts/verify-windows-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME ?? "Quriosity Pty Ltd";
+
+function findInstaller(): string {
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`${distDir} 里找不到 QCut*Setup*.exe`);
+  }
+  return join(distDir, candidates[0].f);
+}
+
+if (process.platform !== "win32") {
+  console.warn("[verify-windows-signature] 非 Windows 主机，跳过");
+  process.exit(0);
+}
+
+const installer = findInstaller();
+const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], { encoding: "utf8" });
+console.log(out);
+
+if (!out.includes(expectedPublisher)) {
+  throw new Error(`签名发布者不匹配；期望在 signtool 输出里看到 "${expectedPublisher}"`);
+}
+
+console.log("[verify-windows-signature] OK");
+```
+
+这个脚本在两个地方跑：
+- `bun run sign:win` 之后（上传 Release 前的 sanity check）。
+- 在 GitHub Release 页面下载已发布 `.exe` 后人工跑（冒烟测试）。
+
+---
+
+## 5. 未来加固（单独跟踪）
+
+- **迁移到 SSL.com eSigner OV** — 如果手工签名变成瓶颈。完全自动化 CI；每年多 ~$50。
+- **给 Certum 账号加第二个团队成员**，避免 Donghao 离线时签不了。
+- **加快信誉积累**：发布频率别太高（不要每周发版），让下载尽量走稳定 URL，加速 hash 信誉积累。
+- **2027-06 重新评估 Azure Artifact Signing** — Quriosity 满 3 年时，看微软是否扩大了国家资格到澳洲。如果两个条件都满足，$120/年 + 全自动 CI 让 Azure 重新有吸引力。
+
+---
+
+## 6. 在干净 Windows VM 上做发布演练
+
+所有 PR 落地后，做一次端到端人工测试：
+
+1. CI：推 `v2026.5.0-rc.1` tag，等 `build-windows` 出 `windows-build-unsigned` artifact。
+2. 把 artifact 下载到本地配好 SimplySign 的 Windows 机。
+3. 跑 `bun run sign:win`。在手机批准。确认脚本输出 "完成"。
+4. 跑 `bun run verify:win-signature`。期望 "OK"。
+5. 把签名 `.exe` + `latest.yml` 手工上传到 GitHub Release 页面。
+6. 在**干净** Windows Sequoia/11 VM（无开发工具，新用户）上：
+   - 从 Release 页面下载 `.exe`。
+   - 双击。SmartScreen 可能弹警告（"Windows protected your PC"）。点 "More info" → 确认看到 "Quriosity Pty Ltd"。点 "Run anyway"。
+   - **预期 UAC 弹窗：** 蓝色背景，"Verified publisher: Quriosity Pty Ltd"。点 "Yes"。
+   - QCut 正常安装。
+7. VM 的 PowerShell 里：
    ```powershell
-   Get-AuthenticodeSignature .\QCut*Setup*.exe
+   Get-AuthenticodeSignature "C:\Users\<你>\Downloads\QCut*Setup*.exe"
    ```
-   期望 `Status: Valid`，`SignerCertificate.Subject` 不为空。
-6. `signtool verify /pa /v .\QCut*Setup*.exe` → 退出 0，输出
-   "Successfully verified"。
+   期望 `Status: Valid`，`SignerCertificate.Subject` 包含 "Quriosity Pty Ltd"。
 
-任何一步失败都**不要**把 rc tag 提升为 release。回滚工作流改动，
-排查问题。
-
----
-
-## 6. 后续加固（单独跟踪）
-
-不属于 v1，但值得另开 issue 跟踪：
-
-- **（仅 Path B）Azure 认证用 OIDC 联邦身份** — 用 `azure/login@v2` +
-  工作负载身份联邦取代 GitHub Secret 里的 `AZURE_CLIENT_SECRET`。
-  永远不用轮换密钥。
-- **（仅 Path A）`latest.yml` 完整性** — SignPath 替换签名安装包后，
-  必须在上传前重算 `latest.yml` 的 SHA512，否则自动更新会拒收。
-- **EV 证书评估** — v1 上线 6 个月后，看看 SmartScreen 警告率，决定
-  是否升级到 EV。
-- **Microsoft Store 渠道** — 单独的渠道、单独的证书、单独的审核流程。
-  issue #289 提到这能加分，但不在本方案范围内。
-- **macOS 签名** — 目前 CI 里**也**没配（没有 `mac.identity`，
-  `release.yml` 没 Apple secret）。单独立 issue 跟踪，不要跟 Windows
-  这次的工作捆绑。
+任一步失败都**不要**把 rc tag 提升为 release。回滚排查问题。

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -87,7 +87,7 @@ Certum SimplySign 要求**每次** `signtool` 调用都通过手机确认 — �
 
 - **`forceCodeSigning: false`** — 仍然 `false`，因为签名发生在 electron-builder **完成之后**（我们的本地签名步骤里）。如果设成 `true`，electron-builder 会在 build 期间想签，但 runner 钥匙串里没证书，构建会失败。
 - **`verifyUpdateCodeSignature: true`** — 从 `false` 翻成 `true`。自动更新会拒绝签名链不匹配同一发布者的更新。防御更新服务器被入侵的场景。
-- **`signAndEditExecutable: false`** — 仍然 `false`，因为我们在本地签名步骤里签**外层**安装包 `.exe`。安装包内的 `app.exe` 也在那一步签。
+- **`signAndEditExecutable: false`** — 仍然 `false`，因为**本地签名步骤里我们只用 `signtool` 签外层 NSIS `Setup.exe`**。安装包内的 `app.exe` 是在 electron-builder 的 **unpacked 阶段**（NSIS 打包之前）签的——前提是构建环境里有 `signtool.exe` 和证书；对已经打包好的 `Setup.exe` 再跑 `signtool` **不会**重新签里面的嵌套二进制。如果将来 CI 构建跳过 unpacked 阶段签名（例如 runner 上没证书），本地签名脚本就需要扩展为：解包 → 签 `app.exe` → 重新打包 → 签 `Setup.exe`。自动更新签名校验（`verifyUpdateCodeSignature: true`）只检查 electron-updater 下载的那个文件 — 对 QCut 来说就是 `Setup.exe`，所以这个两阶段细节不影响更新逻辑，但对于内层二进制的 SmartScreen 信誉很关键。
 - **没有 `azureSignOptions`** — Azure 路径已排除（见 [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md#-azure-trusted-signingmicrosoft-artifact-signing)）。
 
 ### 改本地 `dist:win*` npm 脚本
@@ -114,7 +114,7 @@ Certum SimplySign 要求**每次** `signtool` 调用都通过手机确认 — �
 
 ## 2. 修改 GitHub Actions 发布工作流
 
-**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，第 56–108 行）。
+**文件：** `.github/workflows/release.yml`（Windows 任务，第 56–108 行）。
 
 Windows CI build 出**未签名**的 `.exe` 并上传作为 artifact。维护者下载、本地签、把签好的 `.exe` 手工上传回 Release。
 
@@ -323,7 +323,7 @@ console.log("[verify-windows-signature] OK");
 3. 跑 `bun run sign:win`。在手机批准。确认脚本输出 "完成"。
 4. 跑 `bun run verify:win-signature`。期望 "OK"。
 5. 把签名 `.exe` + `latest.yml` 手工上传到 GitHub Release 页面。
-6. 在**干净** Windows Sequoia/11 VM（无开发工具，新用户）上：
+6. 在**干净** Windows 11 VM（或 Windows 10/11，无开发工具，新用户）上：
    - 从 Release 页面下载 `.exe`。
    - 双击。SmartScreen 可能弹警告（"Windows protected your PC"）。点 "More info" → 确认看到 "Quriosity Pty Ltd"。点 "Run anyway"。
    - **预期 UAC 弹窗：** 蓝色背景，"Verified publisher: Quriosity Pty Ltd"。点 "Yes"。

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -3,27 +3,36 @@
 每个工程子任务的具体步骤。子任务按顺序排列，每个都是一个独立 PR。
 所有路径如无特别说明，均相对于仓库根目录。
 
-> **前置条件：** 子任务 1（购买证书，见
-> [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)）已完成，
-> 下面这些值已经存到 GitHub Actions secret 里：
-> `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`、
-> `AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、
-> `AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME`。
+> **看下面之前先选路径。** [`PLAN.zh-CN.md`](PLAN.zh-CN.md) 里子任务 1
+> 的结果决定走 **Path A（SignPath，免费，开源）** 还是 **Path B
+> （Azure Trusted Signing，付费，fallback）**。§A* 节适用于 Path A，
+> §B* 节适用于 Path B，§4–§6 是共享的。**只实现一条路径。**
 
 ---
 
-## 1. 修改 `electron-builder` Windows 配置
+## Path A — SignPath（推荐）
+
+**前置条件：** 子任务 1a 完成，下面这些已存进 GitHub Actions 的
+secret / variables：
+
+- `SIGNPATH_API_TOKEN`（secret）
+- `SIGNPATH_ORGANIZATION_ID`（variable，UUID）
+- `SIGNPATH_PROJECT_SLUG`（variable，例如 `qcut`）
+- `SIGNPATH_SIGNING_POLICY_SLUG`（variable，例如 `release-signing`）
+- `SIGNPATH_ARTIFACT_SLUG`（variable，例如 `qcut-installer`）
+- `WINDOWS_PUBLISHER_NAME`（variable，期望的 subject CN — SignPath
+  审批通过时会告诉你）
+
+### A1. 修改 `electron-builder` Windows 配置
 
 **文件：** `qcut/package.json`（第 231–240 行的 `build.win` 块）。
-
-### 修改前
 
 ```json
 "win": {
   "target": "nsis",
   "icon": "build/icon.ico",
   "forceCodeSigning": false,
-  "verifyUpdateCodeSignature": false,
+  "verifyUpdateCodeSignature": true,
   "signAndEditExecutable": false,
   "requestedExecutionLevel": "asInvoker",
   "artifactName": "${productName}-Setup-${version}.${ext}",
@@ -31,7 +40,123 @@
 }
 ```
 
-### 修改后
+**为什么 Path A 选这些值：**
+
+- `forceCodeSigning: false` — SignPath 在 `electron-builder` **完成之后**
+  才签名，所以 builder 不能在内联签名上卡住。
+- `verifyUpdateCodeSignature: true` — 自动更新仍然要校验后续更新链到
+  同一发布者。
+- `signAndEditExecutable: false` — 同 `forceCodeSigning` 的原因。
+  SignPath 的 signing policy 可以配置成同时签内层 `app.exe` 和外层
+  安装包，那是服务端的事。
+
+### A2. 修改本地 `dist:win*` 脚本
+
+**文件：** `qcut/package.json`（第 84、86、88、89 行）。
+
+`dist:win` 和 `dist:win:release` 里的 `forceCodeSigning=false` 覆盖
+**还是要去掉**（与新配置重复）。`dist:win:unsigned` 和 `dist:win:fast`
+保留显式 `forceCodeSigning=false`，方便本地开发故意做未签名构建。
+
+| 脚本 | 新值 |
+|------|-----|
+| `dist:win` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | 不变 |
+| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp`（这里**不**跑 `verify:windows-signature` — 那个在 CI 里 SignPath 返回签名产物**之后**才跑，见 §A3） |
+| `dist:win:fast` | 不变 |
+
+`scripts` 块还要新加：
+
+```json
+"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+```
+
+（CI 在 §A3 第 3 步会调它。）
+
+### A3. 修改 GitHub Actions 发布工作流
+
+**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，
+第 56–108 行）。
+
+**第 1 步 — 修改** "Build Electron application"（第 94–98 行），
+去掉 `forceCodeSigning=false` 覆盖：
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**第 2 步 — 新增** "Submit signing request to SignPath"，放在
+build 之后、"Upload artifacts" 之前：
+
+```yaml
+- name: Upload unsigned artifact for signing
+  id: upload-unsigned
+  uses: actions/upload-artifact@v7
+  with:
+    name: windows-unsigned
+    path: qcut/dist-electron/QCut*Setup*.exe
+    if-no-files-found: error
+
+- name: Submit signing request to SignPath
+  id: signpath
+  uses: signpath/github-action-submit-signing-request@v1
+  with:
+    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+    organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+    project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+    signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+    artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_SLUG }}
+    github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+    wait-for-completion: true
+    output-artifact-directory: qcut/dist-electron-signed
+
+- name: Replace unsigned artifact with signed
+  shell: pwsh
+  run: |
+    Remove-Item qcut/dist-electron/QCut*Setup*.exe
+    Move-Item qcut/dist-electron-signed/QCut*Setup*.exe qcut/dist-electron/
+```
+
+**第 3 步 — 新增**签名校验（与 §4 / §B3 同一步）：
+
+```yaml
+- name: Verify Windows signature
+  shell: pwsh
+  env:
+    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
+  run: |
+    cd qcut
+    bun run verify:windows-signature
+```
+
+**第 4 步 — 调整** "Upload artifacts"（第 100 行）使其上传**已签名**的
+文件（路径不变，因为我们把签名文件移回了 `dist-electron/`）。
+
+> **`latest.yml` 注意事项：** `dist-electron/` 里的 `latest.yml` 是
+> electron-builder 基于*未签名*文件的哈希生成的。SignPath 替换文件后，
+> `latest.yml` 里的 SHA512 就错了，自动更新会拒绝产物。修复方法：
+> 在替换步骤之后重新生成 `latest.yml`。SignPath 的文档有覆盖这个，
+> 常见做法是写个小脚本重新计算 SHA512 并改写 `latest.yml`。如果到
+> 实施时 SignPath 官方 action 还没内置，单独立一个子 PR 跟踪。
+
+---
+
+## Path B — Azure Trusted Signing（fallback）
+
+**前置条件：** 子任务 1b 完成，下面这些是 GitHub Actions
+secret / variables：
+
+- `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`（secret）
+- `AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、
+  `AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME`（variable）
+
+### B1. 修改 `electron-builder` Windows 配置
+
+**文件：** `qcut/package.json`（第 231–240 行）。
 
 ```json
 "win": {
@@ -52,84 +177,33 @@
 }
 ```
 
-### 每个 flag 的意义
+**每个 flag 的意义：**
 
 - `forceCodeSigning: true` — 签名配置错误时构建立即失败，避免悄悄发出
-  未签名版本。这是 issue 验收标准里要求的。
-- `verifyUpdateCodeSignature: true` — 自动更新会拒绝签名链不匹配同一
-  发布者的更新包。可防御更新服务器被入侵的场景。
-- `signAndEditExecutable: true` — 不仅给安装包外层签名，还会给安装包里
-  的 `app.exe` 签名。否则**安装后**的程序在系统看来仍然未签名。
-- 所有值都用 `${env.*}` 占位，让本地和 CI 用同一份 `package.json`，
-  机密永远不会进 Git。
+  未签名版本。
+- `verifyUpdateCodeSignature: true` — 自动更新拒绝签名链不匹配的更新。
+- `signAndEditExecutable: true` — 顺带给内层 `app.exe` 签名。
+- `${env.*}` 占位让密钥不进 `package.json`。
 
-### 自检
+### B2. 修改本地 `dist:win*` 脚本
 
-- `bun check-types` — 配置只是 JSON，类型上没影响，但稳妥起见还是跑一遍。
-- `cd qcut && npx electron-builder --help | grep -i azure` — 确认当前
-  装的 `electron-builder` 版本支持 `azureSignOptions`。
+形式与 §A2 一致，但未签名脚本（`dist:win:unsigned`、`dist:win:fast`）
+对没有 Azure 权限的开发者仍然有用。
 
----
+| 脚本 | 新值 |
+|------|-----|
+| `dist:win` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | 不变（`forceCodeSigning=false` 覆盖保留，给本地未签名构建用） |
+| `dist:win:release` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
+| `dist:win:fast` | 不变 |
 
-## 2. 修改本地 `dist:win*` 脚本
+也要按 §A2 加 `verify:windows-signature` 脚本条目。
 
-**文件：** `qcut/package.json`（第 84、86、88、89 行）。
+### B3. 修改 GitHub Actions 发布工作流
 
-当前脚本里写死了 `--config.win.forceCodeSigning=false` 和
-`--config.win.verifyUpdateCodeSignature=false`。子任务 1 落地后，这些
-覆盖参数会**阻止**那些已经设置了 Azure secret 的开发机签名。
+**文件：** `qcut/.github/workflows/release.yml`。
 
-### 改动
-
-| 脚本 | 旧 | 新 |
-|------|----|----|
-| `dist:win` | `electron-builder --win --publish never -c.win.forceCodeSigning=false` | `electron-builder --win --publish never` |
-| `dist:win:unsigned` | （维持原样） | **保持不变** — 显式的本地未签名变体。可以加注释说明意图。 |
-| `dist:win:release` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && …` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
-| `dist:win:fast` | `… --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` | **保持不变** — 故意未签名的快速本地构建。 |
-
-### 设计意图
-
-- `dist:win:unsigned` 和 `dist:win:fast` 故意保持未签名 — 没有 Azure
-  访问权限的开发者也要能本地构建做冒烟测试。这两个脚本不会被发布
-  流水线使用。
-- `dist:win:release` 是正式发布脚本，新加的 `verify:windows-signature`
-  作为双保险（子任务 5 里加进 `package.json` 的 `scripts` 块）：
-
-```json
-"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
-```
-
-跟现有 `verify:packaged-ffmpeg`、`verify:packaged-aicp` 放一起。
-
-### 自检
-
-- 在 Windows 机上跑 `cd qcut && bun run dist:win:unsigned` — 应该仍能
-  生成未签名的安装包供本地测试。
-- 在导出了 Azure secret 的 Windows 机上跑 `cd qcut && bun run dist:win:release`
-   — 应生成签名过的安装包，退出码 0。
-
----
-
-## 3. 修改 GitHub Actions 发布工作流
-
-**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，第 56–108 行）。
-
-### 改动
-
-修改第 94–98 行 "Build Electron application" 步骤：
-
-**改前：**
-
-```yaml
-- name: Build Electron application
-  run: |
-    npx electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false --config.publish.channel=${{ needs.prepare.outputs.channel }}
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**改后：**
+修改 "Build Electron application"（第 94–98 行）：
 
 ```yaml
 - name: Build Electron application
@@ -140,44 +214,22 @@
     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
     AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
-    AZURE_CERTIFICATE_PROFILE: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
-    WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+    AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+    WINDOWS_PUBLISHER_NAME: ${{ vars.WINDOWS_PUBLISHER_NAME }}
 ```
 
-在 "Build Electron application" 之**后**、"Upload artifacts" 之**前**
-加一个新步骤：
+加签名校验步骤（与 §A3 第 3 步相同），放在 build **之后**、
+"Upload artifacts" **之前**。
 
-```yaml
-- name: Verify Windows signature
-  shell: pwsh
-  run: |
-    cd qcut
-    bun run verify:windows-signature
-```
-
-### 为什么要单独做一次校验
-
-`forceCodeSigning: true` 已经会在签名失败时让构建失败，但单独的校验
-步骤还有几个好处：
-
-1. 对**最终上传**的产物路径再跑一次 `signtool verify /pa /v`，能抓到
-   构建后被人改过的情况。
-2. 在日志里输出明确的成功/失败信息，将来排查"为什么这次发布显示未知
-   发布者"时（无论是人还是 `prtaskit`）能快速定位。
-3. 整个步骤大概 2 秒钟，性价比极高。
-
-### 自检
-
-- `actionlint qcut/.github/workflows/release.yml`（或
-  `npx @action-validator/cli`） — YAML 语法 + secret 引用检查。
-- 推一个 `vX.Y.Z-rc.1` tag 触发 release，签名应该成功，校验步骤应输出
-  "Successfully verified"。
+`latest.yml` 在这条路径下是天然正确的，因为签名是内联完成。
 
 ---
 
-## 4. 增加构建后签名校验
+## 4. 增加构建后签名校验（共享）
+
+与路径无关。Path A 和 Path B 都用。
 
 **新增文件：**
 
@@ -188,16 +240,15 @@
 ### 行为规范
 
 1. 在 `qcut/dist-electron/QCut*Setup*.exe` 里找发布产物（取最新修改时间）。
-2. Windows 上跑 `signtool verify /pa /v <path>`。非 Windows 上如果有
-   `osslsigncode` 就用它校验，否则只打 warning 然后退出 0（这个脚本
-   只在 Windows runner 上是权威校验）。
+2. Windows 上跑 `signtool verify /pa /v <path>`。非 Windows 上打 warn
+   然后跳过（这个脚本只在 Windows runner 上是权威校验）。
 3. 解析输出。要求：
    - 退出码为 0。
    - 如果设置了 `process.env.WINDOWS_PUBLISHER_NAME`，subject CN 必须匹配。
 4. 失败时退出非零，并输出明确信息。
 5. 不做静默 fallback。文件不存在就立即报错。
 
-### 代码草稿（最终代码以新文件为准）
+### 代码草稿
 
 ```ts
 // qcut/scripts/verify-windows-signature.ts
@@ -249,18 +300,12 @@ console.log("[verify-windows-signature] OK");
 - 与现有约定一致 — 见 `qcut/scripts/verify-packaged-ffmpeg.ts` 和
   `qcut/scripts/verify-packaged-aicp.ts`（已确认存在）。
 - 单元测试更容易（Vitest 可以 mock `child_process`）。
-- 跨平台安全 — 在 macOS/Linux 开发机上能做 no-op，不会让
+- 跨平台安全 — 在 macOS/Linux 开发机上能 no-op，不会让
   `dist:win:release` 链断掉。
-
-### 自检
-
-- 本地签名构建后跑 `cd qcut && bun run verify:windows-signature` →
-  退出 0。
-- `dist:win:unsigned` 构建后跑同样命令 → 退出非零。
 
 ---
 
-## 5. 发布演练（人工验证）
+## 5. 发布演练（人工验证，共享）
 
 在干净 Windows 虚拟机（无开发工具、新用户配置）上做冒烟测试：
 
@@ -287,13 +332,15 @@ console.log("[verify-windows-signature] OK");
 
 不属于 v1，但值得另开 issue 跟踪：
 
-- **Azure 认证用 OIDC 联邦身份** — 用 `azure/login@v2` + 工作负载身份
-  联邦取代 GitHub Secret 里的 `AZURE_CLIENT_SECRET`。永远不用轮换密钥。
-  详见 [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)
-  最后一节。
+- **（仅 Path B）Azure 认证用 OIDC 联邦身份** — 用 `azure/login@v2` +
+  工作负载身份联邦取代 GitHub Secret 里的 `AZURE_CLIENT_SECRET`。
+  永远不用轮换密钥。
+- **（仅 Path A）`latest.yml` 完整性** — SignPath 替换签名安装包后，
+  必须在上传前重算 `latest.yml` 的 SHA512，否则自动更新会拒收。
 - **EV 证书评估** — v1 上线 6 个月后，看看 SmartScreen 警告率，决定
-  是否升级到 EV（见 [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)）。
+  是否升级到 EV。
 - **Microsoft Store 渠道** — 单独的渠道、单独的证书、单独的审核流程。
   issue #289 提到这能加分，但不在本方案范围内。
-- **可复现产物** — sign-in-place 和 sign-then-archive 对可复现性的影响
-  不同；如果 QCut 将来要做 SLSA 风格的证明，再回过头处理。
+- **macOS 签名** — 目前 CI 里**也**没配（没有 `mac.identity`，
+  `release.yml` 没 Apple secret）。单独立 issue 跟踪，不要跟 Windows
+  这次的工作捆绑。

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -1,0 +1,299 @@
+# Windows 代码签名 — 实现细节
+
+每个工程子任务的具体步骤。子任务按顺序排列，每个都是一个独立 PR。
+所有路径如无特别说明，均相对于仓库根目录。
+
+> **前置条件：** 子任务 1（购买证书，见
+> [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)）已完成，
+> 下面这些值已经存到 GitHub Actions secret 里：
+> `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`、
+> `AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、
+> `AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME`。
+
+---
+
+## 1. 修改 `electron-builder` Windows 配置
+
+**文件：** `qcut/package.json`（第 231–240 行的 `build.win` 块）。
+
+### 修改前
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": false,
+  "verifyUpdateCodeSignature": false,
+  "signAndEditExecutable": false,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store"
+}
+```
+
+### 修改后
+
+```json
+"win": {
+  "target": "nsis",
+  "icon": "build/icon.ico",
+  "forceCodeSigning": true,
+  "verifyUpdateCodeSignature": true,
+  "signAndEditExecutable": true,
+  "requestedExecutionLevel": "asInvoker",
+  "artifactName": "${productName}-Setup-${version}.${ext}",
+  "compression": "store",
+  "azureSignOptions": {
+    "publisherName": "${env.WINDOWS_PUBLISHER_NAME}",
+    "endpoint": "${env.AZURE_TRUSTED_SIGNING_ENDPOINT}",
+    "certificateProfileName": "${env.AZURE_CERTIFICATE_PROFILE}",
+    "codeSigningAccountName": "${env.AZURE_TRUSTED_SIGNING_ACCOUNT}"
+  }
+}
+```
+
+### 每个 flag 的意义
+
+- `forceCodeSigning: true` — 签名配置错误时构建立即失败，避免悄悄发出
+  未签名版本。这是 issue 验收标准里要求的。
+- `verifyUpdateCodeSignature: true` — 自动更新会拒绝签名链不匹配同一
+  发布者的更新包。可防御更新服务器被入侵的场景。
+- `signAndEditExecutable: true` — 不仅给安装包外层签名，还会给安装包里
+  的 `app.exe` 签名。否则**安装后**的程序在系统看来仍然未签名。
+- 所有值都用 `${env.*}` 占位，让本地和 CI 用同一份 `package.json`，
+  机密永远不会进 Git。
+
+### 自检
+
+- `bun check-types` — 配置只是 JSON，类型上没影响，但稳妥起见还是跑一遍。
+- `cd qcut && npx electron-builder --help | grep -i azure` — 确认当前
+  装的 `electron-builder` 版本支持 `azureSignOptions`。
+
+---
+
+## 2. 修改本地 `dist:win*` 脚本
+
+**文件：** `qcut/package.json`（第 84、86、88、89 行）。
+
+当前脚本里写死了 `--config.win.forceCodeSigning=false` 和
+`--config.win.verifyUpdateCodeSignature=false`。子任务 1 落地后，这些
+覆盖参数会**阻止**那些已经设置了 Azure secret 的开发机签名。
+
+### 改动
+
+| 脚本 | 旧 | 新 |
+|------|----|----|
+| `dist:win` | `electron-builder --win --publish never -c.win.forceCodeSigning=false` | `electron-builder --win --publish never` |
+| `dist:win:unsigned` | （维持原样） | **保持不变** — 显式的本地未签名变体。可以加注释说明意图。 |
+| `dist:win:release` | `electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && …` | `electron-builder --win --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp && bun run verify:windows-signature` |
+| `dist:win:fast` | `… --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false` | **保持不变** — 故意未签名的快速本地构建。 |
+
+### 设计意图
+
+- `dist:win:unsigned` 和 `dist:win:fast` 故意保持未签名 — 没有 Azure
+  访问权限的开发者也要能本地构建做冒烟测试。这两个脚本不会被发布
+  流水线使用。
+- `dist:win:release` 是正式发布脚本，新加的 `verify:windows-signature`
+  作为双保险（子任务 5 里加进 `package.json` 的 `scripts` 块）：
+
+```json
+"verify:windows-signature": "bun scripts/verify-windows-signature.ts"
+```
+
+跟现有 `verify:packaged-ffmpeg`、`verify:packaged-aicp` 放一起。
+
+### 自检
+
+- 在 Windows 机上跑 `cd qcut && bun run dist:win:unsigned` — 应该仍能
+  生成未签名的安装包供本地测试。
+- 在导出了 Azure secret 的 Windows 机上跑 `cd qcut && bun run dist:win:release`
+   — 应生成签名过的安装包，退出码 0。
+
+---
+
+## 3. 修改 GitHub Actions 发布工作流
+
+**文件：** `qcut/.github/workflows/release.yml`（Windows 任务，第 56–108 行）。
+
+### 改动
+
+修改第 94–98 行 "Build Electron application" 步骤：
+
+**改前：**
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**改后：**
+
+```yaml
+- name: Build Electron application
+  run: |
+    npx electron-builder --win --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+    AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+    AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+    AZURE_CERTIFICATE_PROFILE: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
+    WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+```
+
+在 "Build Electron application" 之**后**、"Upload artifacts" 之**前**
+加一个新步骤：
+
+```yaml
+- name: Verify Windows signature
+  shell: pwsh
+  run: |
+    cd qcut
+    bun run verify:windows-signature
+```
+
+### 为什么要单独做一次校验
+
+`forceCodeSigning: true` 已经会在签名失败时让构建失败，但单独的校验
+步骤还有几个好处：
+
+1. 对**最终上传**的产物路径再跑一次 `signtool verify /pa /v`，能抓到
+   构建后被人改过的情况。
+2. 在日志里输出明确的成功/失败信息，将来排查"为什么这次发布显示未知
+   发布者"时（无论是人还是 `prtaskit`）能快速定位。
+3. 整个步骤大概 2 秒钟，性价比极高。
+
+### 自检
+
+- `actionlint qcut/.github/workflows/release.yml`（或
+  `npx @action-validator/cli`） — YAML 语法 + secret 引用检查。
+- 推一个 `vX.Y.Z-rc.1` tag 触发 release，签名应该成功，校验步骤应输出
+  "Successfully verified"。
+
+---
+
+## 4. 增加构建后签名校验
+
+**新增文件：**
+
+- `qcut/scripts/verify-windows-signature.ts` — 实现。
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — 见
+  [`TESTING.zh-CN.md`](TESTING.zh-CN.md)。
+
+### 行为规范
+
+1. 在 `qcut/dist-electron/QCut*Setup*.exe` 里找发布产物（取最新修改时间）。
+2. Windows 上跑 `signtool verify /pa /v <path>`。非 Windows 上如果有
+   `osslsigncode` 就用它校验，否则只打 warning 然后退出 0（这个脚本
+   只在 Windows runner 上是权威校验）。
+3. 解析输出。要求：
+   - 退出码为 0。
+   - 如果设置了 `process.env.WINDOWS_PUBLISHER_NAME`，subject CN 必须匹配。
+4. 失败时退出非零，并输出明确信息。
+5. 不做静默 fallback。文件不存在就立即报错。
+
+### 代码草稿（最终代码以新文件为准）
+
+```ts
+// qcut/scripts/verify-windows-signature.ts
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(import.meta.dir, "..", "dist-electron");
+const expectedPublisher = process.env.WINDOWS_PUBLISHER_NAME;
+
+function findInstaller(): string {
+  if (!existsSync(distDir)) {
+    throw new Error(`找不到 dist-electron：${distDir}`);
+  }
+  const candidates = readdirSync(distDir)
+    .filter((f) => /^QCut.*Setup.*\.exe$/i.test(f))
+    .map((f) => ({ f, mtime: statSync(join(distDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (candidates.length === 0) {
+    throw new Error(`${distDir} 里找不到 QCut*Setup*.exe`);
+  }
+  return join(distDir, candidates[0].f);
+}
+
+function verify(installer: string): void {
+  if (process.platform !== "win32") {
+    console.warn("[verify-windows-signature] 非 Windows 主机，跳过");
+    return;
+  }
+  const out = execFileSync("signtool", ["verify", "/pa", "/v", installer], {
+    encoding: "utf8",
+  });
+  console.log(out);
+  if (expectedPublisher && !out.includes(expectedPublisher)) {
+    throw new Error(
+      `发布者不一致；期望在 signtool 输出里看到 "${expectedPublisher}"`,
+    );
+  }
+}
+
+const installer = findInstaller();
+console.log(`[verify-windows-signature] 校验 ${installer}`);
+verify(installer);
+console.log("[verify-windows-signature] OK");
+```
+
+### 为什么用 `.ts` 脚本（不直接写 `.ps1`）
+
+- 与现有约定一致 — 见 `qcut/scripts/verify-packaged-ffmpeg.ts` 和
+  `qcut/scripts/verify-packaged-aicp.ts`（已确认存在）。
+- 单元测试更容易（Vitest 可以 mock `child_process`）。
+- 跨平台安全 — 在 macOS/Linux 开发机上能做 no-op，不会让
+  `dist:win:release` 链断掉。
+
+### 自检
+
+- 本地签名构建后跑 `cd qcut && bun run verify:windows-signature` →
+  退出 0。
+- `dist:win:unsigned` 构建后跑同样命令 → 退出非零。
+
+---
+
+## 5. 发布演练（人工验证）
+
+在干净 Windows 虚拟机（无开发工具、新用户配置）上做冒烟测试：
+
+1. 推一个 `v2026.5.0-rc.1` tag，触发 release 工作流。
+2. 等 `build-windows` 成功，下载 `windows-build` artifact。
+3. 在 VM 上双击 `.exe`。
+4. **预期：** Windows 显示 `发布者：<WINDOWS_PUBLISHER_NAME>`
+   （不是"未知发布者"）。SmartScreen 仍可能显示"Windows protected
+   your PC"，要等信誉积累 — 见 [`PLAN.zh-CN.md`](PLAN.zh-CN.md) 风险章节。
+5. 在 VM 里打开 PowerShell：
+   ```powershell
+   Get-AuthenticodeSignature .\QCut*Setup*.exe
+   ```
+   期望 `Status: Valid`，`SignerCertificate.Subject` 不为空。
+6. `signtool verify /pa /v .\QCut*Setup*.exe` → 退出 0，输出
+   "Successfully verified"。
+
+任何一步失败都**不要**把 rc tag 提升为 release。回滚工作流改动，
+排查问题。
+
+---
+
+## 6. 后续加固（单独跟踪）
+
+不属于 v1，但值得另开 issue 跟踪：
+
+- **Azure 认证用 OIDC 联邦身份** — 用 `azure/login@v2` + 工作负载身份
+  联邦取代 GitHub Secret 里的 `AZURE_CLIENT_SECRET`。永远不用轮换密钥。
+  详见 [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)
+  最后一节。
+- **EV 证书评估** — v1 上线 6 个月后，看看 SmartScreen 警告率，决定
+  是否升级到 EV（见 [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)）。
+- **Microsoft Store 渠道** — 单独的渠道、单独的证书、单独的审核流程。
+  issue #289 提到这能加分，但不在本方案范围内。
+- **可复现产物** — sign-in-place 和 sign-then-archive 对可复现性的影响
+  不同；如果 QCut 将来要做 SLSA 风格的证明，再回过头处理。

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -22,7 +22,7 @@ Certum SimplySign 要求**每次** `signtool` 调用都通过手机确认 — �
 |------|--------------|------|
 | **A（采用）：CI 出未签名包，本地签后再发布** | CI 出未签名 `.exe` artifact；维护者下载、本地 Windows 机签、把签好的 artifact 上传到 GitHub Release | 每次发布人工 ~5 分钟。Inkdrop 也是这个工作流。 |
 | B：自托管 Windows runner 装 SimplySign | runner 触发签名；Donghao 仍然要在手机上点确认 | 增加 runner 托管成本和 SimplySign 常驻运维。手机确认还是要 — 没省什么。 |
-| C：换成 SSL.com eSigner OV | CI 用 REST API token 签 | 每年多 ~$50，全自动。如果 A 变痛点的迁移路径。 |
+| C：换成 SSL.com eSigner OV | CI 用 REST API token 签 | 每年多 ~$220+（双重收费：~$239/年证书 + ~$200–240/年 eSigner Cloud Signing 订阅，详见 §5），全自动。如果 A 变痛点的迁移路径。 |
 
 **采用方案 A。** 这是 indie Electron 圈的行业惯例，而且最便宜。
 迁移到 C 作为未来加固保留。
@@ -43,7 +43,7 @@ Certum SimplySign 要求**每次** `signtool` 调用都通过手机确认 — �
    ```powershell
    certutil -store -user My
    ```
-   应该能看到 Quriosity Pty Ltd 的 Developer ID Application 证书，私钥引用指向 SimplySign 的 CSP。
+   应该能看到颁发给 `Quriosity Pty Ltd` 的 Windows Authenticode 代码签名证书（Subject CN 为 `Quriosity Pty Ltd`），私钥引用指向 SimplySign 的 CSP。（`Developer ID Application` 是 Apple 命名约定，Windows 上不适用。）
 
 任何一步失败，后面的实现都做不了。
 
@@ -177,7 +177,7 @@ v1 选 **2.3a**。把手工步骤写清楚：
 ### 行为规范
 
 1. 在 `qcut/dist-electron/` 找最新的未签名 `QCut*Setup*.exe`。
-2. 跑 `signtool sign /tr http://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`。
+2. 跑 `signtool sign /tr https://timestamp.acs.microsoft.com /td sha256 /fd sha256 /sha1 <thumbprint> /sm <exe>`。
    - `sha1 <thumbprint>` — 从 SimplySign 暴露的身份库选 Quriosity 证书。
    - `tr` — RFC 3161 时间戳服务。微软的对 SmartScreen 信誉对齐最好。
    - `td sha256` 和 `fd sha256` — 现代 SHA-256 算法（CA/B Forum 2024 后强制要求）。
@@ -221,7 +221,7 @@ console.log("[sign-windows-release] 在手机的 SimplySign App 上批准...");
 
 execFileSync("signtool", [
   "sign",
-  "/tr", "http://timestamp.acs.microsoft.com",
+  "/tr", "https://timestamp.acs.microsoft.com",
   "/td", "sha256",
   "/fd", "sha256",
   "/sha1", certThumbprint,

--- a/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/IMPLEMENTATION.zh-CN.md
@@ -307,7 +307,7 @@ console.log("[verify-windows-signature] OK");
 
 ## 5. 未来加固（单独跟踪）
 
-- **迁移到 SSL.com eSigner OV** — 如果手工签名变成瓶颈。完全自动化 CI；每年多 ~$50。
+- **迁移到 SSL.com eSigner OV** — 如果手工签名变成瓶颈。完全自动化 CI。每年多 **~$220+**（$239/年证书 + $200–240/年 eSigner Cloud Signing 订阅，双重收费 — 之前草稿错估 "~$50 更多"）。只有每周发版 1 次以上才值得 — QCut 当前节奏下，手机确认每年只占几分钟，不值 $220。
 - **给 Certum 账号加第二个团队成员**，避免 Donghao 离线时签不了。
 - **加快信誉积累**：发布频率别太高（不要每周发版），让下载尽量走稳定 URL，加速 hash 信誉积累。
 - **2027-06 重新评估 Azure Artifact Signing** — Quriosity 满 3 年时，看微软是否扩大了国家资格到澳洲。如果两个条件都满足，$120/年 + 全自动 CI 让 Azure 重新有吸引力。

--- a/qcut/docs/task/windows-code-signing/PLAN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.md
@@ -2,7 +2,7 @@
 
 **Tracking issue:** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
 **Branch:** `gpt-image-2`
-**Created:** 2026-04-25
+**Created:** 2026-04-25 (revised same day to add SignPath Foundation path)
 
 ## Goal
 
@@ -14,89 +14,142 @@ Long-term outcome (priority order, per `CLAUDE.md`):
 
 1. **Maintainability** — signing is configured once and works across every
    future release without per-release manual steps.
-2. **Scalability** — secrets live in GitHub Actions / cloud KMS, not on a
-   single developer's machine. A new maintainer can release without owning
-   the cert.
+2. **Scalability** — secrets / signing identity live in cloud-hosted
+   services, not on a single developer's machine. A new maintainer can
+   release without owning a USB token.
 3. **Performance** — signing should not noticeably extend release CI time
    (target < 60 s extra on Windows job).
-4. **Short-term gains** — *not* a goal. We will not ship a self-signed cert
-   or one-time hack just to silence SmartScreen for v2026.5.
+4. **Short-term gains** — *not* a goal. We will not ship a self-signed
+   cert or one-time hack just to silence SmartScreen for v2026.5.
 
-## Why this requires buying a license
+## Why this might not require buying a license
 
-Authenticode signing requires a **commercial code-signing certificate**
-issued by a CA that Windows trusts. Self-signed certs do not remove the
-SmartScreen warning. See [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)
-for vendor comparison, cost, and a recommendation.
+`qcut/LICENSE` is MIT-style and `qcut/package.json:308` describes QCut as
+"Open-source AI video editor" — both prerequisites for **SignPath
+Foundation**, a free Authenticode signing program for verified
+open-source projects (used by Blender, OBS Studio, Inkscape, Krita,
+GIMP, KeePass, Notepad++, etc.).
 
-**Recommended:** Azure Trusted Signing (Public Trust identity), ~USD 10/month,
-because:
-- Cloud-native, no HSM token to ship around.
-- Native `electron-builder` support via `azureSignOptions`.
-- Required identity validation is light (org or individual) compared to EV.
-- The issue author already proposed this path.
+**Plan:** apply to SignPath Foundation first (free, ~1–2 weeks for
+review). Only if SignPath denies do we buy Azure Trusted Signing
+(~USD 10/month). See [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)
+for full vendor comparison and the rationale against DigiCert / Sectigo /
+EV in v1.
+
+## Path decision (gates Subtask 1 outcome)
+
+The implementation has two flavors. Subtask 1 picks one based on the
+SignPath outcome.
+
+| | **Path A — SignPath (preferred)** | **Path B — Azure (fallback)** |
+|-|-----------------------------------|-------------------------------|
+| Cost | $0 | ~$120/year |
+| Signing trigger | Post-build via SignPath GitHub Action | Inline during `electron-builder` via `azureSignOptions` |
+| `electron-builder` win config | `forceCodeSigning: false`, `signAndEditExecutable: false` (SignPath signs post-build, otherwise builder doesn't know how) | `forceCodeSigning: true`, `signAndEditExecutable: true`, `azureSignOptions` populated |
+| New CI step | "Submit signing request to SignPath" using `signpath/github-action-submit-signing-request@v1` | None — signing happens in the existing build step |
+| New repo secrets | `SIGNPATH_API_TOKEN`, `SIGNPATH_ORGANIZATION_ID`, `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_SIGNING_POLICY_SLUG`, `SIGNPATH_ARTIFACT_SLUG` | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME` |
+| Verifier script (`verify-windows-signature.ts`) | **Same** — verifies via `signtool /pa /v` and matches `WINDOWS_PUBLISHER_NAME` env var | **Same** |
+
+The verifier script and the manual VM dry-run are path-agnostic. Most
+other subtasks have an "if Path A / if Path B" detail in
+[`IMPLEMENTATION.md`](IMPLEMENTATION.md).
 
 ## Subtask map
 
-The full implementation is **clearly > 20 minutes** (multi-day if you count
-certificate validation by Microsoft). Subtasks are sequenced so each one is
-independently mergeable and reviewable.
+The full implementation is **clearly > 20 minutes** (multi-day if you
+count vendor review). Subtasks are sequenced so each one is independently
+mergeable and reviewable.
 
 | # | Subtask | Owner action | Code? | Est. wall time | Detail file |
 |---|---------|--------------|-------|----------------|-------------|
-| 1 | Certificate procurement | Buy Azure Trusted Signing identity, verify org | No | 1–7 days (Microsoft validation) | [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) |
-| 2 | Update `electron-builder` Windows config | Flip three flags + add `azureSignOptions` | Yes | 30 min | [IMPLEMENTATION.md §1](IMPLEMENTATION.md#1-update-electron-builder-windows-config) |
-| 3 | Update local `dist:win*` npm scripts | Remove `forceCodeSigning=false` overrides; keep one unsigned variant for local dev | Yes | 20 min | [IMPLEMENTATION.md §2](IMPLEMENTATION.md#2-update-local-distwin-npm-scripts) |
-| 4 | Update release workflow | Remove `--config.win.*=false` overrides, inject Azure secrets | Yes | 30 min | [IMPLEMENTATION.md §3](IMPLEMENTATION.md#3-update-github-actions-release-workflow) |
-| 5 | Add post-build signature verification | New script + CI step, fail release if unsigned | Yes | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-add-post-build-signature-verification) |
+| 1a | **Apply to SignPath Foundation** | Submit OSS application | No | 1–2 weeks (review) | [CERTIFICATE-OPTIONS.md §SignPath](CERTIFICATE-OPTIONS.md#signpath-foundation-how-to-apply) |
+| 1b | Azure procurement *(fallback only — only if 1a is denied)* | Buy Trusted Signing identity, verify org | No | 1–7 days | [CERTIFICATE-OPTIONS.md §Azure](CERTIFICATE-OPTIONS.md#azure-trusted-signing-procurement-fallback-only) |
+| 2 | Update `electron-builder` Windows config | Path-dependent edit to `qcut/package.json` `build.win` | Yes | 30 min | [IMPLEMENTATION.md §A1 / §B1](IMPLEMENTATION.md) |
+| 3 | Update local `dist:win*` npm scripts | Remove `forceCodeSigning=false` overrides; keep one unsigned variant | Yes | 20 min | [IMPLEMENTATION.md §A2 / §B2](IMPLEMENTATION.md) |
+| 4 | Update release workflow | Path A: add SignPath submit step. Path B: remove `--config.win.*=false`, inject Azure secrets. | Yes | 30–60 min | [IMPLEMENTATION.md §A3 / §B3](IMPLEMENTATION.md) |
+| 5 | Add post-build signature verification | New script + CI step (path-agnostic) | Yes | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-add-post-build-signature-verification-shared) |
 | 6 | Documentation | Maintainer signing setup guide + release doc update | Yes (docs) | 45 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
-| 7 | Tests | Unit tests for verifier script + workflow YAML lint | Yes | 1 hr | [TESTING.md](TESTING.md) |
-| 8 | Dry-run release | Trigger release workflow on a `rc` tag, verify signed `.exe` on a clean Windows VM | No | 1 hr | [IMPLEMENTATION.md §5](IMPLEMENTATION.md#5-dry-run-release--manual-verification) |
+| 7 | Tests | Unit tests for verifier + workflow YAML guardrail (path-aware) | Yes | 1 hr | [TESTING.md](TESTING.md) |
+| 8 | Dry-run release | Trigger release on `rc` tag, verify signed `.exe` on a clean Windows VM | No | 1 hr | [IMPLEMENTATION.md §5](IMPLEMENTATION.md#5-dry-run-release--manual-verification-shared) |
 
-**Total engineering time (excluding cert procurement wait): ~5 hours.**
+**Total engineering time (excluding vendor review): ~5 hours regardless of path.**
 
 ## Files this plan will touch
 
-Authoritative list — keep this in sync if scope changes.
+Authoritative list — keep this in sync if scope changes. Items marked
+**[A]** are Path A only, **[B]** Path B only, **[shared]** apply to both.
 
 ### Modified
 
 - `qcut/package.json` — lines 84, 86, 88, 89 (scripts) and lines 231–240 (`build.win`).
-- `qcut/.github/workflows/release.yml` — line 96 (Build Electron application step) and surrounding env block (~line 60–98).
+  - **[A]** `build.win` flips `verifyUpdateCodeSignature` to `true` only;
+    `forceCodeSigning` stays `false` because SignPath signs post-build.
+  - **[B]** all three signing flags flipped to `true`, plus
+    `azureSignOptions` block added.
+- `qcut/.github/workflows/release.yml` — line 96 (Build Electron application step) and surrounding env block (~lines 60–98).
+  - **[A]** Removes the `forceCodeSigning=false` overrides; adds new
+    "Submit signing request to SignPath" + "Download signed artifact"
+    steps after the build.
+  - **[B]** Removes overrides; adds Azure secret env vars to the build
+    step.
 - `qcut/docs/release.md` — add signing prerequisites section *(create if missing)*.
 
 ### Added
 
-- `qcut/scripts/verify-windows-signature.ts` — Node/Bun wrapper that shells out to `signtool verify /pa /v` (or PowerShell `Get-AuthenticodeSignature`) and exits non-zero if the artifact is unsigned or signed by an unexpected publisher.
-- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest unit tests for the wrapper (mock child_process).
-- `qcut/docs/setup/windows-code-signing.md` — maintainer-facing setup guide (Azure tenant, GitHub secrets, local dev signing).
+- **[shared]** `qcut/scripts/verify-windows-signature.ts` — Bun/Node wrapper that shells out to `signtool verify /pa /v` and exits non-zero if unsigned or signed by an unexpected publisher.
+- **[shared]** `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest unit tests.
+- **[shared]** `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json` shape guardrail (path-aware: validates either Path A or Path B config).
+- **[shared]** `qcut/scripts/__tests__/release-workflow-signing.test.ts` — workflow YAML guardrail (path-aware).
+- **[shared]** `qcut/docs/setup/windows-code-signing.md` — maintainer-facing setup guide. Covers both Path A (SignPath) and Path B (Azure) credential setup.
 - `qcut/docs/task/windows-code-signing/` — this folder.
 
 ### Not touched (intentional)
 
 - `qcut/build/icon.ico` — icon stays as-is.
-- `qcut/scripts/release.ts` — release orchestrator does not need to know about signing; electron-builder handles it.
+- `qcut/scripts/release.ts` — release orchestrator does not need to know
+  about signing.
+- `qcut/package.json` `build.mac` block — macOS signing is a separate
+  concern (and currently also unsigned in CI; tracked elsewhere).
 
 ## Risks & open questions
 
-1. **Azure validation time** — Microsoft's identity validation can take up to a week. Subtask 1 must start *before* engineering work to avoid blocking release.
-2. **SmartScreen reputation lag** — even after signing, the *first* signed builds may still show "less common app" warnings until reputation accumulates. Document this expectation in the user-facing release notes.
-3. **Cert renewal** — set a calendar reminder for renewal 30 days before expiry. Add to `IMPLEMENTATION.md §6` once cert is purchased.
-4. **macOS / Linux unaffected** — this plan deliberately scopes to Windows. macOS already signs via Apple Developer ID (verify in `qcut/package.json` `build.mac` once we get to it).
+1. **SignPath review timing** — typically 1–2 weeks. Subtask 1a must
+   start *before* engineering work to avoid blocking release.
+2. **SignPath denial path** — if denied, Subtask 1b (Azure) adds another
+   1–7 days for Microsoft identity validation. Plan release timing
+   accordingly.
+3. **SmartScreen reputation lag** — even after signing, the *first*
+   signed builds may show "less common app" warnings until reputation
+   accumulates. Document this expectation in the user-facing release
+   notes.
+4. **macOS / Linux unaffected** — this plan deliberately scopes to
+   Windows. macOS is *also* currently unsigned in CI (no `mac.identity`,
+   no Apple secrets in `release.yml`); that is a separate task.
+5. **Cert renewal**
+   - Path A: SignPath rotates automatically; no calendar reminder needed.
+   - Path B: profile auto-rotates, but the Azure subscription billing
+     should have an alert.
 
 ## Success criteria
 
 Mirrors the issue acceptance criteria, made testable:
 
 - [ ] `signtool verify /pa /v QCut*Setup*.exe` exits 0 on the release artifact.
-- [ ] `Get-AuthenticodeSignature` reports `Status: Valid` and a `SignerCertificate.Subject` matching the expected publisher.
-- [ ] `qcut/package.json` `build.win.forceCodeSigning` is `true`.
+- [ ] `Get-AuthenticodeSignature` reports `Status: Valid` and a
+      `SignerCertificate.Subject` matching the expected publisher
+      (SignPath-issued or Azure-issued).
+- [ ] `qcut/package.json` `build.win` has the appropriate signing config
+      for the chosen path (see Path decision table above).
 - [ ] CI release job fails fast (before publishing) if signing fails.
-- [ ] A first-time Windows user sees the verified publisher name on installer launch (verified manually on a clean VM).
-- [ ] Maintainer signing setup is documented at `qcut/docs/setup/windows-code-signing.md`.
+- [ ] A first-time Windows user sees the verified publisher name on
+      installer launch (verified manually on a clean VM).
+- [ ] Maintainer signing setup is documented at
+      `qcut/docs/setup/windows-code-signing.md`.
 
 ## Out of scope for this plan
 
 - macOS notarization changes.
-- Microsoft Store submission (mentioned in the issue as a *future* reputation booster — file a separate issue).
-- Auto-update signature pinning beyond what `electron-builder`'s `verifyUpdateCodeSignature: true` already provides.
+- Microsoft Store submission (mentioned in the issue as a *future*
+  reputation booster — file a separate issue).
+- Auto-update signature pinning beyond what `electron-builder`'s
+  `verifyUpdateCodeSignature: true` already provides.

--- a/qcut/docs/task/windows-code-signing/PLAN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.md
@@ -1,0 +1,102 @@
+# Windows Installer Code Signing — Plan
+
+**Tracking issue:** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
+**Branch:** `gpt-image-2`
+**Created:** 2026-04-25
+
+## Goal
+
+Remove the `Publisher: Unknown publisher` warning from the QCut Windows
+installer by Authenticode-signing the NSIS `.exe` produced by
+`electron-builder` in the GitHub Actions release pipeline.
+
+Long-term outcome (priority order, per `CLAUDE.md`):
+
+1. **Maintainability** — signing is configured once and works across every
+   future release without per-release manual steps.
+2. **Scalability** — secrets live in GitHub Actions / cloud KMS, not on a
+   single developer's machine. A new maintainer can release without owning
+   the cert.
+3. **Performance** — signing should not noticeably extend release CI time
+   (target < 60 s extra on Windows job).
+4. **Short-term gains** — *not* a goal. We will not ship a self-signed cert
+   or one-time hack just to silence SmartScreen for v2026.5.
+
+## Why this requires buying a license
+
+Authenticode signing requires a **commercial code-signing certificate**
+issued by a CA that Windows trusts. Self-signed certs do not remove the
+SmartScreen warning. See [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)
+for vendor comparison, cost, and a recommendation.
+
+**Recommended:** Azure Trusted Signing (Public Trust identity), ~USD 10/month,
+because:
+- Cloud-native, no HSM token to ship around.
+- Native `electron-builder` support via `azureSignOptions`.
+- Required identity validation is light (org or individual) compared to EV.
+- The issue author already proposed this path.
+
+## Subtask map
+
+The full implementation is **clearly > 20 minutes** (multi-day if you count
+certificate validation by Microsoft). Subtasks are sequenced so each one is
+independently mergeable and reviewable.
+
+| # | Subtask | Owner action | Code? | Est. wall time | Detail file |
+|---|---------|--------------|-------|----------------|-------------|
+| 1 | Certificate procurement | Buy Azure Trusted Signing identity, verify org | No | 1–7 days (Microsoft validation) | [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) |
+| 2 | Update `electron-builder` Windows config | Flip three flags + add `azureSignOptions` | Yes | 30 min | [IMPLEMENTATION.md §1](IMPLEMENTATION.md#1-update-electron-builder-windows-config) |
+| 3 | Update local `dist:win*` npm scripts | Remove `forceCodeSigning=false` overrides; keep one unsigned variant for local dev | Yes | 20 min | [IMPLEMENTATION.md §2](IMPLEMENTATION.md#2-update-local-distwin-npm-scripts) |
+| 4 | Update release workflow | Remove `--config.win.*=false` overrides, inject Azure secrets | Yes | 30 min | [IMPLEMENTATION.md §3](IMPLEMENTATION.md#3-update-github-actions-release-workflow) |
+| 5 | Add post-build signature verification | New script + CI step, fail release if unsigned | Yes | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-add-post-build-signature-verification) |
+| 6 | Documentation | Maintainer signing setup guide + release doc update | Yes (docs) | 45 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
+| 7 | Tests | Unit tests for verifier script + workflow YAML lint | Yes | 1 hr | [TESTING.md](TESTING.md) |
+| 8 | Dry-run release | Trigger release workflow on a `rc` tag, verify signed `.exe` on a clean Windows VM | No | 1 hr | [IMPLEMENTATION.md §5](IMPLEMENTATION.md#5-dry-run-release--manual-verification) |
+
+**Total engineering time (excluding cert procurement wait): ~5 hours.**
+
+## Files this plan will touch
+
+Authoritative list — keep this in sync if scope changes.
+
+### Modified
+
+- `qcut/package.json` — lines 84, 86, 88, 89 (scripts) and lines 231–240 (`build.win`).
+- `qcut/.github/workflows/release.yml` — line 96 (Build Electron application step) and surrounding env block (~line 60–98).
+- `qcut/docs/release.md` — add signing prerequisites section *(create if missing)*.
+
+### Added
+
+- `qcut/scripts/verify-windows-signature.ts` — Node/Bun wrapper that shells out to `signtool verify /pa /v` (or PowerShell `Get-AuthenticodeSignature`) and exits non-zero if the artifact is unsigned or signed by an unexpected publisher.
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest unit tests for the wrapper (mock child_process).
+- `qcut/docs/setup/windows-code-signing.md` — maintainer-facing setup guide (Azure tenant, GitHub secrets, local dev signing).
+- `qcut/docs/task/windows-code-signing/` — this folder.
+
+### Not touched (intentional)
+
+- `qcut/build/icon.ico` — icon stays as-is.
+- `qcut/scripts/release.ts` — release orchestrator does not need to know about signing; electron-builder handles it.
+
+## Risks & open questions
+
+1. **Azure validation time** — Microsoft's identity validation can take up to a week. Subtask 1 must start *before* engineering work to avoid blocking release.
+2. **SmartScreen reputation lag** — even after signing, the *first* signed builds may still show "less common app" warnings until reputation accumulates. Document this expectation in the user-facing release notes.
+3. **Cert renewal** — set a calendar reminder for renewal 30 days before expiry. Add to `IMPLEMENTATION.md §6` once cert is purchased.
+4. **macOS / Linux unaffected** — this plan deliberately scopes to Windows. macOS already signs via Apple Developer ID (verify in `qcut/package.json` `build.mac` once we get to it).
+
+## Success criteria
+
+Mirrors the issue acceptance criteria, made testable:
+
+- [ ] `signtool verify /pa /v QCut*Setup*.exe` exits 0 on the release artifact.
+- [ ] `Get-AuthenticodeSignature` reports `Status: Valid` and a `SignerCertificate.Subject` matching the expected publisher.
+- [ ] `qcut/package.json` `build.win.forceCodeSigning` is `true`.
+- [ ] CI release job fails fast (before publishing) if signing fails.
+- [ ] A first-time Windows user sees the verified publisher name on installer launch (verified manually on a clean VM).
+- [ ] Maintainer signing setup is documented at `qcut/docs/setup/windows-code-signing.md`.
+
+## Out of scope for this plan
+
+- macOS notarization changes.
+- Microsoft Store submission (mentioned in the issue as a *future* reputation booster — file a separate issue).
+- Auto-update signature pinning beyond what `electron-builder`'s `verifyUpdateCodeSignature: true` already provides.

--- a/qcut/docs/task/windows-code-signing/PLAN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.md
@@ -2,154 +2,106 @@
 
 **Tracking issue:** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
 **Branch:** `gpt-image-2`
-**Created:** 2026-04-25 (revised same day to add SignPath Foundation path)
+**Created:** 2026-04-25 (revised same day after eliminating Azure / SignPath / EV paths)
 
 ## Goal
 
-Remove the `Publisher: Unknown publisher` warning from the QCut Windows
-installer by Authenticode-signing the NSIS `.exe` produced by
-`electron-builder` in the GitHub Actions release pipeline.
+Sign the QCut Windows NSIS installer with an Authenticode certificate
+issued to **Quriosity Pty Ltd**, so:
+
+1. The UAC dialog shows "Verified publisher: Quriosity Pty Ltd" instead of yellow "Unknown publisher".
+2. Enterprise IT policies that block unsigned executables stop blocking QCut.
+3. Antivirus false-positive rate drops.
+4. SmartScreen "Windows protected your PC" warning at least shows the publisher name (still triggers on early downloads — see [CERTIFICATE-OPTIONS.md §SmartScreen reputation reality](CERTIFICATE-OPTIONS.md#smartscreen-reputation-reality-2026)).
 
 Long-term outcome (priority order, per `CLAUDE.md`):
+1. **Maintainability** — signing fits into the release workflow with manageable manual overhead.
+2. **Scalability** — credentials and identity live in cloud HSM, not on a single laptop.
+3. **Performance** — signing should not extend release wall time by more than a few minutes.
+4. **Short-term gains** — *not* a goal. We are not buying a cheap OV reseller cert that comes with USB-token operational debt.
 
-1. **Maintainability** — signing is configured once and works across every
-   future release without per-release manual steps.
-2. **Scalability** — secrets / signing identity live in cloud-hosted
-   services, not on a single developer's machine. A new maintainer can
-   release without owning a USB token.
-3. **Performance** — signing should not noticeably extend release CI time
-   (target < 60 s extra on Windows job).
-4. **Short-term gains** — *not* a goal. We will not ship a self-signed
-   cert or one-time hack just to silence SmartScreen for v2026.5.
+## Why we are buying
 
-## Why this might not require buying a license
+QCut may close-source. Free/OSS-only paths (SignPath Foundation) are
+incompatible. The team has elected to buy a commercial certificate.
 
-`qcut/LICENSE` is MIT-style and `qcut/package.json:308` describes QCut as
-"Open-source AI video editor" — both prerequisites for **SignPath
-Foundation**, a free Authenticode signing program for verified
-open-source projects (used by Blender, OBS Studio, Inkscape, Krita,
-GIMP, KeePass, Notepad++, etc.).
+## Path chosen: Certum SimplySign Standard Code Signing
 
-**Plan:** apply to SignPath Foundation first (free, ~1–2 weeks for
-review). Only if SignPath denies do we buy Azure Trusted Signing
-(~USD 10/month). See [`CERTIFICATE-OPTIONS.md`](CERTIFICATE-OPTIONS.md)
-for full vendor comparison and the rationale against DigiCert / Sectigo /
-EV in v1.
+- **Cost:** ~USD 200/year (€189/year)
+- **Type:** OV (Organization Validation), Cloud HSM
+- **Subject:** "Quriosity Pty Ltd"
+- **Why this and not others:** see [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md). Short version: Azure unavailable (country + age), SignPath OSS-only, EV no longer worth premium since 2024, Sectigo/DigiCert OV needs USB token.
+- **Tradeoff to accept:** Each `signtool sign` operation prompts Donghao's phone via SimplySign mobile app for approval. Releases are no longer fully unattended — the signing step is manual, taking ~30 seconds of human input per release.
 
-## Path decision (gates Subtask 1 outcome)
-
-The implementation has two flavors. Subtask 1 picks one based on the
-SignPath outcome.
-
-| | **Path A — SignPath (preferred)** | **Path B — Azure (fallback)** |
-|-|-----------------------------------|-------------------------------|
-| Cost | $0 | ~$120/year |
-| Signing trigger | Post-build via SignPath GitHub Action | Inline during `electron-builder` via `azureSignOptions` |
-| `electron-builder` win config | `forceCodeSigning: false`, `signAndEditExecutable: false` (SignPath signs post-build, otherwise builder doesn't know how) | `forceCodeSigning: true`, `signAndEditExecutable: true`, `azureSignOptions` populated |
-| New CI step | "Submit signing request to SignPath" using `signpath/github-action-submit-signing-request@v1` | None — signing happens in the existing build step |
-| New repo secrets | `SIGNPATH_API_TOKEN`, `SIGNPATH_ORGANIZATION_ID`, `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_SIGNING_POLICY_SLUG`, `SIGNPATH_ARTIFACT_SLUG` | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, `AZURE_CERTIFICATE_PROFILE`, `WINDOWS_PUBLISHER_NAME` |
-| Verifier script (`verify-windows-signature.ts`) | **Same** — verifies via `signtool /pa /v` and matches `WINDOWS_PUBLISHER_NAME` env var | **Same** |
-
-The verifier script and the manual VM dry-run are path-agnostic. Most
-other subtasks have an "if Path A / if Path B" detail in
-[`IMPLEMENTATION.md`](IMPLEMENTATION.md).
+If signing-step manual overhead becomes painful (e.g. weekly hotfix releases), the migration path is **SSL.com eSigner OV** (~$250/year, full REST API automation). See [IMPLEMENTATION.md §future hardening](IMPLEMENTATION.md#5-future-hardening-track-separately).
 
 ## Subtask map
 
-The full implementation is **clearly > 20 minutes** (multi-day if you
-count vendor review). Subtasks are sequenced so each one is independently
-mergeable and reviewable.
+| # | Subtask | Owner action | Code? | Wall time | Detail |
+|---|---------|--------------|-------|-----------|--------|
+| 1 | Order Certum cert | Pay €189 at shop.certum.eu | No | 15 min | [CERTIFICATE-OPTIONS.md §how to apply](CERTIFICATE-OPTIONS.md#certum-simplysign-how-to-apply) |
+| 2 | Submit identity validation docs | Upload ASIC, D-U-N-S, passport, address proof | No | 30 min submit + 3–7 days Certum review | [CERTIFICATE-OPTIONS.md §how to apply](CERTIFICATE-OPTIONS.md#certum-simplysign-how-to-apply) |
+| 3 | Install SimplySign mobile app + desktop signing tool | On Donghao's phone + signing machine | No | 30 min | [IMPLEMENTATION.md §0](IMPLEMENTATION.md#0-tooling-setup) |
+| 4 | Update `electron-builder` Windows config | Remove signing-disable flags from `qcut/package.json` | Yes | 20 min | [IMPLEMENTATION.md §1](IMPLEMENTATION.md#1-update-electron-builder-windows-config) |
+| 5 | Update GitHub Actions release workflow | CI builds unsigned, exposes artifact for manual signing | Yes | 30 min | [IMPLEMENTATION.md §2](IMPLEMENTATION.md#2-update-github-actions-release-workflow) |
+| 6 | Add local signing helper script | New `qcut/scripts/sign-windows-release.ts` | Yes | 1 hr | [IMPLEMENTATION.md §3](IMPLEMENTATION.md#3-add-local-signing-helper-script) |
+| 7 | Add post-signing signature verifier | New `qcut/scripts/verify-windows-signature.ts` | Yes | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-add-post-signing-signature-verifier) |
+| 8 | Add Windows download-page warning copy | Explain SmartScreen first-run experience | Yes (web) | 30 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
+| 9 | Maintainer documentation | New `qcut/docs/setup/windows-code-signing.md` | Yes (docs) | 45 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
+| 10 | Tests | Verifier + workflow guardrails | Yes | 1 hr | [TESTING.md](TESTING.md) |
+| 11 | Dry-run release on clean Windows VM | Manual verification | No | 1 hr | [IMPLEMENTATION.md §6](IMPLEMENTATION.md#6-dry-run-release-on-clean-windows-vm) |
 
-| # | Subtask | Owner action | Code? | Est. wall time | Detail file |
-|---|---------|--------------|-------|----------------|-------------|
-| 1a | **Apply to SignPath Foundation** | Submit OSS application | No | 1–2 weeks (review) | [CERTIFICATE-OPTIONS.md §SignPath](CERTIFICATE-OPTIONS.md#signpath-foundation-how-to-apply) |
-| 1b | Azure procurement *(fallback only — only if 1a is denied)* | Buy Trusted Signing identity, verify org | No | 1–7 days | [CERTIFICATE-OPTIONS.md §Azure](CERTIFICATE-OPTIONS.md#azure-trusted-signing-procurement-fallback-only) |
-| 2 | Update `electron-builder` Windows config | Path-dependent edit to `qcut/package.json` `build.win` | Yes | 30 min | [IMPLEMENTATION.md §A1 / §B1](IMPLEMENTATION.md) |
-| 3 | Update local `dist:win*` npm scripts | Remove `forceCodeSigning=false` overrides; keep one unsigned variant | Yes | 20 min | [IMPLEMENTATION.md §A2 / §B2](IMPLEMENTATION.md) |
-| 4 | Update release workflow | Path A: add SignPath submit step. Path B: remove `--config.win.*=false`, inject Azure secrets. | Yes | 30–60 min | [IMPLEMENTATION.md §A3 / §B3](IMPLEMENTATION.md) |
-| 5 | Add post-build signature verification | New script + CI step (path-agnostic) | Yes | 1 hr | [IMPLEMENTATION.md §4](IMPLEMENTATION.md#4-add-post-build-signature-verification-shared) |
-| 6 | Documentation | Maintainer signing setup guide + release doc update | Yes (docs) | 45 min | [DOCUMENTATION.md](DOCUMENTATION.md) |
-| 7 | Tests | Unit tests for verifier + workflow YAML guardrail (path-aware) | Yes | 1 hr | [TESTING.md](TESTING.md) |
-| 8 | Dry-run release | Trigger release on `rc` tag, verify signed `.exe` on a clean Windows VM | No | 1 hr | [IMPLEMENTATION.md §5](IMPLEMENTATION.md#5-dry-run-release--manual-verification-shared) |
-
-**Total engineering time (excluding vendor review): ~5 hours regardless of path.**
+**Total engineering time: ~5 hours. Wall time: dominated by Certum's 3–7 day identity review.**
 
 ## Files this plan will touch
 
-Authoritative list — keep this in sync if scope changes. Items marked
-**[A]** are Path A only, **[B]** Path B only, **[shared]** apply to both.
-
 ### Modified
 
-- `qcut/package.json` — lines 84, 86, 88, 89 (scripts) and lines 231–240 (`build.win`).
-  - **[A]** `build.win` flips `verifyUpdateCodeSignature` to `true` only;
-    `forceCodeSigning` stays `false` because SignPath signs post-build.
-  - **[B]** all three signing flags flipped to `true`, plus
-    `azureSignOptions` block added.
-- `qcut/.github/workflows/release.yml` — line 96 (Build Electron application step) and surrounding env block (~lines 60–98).
-  - **[A]** Removes the `forceCodeSigning=false` overrides; adds new
-    "Submit signing request to SignPath" + "Download signed artifact"
-    steps after the build.
-  - **[B]** Removes overrides; adds Azure secret env vars to the build
-    step.
-- `qcut/docs/release.md` — add signing prerequisites section *(create if missing)*.
+- `qcut/package.json`
+  - Lines 84, 86, 88, 89 (`scripts` block) — remove `forceCodeSigning=false` overrides
+  - Lines 231–240 (`build.win` block) — keep `forceCodeSigning: false` because we sign **after** electron-builder finishes (manual local signing); flip `verifyUpdateCodeSignature` to `true`
+- `qcut/.github/workflows/release.yml` — line 96 area: remove `--config.win.*=false` overrides; document that signing happens manually after CI
+- `qcut/docs/release.md` — signing prerequisites note (create if missing)
 
 ### Added
 
-- **[shared]** `qcut/scripts/verify-windows-signature.ts` — Bun/Node wrapper that shells out to `signtool verify /pa /v` and exits non-zero if unsigned or signed by an unexpected publisher.
-- **[shared]** `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest unit tests.
-- **[shared]** `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json` shape guardrail (path-aware: validates either Path A or Path B config).
-- **[shared]** `qcut/scripts/__tests__/release-workflow-signing.test.ts` — workflow YAML guardrail (path-aware).
-- **[shared]** `qcut/docs/setup/windows-code-signing.md` — maintainer-facing setup guide. Covers both Path A (SignPath) and Path B (Azure) credential setup.
+- `qcut/scripts/sign-windows-release.ts` — wrapper that calls `signtool sign` with Certum SimplySign Cloud HSM identity; expects SimplySign desktop tool installed and authenticated.
+- `qcut/scripts/verify-windows-signature.ts` — runs `signtool verify /pa /v` against the signed artifact, fails non-zero on missing signature or wrong publisher.
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest unit tests.
+- `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json` shape guardrail.
+- `qcut/scripts/__tests__/release-workflow-signing.test.ts` — workflow YAML guardrail.
+- `qcut/docs/setup/windows-code-signing.md` — maintainer-facing setup guide.
 - `qcut/docs/task/windows-code-signing/` — this folder.
 
 ### Not touched (intentional)
 
-- `qcut/build/icon.ico` — icon stays as-is.
-- `qcut/scripts/release.ts` — release orchestrator does not need to know
-  about signing.
-- `qcut/package.json` `build.mac` block — macOS signing is a separate
-  concern (and currently also unsigned in CI; tracked elsewhere).
+- `qcut/build/icon.ico` — icon stays.
+- `qcut/scripts/release.ts` — release orchestrator does not need to know about signing.
+- `qcut/package.json` `build.mac` block — macOS signing is a separate task.
 
 ## Risks & open questions
 
-1. **SignPath review timing** — typically 1–2 weeks. Subtask 1a must
-   start *before* engineering work to avoid blocking release.
-2. **SignPath denial path** — if denied, Subtask 1b (Azure) adds another
-   1–7 days for Microsoft identity validation. Plan release timing
-   accordingly.
-3. **SmartScreen reputation lag** — even after signing, the *first*
-   signed builds may show "less common app" warnings until reputation
-   accumulates. Document this expectation in the user-facing release
-   notes.
-4. **macOS / Linux unaffected** — this plan deliberately scopes to
-   Windows. macOS is *also* currently unsigned in CI (no `mac.identity`,
-   no Apple secrets in `release.yml`); that is a separate task.
-5. **Cert renewal**
-   - Path A: SignPath rotates automatically; no calendar reminder needed.
-   - Path B: profile auto-rotates, but the Azure subscription billing
-     should have an alert.
+1. **Certum identity review delay.** Typical 3–7 business days. With D-U-N-S already issued, expect the faster end of that range.
+2. **SimplySign desktop tool platform support.** Certum officially supports Windows. Mac/Linux signing requires running the Windows tool through a VM or finding alternatives. Donghao currently uses macOS — verify SimplySign workflow works for him before relying on it.
+3. **Phone availability for every release.** Donghao must approve each `signtool` operation via SimplySign app. If he's offline (flight, vacation), no signed release possible. Mitigation: add a second team member to the Certum account once cert is issued.
+4. **SmartScreen reputation will not be instant.** Even after signing, the first ~hundreds of downloads of each new build will still trigger SmartScreen. This is unavoidable in 2026 (see [CERTIFICATE-OPTIONS.md §SmartScreen reputation reality](CERTIFICATE-OPTIONS.md#smartscreen-reputation-reality-2026)). Mitigation: add a download-page note explaining the first-run warning is expected.
+5. **Cert renewal.** 460-day max validity (2026 CA/B Forum rule). Calendar reminder 60 days before expiry. Renewal preserves nothing — each cert renewal effectively starts fresh on SmartScreen reputation per file hash anyway.
+6. **macOS / Linux unaffected.** This plan deliberately scopes to Windows. macOS is *also* currently unsigned in CI (no `mac.identity`, no Apple secrets in `release.yml`); that is tracked at [`docs/task/macos-code-signing/`](../macos-code-signing/).
 
 ## Success criteria
 
-Mirrors the issue acceptance criteria, made testable:
+Mirrors GitHub issue #289 acceptance, made testable:
 
-- [ ] `signtool verify /pa /v QCut*Setup*.exe` exits 0 on the release artifact.
-- [ ] `Get-AuthenticodeSignature` reports `Status: Valid` and a
-      `SignerCertificate.Subject` matching the expected publisher
-      (SignPath-issued or Azure-issued).
-- [ ] `qcut/package.json` `build.win` has the appropriate signing config
-      for the chosen path (see Path decision table above).
-- [ ] CI release job fails fast (before publishing) if signing fails.
-- [ ] A first-time Windows user sees the verified publisher name on
-      installer launch (verified manually on a clean VM).
-- [ ] Maintainer signing setup is documented at
-      `qcut/docs/setup/windows-code-signing.md`.
+- [ ] `signtool verify /pa /v QCut*Setup*.exe` exits 0 on the released artifact.
+- [ ] `Get-AuthenticodeSignature` reports `Status: Valid` with `SignerCertificate.Subject` containing "Quriosity Pty Ltd".
+- [ ] `qcut/package.json` `build.win` no longer has `forceCodeSigning: false` overrides in npm scripts.
+- [ ] On a clean Windows VM, double-clicking the installer shows blue UAC dialog with "Verified publisher: Quriosity Pty Ltd" (not yellow "Unknown publisher").
+- [ ] Maintainer signing setup is documented at `qcut/docs/setup/windows-code-signing.md`.
+- [ ] Windows download page on QCut website has a one-paragraph note explaining the first-run SmartScreen warning is normal and how to proceed.
 
 ## Out of scope for this plan
 
-- macOS notarization changes.
-- Microsoft Store submission (mentioned in the issue as a *future*
-  reputation booster — file a separate issue).
-- Auto-update signature pinning beyond what `electron-builder`'s
-  `verifyUpdateCodeSignature: true` already provides.
+- macOS notarization changes (separate task).
+- Microsoft Store submission (different cert path entirely; mentioned in issue as future reputation booster).
+- Auto-update signature pinning beyond what `electron-builder`'s `verifyUpdateCodeSignature: true` already provides.
+- Migration to fully-automated CI signing (SSL.com eSigner) — track as future hardening once Certum manual flow is operational.

--- a/qcut/docs/task/windows-code-signing/PLAN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.md
@@ -33,7 +33,7 @@ incompatible. The team has elected to buy a commercial certificate.
 - **Why this and not others:** see [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md). Short version: Azure unavailable (country + age), SignPath OSS-only, EV no longer worth premium since 2024, Sectigo/DigiCert OV needs USB token.
 - **Tradeoff to accept:** Each `signtool sign` operation prompts Donghao's phone via SimplySign mobile app for approval. Releases are no longer fully unattended — the signing step is manual, taking ~30 seconds of human input per release.
 
-If signing-step manual overhead becomes painful (e.g. weekly hotfix releases), the migration path is **SSL.com eSigner OV** (~$250/year, full REST API automation). See [IMPLEMENTATION.md §future hardening](IMPLEMENTATION.md#5-future-hardening-track-separately).
+If signing-step manual overhead becomes painful (e.g. weekly hotfix releases), the migration path is **SSL.com eSigner OV** (~$439–479/year — that is *$239 cert + $200–240/year eSigner subscription*; the second cost surprised earlier drafts). At QCut's current ~monthly release cadence, the manual phone-approval cost is ~minutes/year and not worth the ~$220+ Certum-vs-SSL.com price gap. See [IMPLEMENTATION.md §future hardening](IMPLEMENTATION.md#5-future-hardening-track-separately).
 
 ## Subtask map
 

--- a/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
@@ -2,148 +2,114 @@
 
 **对应 issue：** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
 **分支：** `gpt-image-2`
-**创建日期：** 2026-04-25（同日修订，加入 SignPath Foundation 路线）
+**创建日期：** 2026-04-25（同日修订，排除掉 Azure / SignPath / EV 路径之后定方案）
 
 ## 目标
 
-通过对 `electron-builder` 产出的 NSIS `.exe` 进行 Authenticode 签名，
-消除 QCut Windows 安装包上"发布者：未知发布者"的警告。签名工作在
-GitHub Actions 发布流水线里完成。
+用 Authenticode 证书（颁发给 **Quriosity Pty Ltd**）签 QCut 的 Windows
+NSIS 安装包，使：
 
-按 `CLAUDE.md` 的优先级顺序，长期目标是：
+1. UAC 弹窗显示蓝色 "Verified publisher: Quriosity Pty Ltd"，不再是
+   黄色 "Unknown publisher"。
+2. 禁未签名 .exe 的企业 IT 策略不再拦 QCut。
+3. 杀毒软件误报率下降。
+4. SmartScreen "Windows protected your PC" 警告至少能显示发布者名
+   （早期下载仍会触发 — 详见
+   [CERTIFICATE-OPTIONS.zh-CN.md §SmartScreen 信誉的现实](CERTIFICATE-OPTIONS.zh-CN.md#smartscreen-信誉的现实2026)）。
 
-1. **可维护性** — 一次配置好，以后每次发布都能自动签，无需手工干预。
-2. **可扩展性** — 密钥/签名身份放在云服务里，不绑定到某个开发者
-   的电脑。新维护者也能正常发布，不用拿 USB 令牌。
-3. **性能** — 签名不应明显增加发布 CI 时间（目标：Windows 任务额外
-   不超过 60 秒）。
-4. **短期收益** — *不是*目标。我们不会用自签证书或一次性 hack 来
-   敷衍 v2026.5。
+按 `CLAUDE.md` 优先级顺序：
+1. **可维护性** — 签名能融入发布流程，手工开销可控。
+2. **可扩展性** — 凭据和身份在云 HSM 里，不绑定到某台电脑。
+3. **性能** — 签名不应让发布墙上时间多于几分钟。
+4. **短期收益** — *不是*目标。我们不会为了便宜 50 美金买一个带 USB
+   token 运维债的 OV 分销证书。
 
-## 这件事不一定要"买 license"
+## 为什么要买
 
-`qcut/LICENSE` 是 MIT 类许可证，`qcut/package.json:308` 把 QCut 描述成
-"Open-source AI video editor" — 这两条满足了 **SignPath Foundation**
-的资格。SignPath Foundation 是面向开源项目的免费 Authenticode 签名计划
-（Blender、OBS Studio、Inkscape、Krita、GIMP、KeePass、Notepad++ 等都用
-它）。
+QCut 之后可能闭源，免费/仅开源路径（SignPath Foundation）不兼容。
+团队决定走商业证书路径。
 
-**计划：** 先申请 SignPath Foundation（免费，约 1–2 周审批）。只有
-SignPath 拒绝了，才去买 Azure Trusted Signing（约 USD 10/月）。完整的
-厂商对比和 v1 不选 DigiCert/Sectigo/EV 的理由见
-[`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)。
+## 选定路径：Certum SimplySign Standard Code Signing
 
-## 路径决策（取决于子任务 1 结果）
+- **价格：** 约 USD 200/年（€189/年）
+- **类型：** OV（Organization Validation），云 HSM
+- **Subject：** "Quriosity Pty Ltd"
+- **为什么是这个**：见 [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md)。简版：Azure 不可用（国家+年限）、SignPath 仅开源、EV 自 2024 起不再值溢价、Sectigo/DigiCert OV 要 USB token。
+- **要接受的权衡：** 每次 `signtool sign` 都会通过 SimplySign 手机
+  App 让 Donghao 确认。发布**不再**完全无人值守 — 签名步骤是手工的，
+  每次发布需要约 30 秒人工确认。
 
-实现有两种风格。子任务 1 的结果决定走哪条。
-
-| | **Path A — SignPath（首选）** | **Path B — Azure（fallback）** |
-|-|-------------------------------|--------------------------------|
-| 成本 | $0 | 约 $120/年 |
-| 签名时机 | 构建后通过 SignPath GitHub Action 签 | 构建过程中 `electron-builder` 通过 `azureSignOptions` 内联签 |
-| `electron-builder` win 配置 | `forceCodeSigning: false`、`signAndEditExecutable: false`（SignPath 在构建后才签，否则 builder 不知道怎么签） | `forceCodeSigning: true`、`signAndEditExecutable: true`，加上 `azureSignOptions` |
-| 新增 CI 步骤 | "Submit signing request to SignPath"，用 `signpath/github-action-submit-signing-request@v1` | 无 — 签名在原有 build 步骤里发生 |
-| 新增仓库 secret | `SIGNPATH_API_TOKEN`、`SIGNPATH_ORGANIZATION_ID`、`SIGNPATH_PROJECT_SLUG`、`SIGNPATH_SIGNING_POLICY_SLUG`、`SIGNPATH_ARTIFACT_SLUG` | `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`、`AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、`AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME` |
-| 校验脚本 (`verify-windows-signature.ts`) | **相同** — 用 `signtool /pa /v` 校验，匹配 `WINDOWS_PUBLISHER_NAME` 环境变量 | **相同** |
-
-校验脚本和人工 VM 演练与具体路径无关。其它子任务在
-[`IMPLEMENTATION.zh-CN.md`](IMPLEMENTATION.zh-CN.md) 里都有 "Path A / Path B"
-分支说明。
+如果手工签名变成痛点（比如要每周热修发版），迁移路径是
+**SSL.com eSigner OV**（约 $250/年，REST API 全自动）。详见
+[IMPLEMENTATION.zh-CN.md §未来加固](IMPLEMENTATION.zh-CN.md#5-未来加固单独跟踪)。
 
 ## 子任务拆分
 
-整个工作明显**超过 20 分钟**（如果算上厂商审核，可能要几天）。
-下面的子任务按顺序排列，每个都可以独立合并、独立 review。
+| # | 子任务 | 操作内容 | 改代码？ | 耗时 | 详情 |
+|---|--------|----------|---------|------|------|
+| 1 | Certum 下单 | 在 shop.certum.eu 付 €189 | 否 | 15 分钟 | [CERTIFICATE-OPTIONS.zh-CN.md §怎么申请](CERTIFICATE-OPTIONS.zh-CN.md#certum-simplysign怎么申请) |
+| 2 | 提交身份验证材料 | 上传 ASIC、D-U-N-S、护照、地址证明 | 否 | 提交 30 分钟 + Certum 审核 3–7 天 | 同上 |
+| 3 | 装 SimplySign 手机 App + 桌面签名工具 | 在 Donghao 的手机和签名机 | 否 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §0](IMPLEMENTATION.zh-CN.md#0-工具链准备) |
+| 4 | 改 `electron-builder` Windows 配置 | 从 `qcut/package.json` 删 signing-disable 标志 | 是 | 20 分钟 | [IMPLEMENTATION.zh-CN.md §1](IMPLEMENTATION.zh-CN.md#1-修改-electron-builder-windows-配置) |
+| 5 | 改 GitHub Actions 发布工作流 | CI 出未签名包，artifact 留给本地签 | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §2](IMPLEMENTATION.zh-CN.md#2-修改-github-actions-发布工作流) |
+| 6 | 加本地签名辅助脚本 | 新增 `qcut/scripts/sign-windows-release.ts` | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §3](IMPLEMENTATION.zh-CN.md#3-加本地签名辅助脚本) |
+| 7 | 加签名后校验脚本 | 新增 `qcut/scripts/verify-windows-signature.ts` | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-加签名后的校验脚本) |
+| 8 | Windows 下载页加警告文案 | 解释 SmartScreen 首次运行体验 | 是（网站） | 30 分钟 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) |
+| 9 | 维护者文档 | 新增 `qcut/docs/setup/windows-code-signing.md` | 是（文档） | 45 分钟 | 同上 |
+| 10 | 测试 | 校验脚本 + workflow 守门 | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
+| 11 | 在干净 Windows VM 上做发布演练 | 人工验证 | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §6](IMPLEMENTATION.zh-CN.md#6-在干净-windows-vm-上做发布演练) |
 
-| # | 子任务 | 操作内容 | 是否改代码 | 预估耗时 | 详细文件 |
-|---|--------|----------|-----------|----------|----------|
-| 1a | **申请 SignPath Foundation** | 提交开源项目申请 | 否 | 1–2 周（审核） | [CERTIFICATE-OPTIONS.zh-CN.md §SignPath](CERTIFICATE-OPTIONS.zh-CN.md#signpath-foundation怎么申请) |
-| 1b | Azure 采购 *（仅 1a 被拒时执行）* | 在 Azure 申请 Trusted Signing 身份 | 否 | 1–7 天 | [CERTIFICATE-OPTIONS.zh-CN.md §Azure](CERTIFICATE-OPTIONS.zh-CN.md#azure-trusted-signing采购步骤仅-fallback-时执行) |
-| 2 | 改 `electron-builder` Windows 配置 | 路径相关，编辑 `qcut/package.json` 的 `build.win` | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §A1 / §B1](IMPLEMENTATION.zh-CN.md) |
-| 3 | 改本地 `dist:win*` 脚本 | 删掉 `forceCodeSigning=false` 覆盖，保留一个未签名变体 | 是 | 20 分钟 | [IMPLEMENTATION.zh-CN.md §A2 / §B2](IMPLEMENTATION.zh-CN.md) |
-| 4 | 改发布工作流 | Path A：加 SignPath 提交步骤。Path B：删除 `--config.win.*=false`，注入 Azure secret。 | 是 | 30–60 分钟 | [IMPLEMENTATION.zh-CN.md §A3 / §B3](IMPLEMENTATION.zh-CN.md) |
-| 5 | 加构建后签名校验 | 新增脚本 + CI 步骤（与路径无关） | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-增加构建后签名校验共享) |
-| 6 | 文档 | 维护者签名设置指南 + 发布文档更新 | 是（文档） | 45 分钟 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) |
-| 7 | 测试 | 校验脚本单元测试 + 工作流 YAML 守门测试（路径相关） | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
-| 8 | 发布演练 | 推 `rc` tag，在干净 Windows VM 上验证签名 `.exe` | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §5](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证共享) |
-
-**工程总耗时（不含厂商审核）：两条路都是约 5 小时。**
+**工程总耗时：约 5 小时。墙上时间主要被 Certum 的 3–7 天身份审核占据。**
 
 ## 本方案会动到的文件
 
-下面是权威清单。**[A]** 仅 Path A，**[B]** 仅 Path B，**[共享]** 两条
-路都涉及。
-
 ### 需要修改
 
-- `qcut/package.json` — 第 84、86、88、89 行（`scripts` 块）和第
-  231–240 行（`build.win` 块）。
-  - **[A]** `build.win` 只把 `verifyUpdateCodeSignature` 改成 `true`；
-    `forceCodeSigning` 保持 `false`，因为 SignPath 在构建后才签。
-  - **[B]** 三个签名 flag 全部改成 `true`，并加 `azureSignOptions` 块。
-- `qcut/.github/workflows/release.yml` — 第 96 行 "Build Electron
-  application" 步骤和周边 env 块（约第 60–98 行）。
-  - **[A]** 删掉 `forceCodeSigning=false` 覆盖；在 build 之后加新的
-    "Submit signing request to SignPath" + "Download signed artifact"
-    步骤。
-  - **[B]** 删掉覆盖；给 build 步骤的 env 块加 Azure secret。
-- `qcut/docs/release.md` — 加一段签名前置条件说明（如果文件不存在，
-  新建）。
+- `qcut/package.json`
+  - 第 84、86、88、89 行（`scripts` 块） — 删 `forceCodeSigning=false` 覆盖
+  - 第 231–240 行（`build.win` 块） — 保持 `forceCodeSigning: false`，因为我们在 electron-builder **完成之后**手工本地签；把 `verifyUpdateCodeSignature` 改成 `true`
+- `qcut/.github/workflows/release.yml` — 第 96 行附近：删 `--config.win.*=false` 覆盖；说明签名在 CI 之后手工进行
+- `qcut/docs/release.md` — 加签名前置条件说明（不存在则新建）
 
 ### 需要新增
 
-- **[共享]** `qcut/scripts/verify-windows-signature.ts` — Bun/Node 包装
-  脚本，调用 `signtool verify /pa /v`，签名异常或发布者不匹配时退出
-  非零。
-- **[共享]** `qcut/scripts/__tests__/verify-windows-signature.test.ts` —
-  Vitest 单元测试。
-- **[共享]** `qcut/scripts/__tests__/package-json-signing.test.ts` —
-  `package.json` 形态守门（路径相关：能识别 Path A 或 Path B 配置）。
-- **[共享]** `qcut/scripts/__tests__/release-workflow-signing.test.ts` —
-  工作流 YAML 守门（路径相关）。
-- **[共享]** `qcut/docs/setup/windows-code-signing.md` — 维护者签名
-  设置指南。覆盖 Path A（SignPath）和 Path B（Azure）的凭据设置。
+- `qcut/scripts/sign-windows-release.ts` — 调 `signtool sign` 用 Certum SimplySign 云 HSM 身份的 wrapper；前提是 SimplySign 桌面工具已安装并已认证。
+- `qcut/scripts/verify-windows-signature.ts` — 跑 `signtool verify /pa /v`，签名缺失或发布者错时退出非零。
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest 单测。
+- `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json` 形态守门。
+- `qcut/scripts/__tests__/release-workflow-signing.test.ts` — 工作流 YAML 守门。
+- `qcut/docs/setup/windows-code-signing.md` — 维护者签名设置指南。
 - `qcut/docs/task/windows-code-signing/` — 本目录。
 
 ### 故意不动
 
 - `qcut/build/icon.ico` — 图标保持原样。
 - `qcut/scripts/release.ts` — 发布编排脚本不需要知道签名细节。
-- `qcut/package.json` 的 `build.mac` 块 — macOS 签名是另一个独立任务
-  （目前 CI 里 macOS 也没真正签名；另开 issue 跟踪）。
+- `qcut/package.json` 的 `build.mac` 块 — macOS 签名是另一个任务。
 
 ## 风险与待定问题
 
-1. **SignPath 审核时间** — 一般 1–2 周。子任务 1a 必须*先于*工程改动
-   启动，否则会卡发布。
-2. **SignPath 拒绝路径** — 如果被拒，子任务 1b（Azure）还要再 1–7 天
-   等微软身份验证。发布节奏要据此规划。
-3. **SmartScreen 信誉滞后** — 即使签了名，*前几个*签名版本仍可能显示
-   "不常见的应用"警告，要等信誉积累。这条要写进面向用户的发布说明。
-4. **macOS / Linux 不受影响** — 本方案故意只覆盖 Windows。macOS *目前*
-   在 CI 里**也**没签名（`mac.identity` 和 Apple secret 都没配），是
-   独立的另一个任务。
-5. **证书续期**
-   - Path A：SignPath 自动轮换，不需要日历提醒。
-   - Path B：profile 自动轮换，但 Azure 订阅账单要设告警。
+1. **Certum 身份审核延迟。** 一般 3–7 个工作日。已有 D-U-N-S 会偏快一端。
+2. **SimplySign 桌面工具的平台支持。** Certum 官方支持 Windows。Mac/Linux 签名要么 VM 跑 Windows 工具，要么找替代方案。Donghao 目前主用 macOS — 上线前确认 SimplySign 工作流在他这边能跑通。
+3. **每次发布都要手机能用。** Donghao 要在 SimplySign App 上确认每次 `signtool` 操作。如果他离线（飞机、休假），就发不出签名包。缓解：证书签发后给 Certum 账号添加第二个团队成员。
+4. **SmartScreen 信誉不会立即生效。** 即使签了，新版本前 ~几百次下载仍会触发 SmartScreen。这在 2026 年是不可避免的（详见 [CERTIFICATE-OPTIONS.zh-CN.md §SmartScreen 信誉的现实](CERTIFICATE-OPTIONS.zh-CN.md#smartscreen-信誉的现实2026)）。缓解：在下载页加说明，告诉用户首次运行警告是预期的。
+5. **证书续期。** 460 天上限（2026 CA/B Forum 规则）。提前 60 天日历提醒。续期不保留任何东西 — 信誉本来就按文件 hash 算，且续期不影响已发布的旧版本（它们各自保留自己的信誉）。
+6. **macOS / Linux 不受影响。** 本方案故意只覆盖 Windows。macOS 在 CI 里**也**目前没签（没有 `mac.identity`，`release.yml` 没 Apple secret），跟踪在 [`docs/task/macos-code-signing/`](../macos-code-signing/)。
 
 ## 验收标准
 
-参考 issue 的验收标准，转化为可测的形式：
+参考 GitHub issue #289 验收，转化成可测形式：
 
 - [ ] `signtool verify /pa /v QCut*Setup*.exe` 在发布产物上退出 0。
-- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`，
-      `SignerCertificate.Subject` 是预期发布者（SignPath 颁发或
-      Azure 颁发）。
-- [ ] `qcut/package.json` 的 `build.win` 是当前路径下的正确签名配置
-      （见上文路径决策表）。
-- [ ] CI 发布任务在签名失败时立即失败（不发布到 release）。
-- [ ] 在干净 Windows VM 上首次安装时，能看到经过验证的发布者名称。
+- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`，`SignerCertificate.Subject` 包含 "Quriosity Pty Ltd"。
+- [ ] `qcut/package.json` 的 `build.win` 在 npm 脚本里不再有 `forceCodeSigning: false` 覆盖。
+- [ ] 在干净 Windows VM 上双击安装包，UAC 弹**蓝色** "Verified publisher: Quriosity Pty Ltd"（不再是黄色"Unknown publisher"）。
 - [ ] 维护者签名指南已发布在 `qcut/docs/setup/windows-code-signing.md`。
+- [ ] QCut 网站 Windows 下载页有一段说明，告诉用户首次运行的 SmartScreen 警告是正常的、怎么继续。
 
 ## 本方案不覆盖的部分
 
-- macOS 公证（notarization）相关改动。
-- Microsoft Store 提交（issue 提了将来可作为信誉补充，单独立 issue）。
-- 自动更新签名校验里 `electron-builder` 的
-  `verifyUpdateCodeSignature: true` 以外的额外校验。
+- macOS 公证相关改动（独立任务）。
+- Microsoft Store 提交（完全不同的证书路径；issue 提了将来可作为信誉补充）。
+- 自动更新签名校验里 `electron-builder` 的 `verifyUpdateCodeSignature: true` 以外的额外校验。
+- 迁移到完全自动化 CI 签名（SSL.com eSigner） — 在 Certum 手工流程跑通后单独跟踪。

--- a/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
@@ -40,7 +40,8 @@ QCut 之后可能闭源，免费/仅开源路径（SignPath Foundation）不兼�
   每次发布需要约 30 秒人工确认。
 
 如果手工签名变成痛点（比如要每周热修发版），迁移路径是
-**SSL.com eSigner OV**（约 $250/年，REST API 全自动）。详见
+**SSL.com eSigner OV**（约 $439–479/年 — 即 *$239 证书 + $200–240/年 eSigner 订阅*；第二笔费用之前的草稿都漏了）。
+按 QCut 当前约每月一次的发版节奏，手工确认成本一年只有几分钟，不值 ~$220+ 的 Certum vs SSL.com 价差。详见
 [IMPLEMENTATION.zh-CN.md §未来加固](IMPLEMENTATION.zh-CN.md#5-未来加固单独跟踪)。
 
 ## 子任务拆分

--- a/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
@@ -2,7 +2,7 @@
 
 **对应 issue：** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
 **分支：** `gpt-image-2`
-**创建日期：** 2026-04-25
+**创建日期：** 2026-04-25（同日修订，加入 SignPath Foundation 路线）
 
 ## 目标
 
@@ -13,100 +13,130 @@ GitHub Actions 发布流水线里完成。
 按 `CLAUDE.md` 的优先级顺序，长期目标是：
 
 1. **可维护性** — 一次配置好，以后每次发布都能自动签，无需手工干预。
-2. **可扩展性** — 密钥放在 GitHub Actions / 云 KMS 里，不绑定到某个开发者
-   的电脑。换一个维护者也能正常发布。
+2. **可扩展性** — 密钥/签名身份放在云服务里，不绑定到某个开发者
+   的电脑。新维护者也能正常发布，不用拿 USB 令牌。
 3. **性能** — 签名不应明显增加发布 CI 时间（目标：Windows 任务额外
    不超过 60 秒）。
 4. **短期收益** — *不是*目标。我们不会用自签证书或一次性 hack 来
    敷衍 v2026.5。
 
-## 为什么这件事需要"买 license"
+## 这件事不一定要"买 license"
 
-Authenticode 签名要求由 Windows 信任的 CA 颁发的**商用代码签名证书**。
-自签证书无法消除 SmartScreen 警告。证书选型、价格和推荐方案见
+`qcut/LICENSE` 是 MIT 类许可证，`qcut/package.json:308` 把 QCut 描述成
+"Open-source AI video editor" — 这两条满足了 **SignPath Foundation**
+的资格。SignPath Foundation 是面向开源项目的免费 Authenticode 签名计划
+（Blender、OBS Studio、Inkscape、Krita、GIMP、KeePass、Notepad++ 等都用
+它）。
+
+**计划：** 先申请 SignPath Foundation（免费，约 1–2 周审批）。只有
+SignPath 拒绝了，才去买 Azure Trusted Signing（约 USD 10/月）。完整的
+厂商对比和 v1 不选 DigiCert/Sectigo/EV 的理由见
 [`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)。
 
-**推荐：** Azure Trusted Signing（Public Trust 身份），约 USD 10/月，
-原因：
+## 路径决策（取决于子任务 1 结果）
 
-- 云原生，不需要带 USB HSM 硬件令牌。
-- `electron-builder` 原生支持 `azureSignOptions`。
-- 身份验证比 EV 证书宽松（组织或个人均可）。
-- 这条路线在 issue #289 里就是作者推荐的。
+实现有两种风格。子任务 1 的结果决定走哪条。
+
+| | **Path A — SignPath（首选）** | **Path B — Azure（fallback）** |
+|-|-------------------------------|--------------------------------|
+| 成本 | $0 | 约 $120/年 |
+| 签名时机 | 构建后通过 SignPath GitHub Action 签 | 构建过程中 `electron-builder` 通过 `azureSignOptions` 内联签 |
+| `electron-builder` win 配置 | `forceCodeSigning: false`、`signAndEditExecutable: false`（SignPath 在构建后才签，否则 builder 不知道怎么签） | `forceCodeSigning: true`、`signAndEditExecutable: true`，加上 `azureSignOptions` |
+| 新增 CI 步骤 | "Submit signing request to SignPath"，用 `signpath/github-action-submit-signing-request@v1` | 无 — 签名在原有 build 步骤里发生 |
+| 新增仓库 secret | `SIGNPATH_API_TOKEN`、`SIGNPATH_ORGANIZATION_ID`、`SIGNPATH_PROJECT_SLUG`、`SIGNPATH_SIGNING_POLICY_SLUG`、`SIGNPATH_ARTIFACT_SLUG` | `AZURE_TENANT_ID`、`AZURE_CLIENT_ID`、`AZURE_CLIENT_SECRET`、`AZURE_TRUSTED_SIGNING_ENDPOINT`、`AZURE_TRUSTED_SIGNING_ACCOUNT`、`AZURE_CERTIFICATE_PROFILE`、`WINDOWS_PUBLISHER_NAME` |
+| 校验脚本 (`verify-windows-signature.ts`) | **相同** — 用 `signtool /pa /v` 校验，匹配 `WINDOWS_PUBLISHER_NAME` 环境变量 | **相同** |
+
+校验脚本和人工 VM 演练与具体路径无关。其它子任务在
+[`IMPLEMENTATION.zh-CN.md`](IMPLEMENTATION.zh-CN.md) 里都有 "Path A / Path B"
+分支说明。
 
 ## 子任务拆分
 
-整个工作明显**超过 20 分钟**（如果算上微软审核证书的时间，可能要好几天）。
+整个工作明显**超过 20 分钟**（如果算上厂商审核，可能要几天）。
 下面的子任务按顺序排列，每个都可以独立合并、独立 review。
 
 | # | 子任务 | 操作内容 | 是否改代码 | 预估耗时 | 详细文件 |
 |---|--------|----------|-----------|----------|----------|
-| 1 | 购买证书 | 在 Azure 上申请 Trusted Signing 身份，等微软审核 | 否 | 1–7 天（看微软审核） | [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md) |
-| 2 | 改 `electron-builder` Windows 配置 | 三个 flag 翻成 true，加 `azureSignOptions` | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §1](IMPLEMENTATION.zh-CN.md#1-修改-electron-builder-windows-配置) |
-| 3 | 改本地 `dist:win*` 脚本 | 删掉 `forceCodeSigning=false` 覆盖，保留一个未签名的本地开发变体 | 是 | 20 分钟 | [IMPLEMENTATION.zh-CN.md §2](IMPLEMENTATION.zh-CN.md#2-修改本地-distwin-脚本) |
-| 4 | 改发布工作流 | 删除 `--config.win.*=false` 覆盖，注入 Azure secret | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §3](IMPLEMENTATION.zh-CN.md#3-修改-github-actions-发布工作流) |
-| 5 | 加构建后签名校验 | 新增脚本 + CI 步骤，签名失败立即让 release 失败 | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-增加构建后签名校验) |
+| 1a | **申请 SignPath Foundation** | 提交开源项目申请 | 否 | 1–2 周（审核） | [CERTIFICATE-OPTIONS.zh-CN.md §SignPath](CERTIFICATE-OPTIONS.zh-CN.md#signpath-foundation怎么申请) |
+| 1b | Azure 采购 *（仅 1a 被拒时执行）* | 在 Azure 申请 Trusted Signing 身份 | 否 | 1–7 天 | [CERTIFICATE-OPTIONS.zh-CN.md §Azure](CERTIFICATE-OPTIONS.zh-CN.md#azure-trusted-signing采购步骤仅-fallback-时执行) |
+| 2 | 改 `electron-builder` Windows 配置 | 路径相关，编辑 `qcut/package.json` 的 `build.win` | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §A1 / §B1](IMPLEMENTATION.zh-CN.md) |
+| 3 | 改本地 `dist:win*` 脚本 | 删掉 `forceCodeSigning=false` 覆盖，保留一个未签名变体 | 是 | 20 分钟 | [IMPLEMENTATION.zh-CN.md §A2 / §B2](IMPLEMENTATION.zh-CN.md) |
+| 4 | 改发布工作流 | Path A：加 SignPath 提交步骤。Path B：删除 `--config.win.*=false`，注入 Azure secret。 | 是 | 30–60 分钟 | [IMPLEMENTATION.zh-CN.md §A3 / §B3](IMPLEMENTATION.zh-CN.md) |
+| 5 | 加构建后签名校验 | 新增脚本 + CI 步骤（与路径无关） | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-增加构建后签名校验共享) |
 | 6 | 文档 | 维护者签名设置指南 + 发布文档更新 | 是（文档） | 45 分钟 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) |
-| 7 | 测试 | 校验脚本的单元测试 + 工作流 YAML 守门测试 | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
-| 8 | 发布演练 | 在干净 Windows VM 上跑 `rc` tag，确认签名 `.exe` 的发布者 | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §5](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证) |
+| 7 | 测试 | 校验脚本单元测试 + 工作流 YAML 守门测试（路径相关） | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
+| 8 | 发布演练 | 推 `rc` tag，在干净 Windows VM 上验证签名 `.exe` | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §5](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证共享) |
 
-**工程总耗时（不含等待证书审核）：约 5 小时。**
+**工程总耗时（不含厂商审核）：两条路都是约 5 小时。**
 
 ## 本方案会动到的文件
 
-下面是权威清单 — 如果范围有变化，请同步更新。
+下面是权威清单。**[A]** 仅 Path A，**[B]** 仅 Path B，**[共享]** 两条
+路都涉及。
 
 ### 需要修改
 
-- `qcut/package.json`
-  - 第 84、86、88、89 行（`scripts` 块）
-  - 第 231–240 行（`build.win` 块）
-- `qcut/.github/workflows/release.yml`
-  - 第 96 行 "Build Electron application" 步骤
-  - 周边 env 块（约第 60–98 行）
-- `qcut/docs/release.md` — 加一段签名前置条件说明（如果文件不存在，新建）。
+- `qcut/package.json` — 第 84、86、88、89 行（`scripts` 块）和第
+  231–240 行（`build.win` 块）。
+  - **[A]** `build.win` 只把 `verifyUpdateCodeSignature` 改成 `true`；
+    `forceCodeSigning` 保持 `false`，因为 SignPath 在构建后才签。
+  - **[B]** 三个签名 flag 全部改成 `true`，并加 `azureSignOptions` 块。
+- `qcut/.github/workflows/release.yml` — 第 96 行 "Build Electron
+  application" 步骤和周边 env 块（约第 60–98 行）。
+  - **[A]** 删掉 `forceCodeSigning=false` 覆盖；在 build 之后加新的
+    "Submit signing request to SignPath" + "Download signed artifact"
+    步骤。
+  - **[B]** 删掉覆盖；给 build 步骤的 env 块加 Azure secret。
+- `qcut/docs/release.md` — 加一段签名前置条件说明（如果文件不存在，
+  新建）。
 
 ### 需要新增
 
-- `qcut/scripts/verify-windows-signature.ts` — Bun/Node 脚本，调用
-  `signtool verify /pa /v`（或 PowerShell `Get-AuthenticodeSignature`），
-  签名异常或发布者不匹配时退出非零。
-- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest
-  单元测试，mock `child_process`。
-- `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json`
-  形态守门测试。
-- `qcut/scripts/__tests__/release-workflow-signing.test.ts` — 工作流
-  YAML 守门测试。
-- `qcut/docs/setup/windows-code-signing.md` — 维护者签名设置指南
-  （Azure 租户配置、GitHub secret、本地签名）。
+- **[共享]** `qcut/scripts/verify-windows-signature.ts` — Bun/Node 包装
+  脚本，调用 `signtool verify /pa /v`，签名异常或发布者不匹配时退出
+  非零。
+- **[共享]** `qcut/scripts/__tests__/verify-windows-signature.test.ts` —
+  Vitest 单元测试。
+- **[共享]** `qcut/scripts/__tests__/package-json-signing.test.ts` —
+  `package.json` 形态守门（路径相关：能识别 Path A 或 Path B 配置）。
+- **[共享]** `qcut/scripts/__tests__/release-workflow-signing.test.ts` —
+  工作流 YAML 守门（路径相关）。
+- **[共享]** `qcut/docs/setup/windows-code-signing.md` — 维护者签名
+  设置指南。覆盖 Path A（SignPath）和 Path B（Azure）的凭据设置。
 - `qcut/docs/task/windows-code-signing/` — 本目录。
 
 ### 故意不动
 
 - `qcut/build/icon.ico` — 图标保持原样。
-- `qcut/scripts/release.ts` — 发布编排脚本不需要知道签名细节，
-  `electron-builder` 会处理。
+- `qcut/scripts/release.ts` — 发布编排脚本不需要知道签名细节。
+- `qcut/package.json` 的 `build.mac` 块 — macOS 签名是另一个独立任务
+  （目前 CI 里 macOS 也没真正签名；另开 issue 跟踪）。
 
 ## 风险与待定问题
 
-1. **Azure 审核时间** — 微软的身份验证最长可能要一周。子任务 1 必须
-   *先于*工程改动启动，否则会卡发布。
-2. **SmartScreen 信誉滞后** — 即使签了名，*前几个*签名版本仍可能显示
+1. **SignPath 审核时间** — 一般 1–2 周。子任务 1a 必须*先于*工程改动
+   启动，否则会卡发布。
+2. **SignPath 拒绝路径** — 如果被拒，子任务 1b（Azure）还要再 1–7 天
+   等微软身份验证。发布节奏要据此规划。
+3. **SmartScreen 信誉滞后** — 即使签了名，*前几个*签名版本仍可能显示
    "不常见的应用"警告，要等信誉积累。这条要写进面向用户的发布说明。
-3. **证书续期** — 设置一个日历提醒，到期前 30 天准备续期。证书买好后
-   补到 `IMPLEMENTATION.zh-CN.md §6`。
-4. **macOS / Linux 不受影响** — 本方案故意只覆盖 Windows。macOS 已经
-   有 Apple Developer ID 签名（在 `qcut/package.json` 的 `build.mac` 里
-   能确认）。
+4. **macOS / Linux 不受影响** — 本方案故意只覆盖 Windows。macOS *目前*
+   在 CI 里**也**没签名（`mac.identity` 和 Apple secret 都没配），是
+   独立的另一个任务。
+5. **证书续期**
+   - Path A：SignPath 自动轮换，不需要日历提醒。
+   - Path B：profile 自动轮换，但 Azure 订阅账单要设告警。
 
 ## 验收标准
 
 参考 issue 的验收标准，转化为可测的形式：
 
-- [ ] `signtool verify /pa /v QCut*Setup*.exe` 在发布产物上退出码为 0。
-- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`，且
-      `SignerCertificate.Subject` 是预期的发布者。
-- [ ] `qcut/package.json` 中 `build.win.forceCodeSigning` 为 `true`。
+- [ ] `signtool verify /pa /v QCut*Setup*.exe` 在发布产物上退出 0。
+- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`，
+      `SignerCertificate.Subject` 是预期发布者（SignPath 颁发或
+      Azure 颁发）。
+- [ ] `qcut/package.json` 的 `build.win` 是当前路径下的正确签名配置
+      （见上文路径决策表）。
 - [ ] CI 发布任务在签名失败时立即失败（不发布到 release）。
 - [ ] 在干净 Windows VM 上首次安装时，能看到经过验证的发布者名称。
 - [ ] 维护者签名指南已发布在 `qcut/docs/setup/windows-code-signing.md`。
@@ -115,5 +145,5 @@ Authenticode 签名要求由 Windows 信任的 CA 颁发的**商用代码签名�
 
 - macOS 公证（notarization）相关改动。
 - Microsoft Store 提交（issue 提了将来可作为信誉补充，单独立 issue）。
-- 自动更新签名校验里 `electron-builder` 的 `verifyUpdateCodeSignature: true`
-  以外的额外校验。
+- 自动更新签名校验里 `electron-builder` 的
+  `verifyUpdateCodeSignature: true` 以外的额外校验。

--- a/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/PLAN.zh-CN.md
@@ -1,0 +1,119 @@
+# Windows 安装包代码签名 — 总体方案
+
+**对应 issue：** [Quriosity-agent/qcut#289](https://github.com/Quriosity-agent/qcut/issues/289)
+**分支：** `gpt-image-2`
+**创建日期：** 2026-04-25
+
+## 目标
+
+通过对 `electron-builder` 产出的 NSIS `.exe` 进行 Authenticode 签名，
+消除 QCut Windows 安装包上"发布者：未知发布者"的警告。签名工作在
+GitHub Actions 发布流水线里完成。
+
+按 `CLAUDE.md` 的优先级顺序，长期目标是：
+
+1. **可维护性** — 一次配置好，以后每次发布都能自动签，无需手工干预。
+2. **可扩展性** — 密钥放在 GitHub Actions / 云 KMS 里，不绑定到某个开发者
+   的电脑。换一个维护者也能正常发布。
+3. **性能** — 签名不应明显增加发布 CI 时间（目标：Windows 任务额外
+   不超过 60 秒）。
+4. **短期收益** — *不是*目标。我们不会用自签证书或一次性 hack 来
+   敷衍 v2026.5。
+
+## 为什么这件事需要"买 license"
+
+Authenticode 签名要求由 Windows 信任的 CA 颁发的**商用代码签名证书**。
+自签证书无法消除 SmartScreen 警告。证书选型、价格和推荐方案见
+[`CERTIFICATE-OPTIONS.zh-CN.md`](CERTIFICATE-OPTIONS.zh-CN.md)。
+
+**推荐：** Azure Trusted Signing（Public Trust 身份），约 USD 10/月，
+原因：
+
+- 云原生，不需要带 USB HSM 硬件令牌。
+- `electron-builder` 原生支持 `azureSignOptions`。
+- 身份验证比 EV 证书宽松（组织或个人均可）。
+- 这条路线在 issue #289 里就是作者推荐的。
+
+## 子任务拆分
+
+整个工作明显**超过 20 分钟**（如果算上微软审核证书的时间，可能要好几天）。
+下面的子任务按顺序排列，每个都可以独立合并、独立 review。
+
+| # | 子任务 | 操作内容 | 是否改代码 | 预估耗时 | 详细文件 |
+|---|--------|----------|-----------|----------|----------|
+| 1 | 购买证书 | 在 Azure 上申请 Trusted Signing 身份，等微软审核 | 否 | 1–7 天（看微软审核） | [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md) |
+| 2 | 改 `electron-builder` Windows 配置 | 三个 flag 翻成 true，加 `azureSignOptions` | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §1](IMPLEMENTATION.zh-CN.md#1-修改-electron-builder-windows-配置) |
+| 3 | 改本地 `dist:win*` 脚本 | 删掉 `forceCodeSigning=false` 覆盖，保留一个未签名的本地开发变体 | 是 | 20 分钟 | [IMPLEMENTATION.zh-CN.md §2](IMPLEMENTATION.zh-CN.md#2-修改本地-distwin-脚本) |
+| 4 | 改发布工作流 | 删除 `--config.win.*=false` 覆盖，注入 Azure secret | 是 | 30 分钟 | [IMPLEMENTATION.zh-CN.md §3](IMPLEMENTATION.zh-CN.md#3-修改-github-actions-发布工作流) |
+| 5 | 加构建后签名校验 | 新增脚本 + CI 步骤，签名失败立即让 release 失败 | 是 | 1 小时 | [IMPLEMENTATION.zh-CN.md §4](IMPLEMENTATION.zh-CN.md#4-增加构建后签名校验) |
+| 6 | 文档 | 维护者签名设置指南 + 发布文档更新 | 是（文档） | 45 分钟 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) |
+| 7 | 测试 | 校验脚本的单元测试 + 工作流 YAML 守门测试 | 是 | 1 小时 | [TESTING.zh-CN.md](TESTING.zh-CN.md) |
+| 8 | 发布演练 | 在干净 Windows VM 上跑 `rc` tag，确认签名 `.exe` 的发布者 | 否 | 1 小时 | [IMPLEMENTATION.zh-CN.md §5](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证) |
+
+**工程总耗时（不含等待证书审核）：约 5 小时。**
+
+## 本方案会动到的文件
+
+下面是权威清单 — 如果范围有变化，请同步更新。
+
+### 需要修改
+
+- `qcut/package.json`
+  - 第 84、86、88、89 行（`scripts` 块）
+  - 第 231–240 行（`build.win` 块）
+- `qcut/.github/workflows/release.yml`
+  - 第 96 行 "Build Electron application" 步骤
+  - 周边 env 块（约第 60–98 行）
+- `qcut/docs/release.md` — 加一段签名前置条件说明（如果文件不存在，新建）。
+
+### 需要新增
+
+- `qcut/scripts/verify-windows-signature.ts` — Bun/Node 脚本，调用
+  `signtool verify /pa /v`（或 PowerShell `Get-AuthenticodeSignature`），
+  签名异常或发布者不匹配时退出非零。
+- `qcut/scripts/__tests__/verify-windows-signature.test.ts` — Vitest
+  单元测试，mock `child_process`。
+- `qcut/scripts/__tests__/package-json-signing.test.ts` — `package.json`
+  形态守门测试。
+- `qcut/scripts/__tests__/release-workflow-signing.test.ts` — 工作流
+  YAML 守门测试。
+- `qcut/docs/setup/windows-code-signing.md` — 维护者签名设置指南
+  （Azure 租户配置、GitHub secret、本地签名）。
+- `qcut/docs/task/windows-code-signing/` — 本目录。
+
+### 故意不动
+
+- `qcut/build/icon.ico` — 图标保持原样。
+- `qcut/scripts/release.ts` — 发布编排脚本不需要知道签名细节，
+  `electron-builder` 会处理。
+
+## 风险与待定问题
+
+1. **Azure 审核时间** — 微软的身份验证最长可能要一周。子任务 1 必须
+   *先于*工程改动启动，否则会卡发布。
+2. **SmartScreen 信誉滞后** — 即使签了名，*前几个*签名版本仍可能显示
+   "不常见的应用"警告，要等信誉积累。这条要写进面向用户的发布说明。
+3. **证书续期** — 设置一个日历提醒，到期前 30 天准备续期。证书买好后
+   补到 `IMPLEMENTATION.zh-CN.md §6`。
+4. **macOS / Linux 不受影响** — 本方案故意只覆盖 Windows。macOS 已经
+   有 Apple Developer ID 签名（在 `qcut/package.json` 的 `build.mac` 里
+   能确认）。
+
+## 验收标准
+
+参考 issue 的验收标准，转化为可测的形式：
+
+- [ ] `signtool verify /pa /v QCut*Setup*.exe` 在发布产物上退出码为 0。
+- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`，且
+      `SignerCertificate.Subject` 是预期的发布者。
+- [ ] `qcut/package.json` 中 `build.win.forceCodeSigning` 为 `true`。
+- [ ] CI 发布任务在签名失败时立即失败（不发布到 release）。
+- [ ] 在干净 Windows VM 上首次安装时，能看到经过验证的发布者名称。
+- [ ] 维护者签名指南已发布在 `qcut/docs/setup/windows-code-signing.md`。
+
+## 本方案不覆盖的部分
+
+- macOS 公证（notarization）相关改动。
+- Microsoft Store 提交（issue 提了将来可作为信誉补充，单独立 issue）。
+- 自动更新签名校验里 `electron-builder` 的 `verifyUpdateCodeSignature: true`
+  以外的额外校验。

--- a/qcut/docs/task/windows-code-signing/README.md
+++ b/qcut/docs/task/windows-code-signing/README.md
@@ -1,0 +1,27 @@
+# Windows Code Signing — Task Folder
+
+Plan for [issue #289](https://github.com/Quriosity-agent/qcut/issues/289):
+sign the Windows installer so SmartScreen no longer says
+"Publisher: Unknown publisher".
+
+## Files in this folder
+
+| File | What it covers |
+|------|----------------|
+| [PLAN.md](PLAN.md) | Overview, subtask map, success criteria, risks. **Start here.** |
+| [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) | The "license" decision — vendor comparison and Azure Trusted Signing procurement steps. |
+| [IMPLEMENTATION.md](IMPLEMENTATION.md) | Per-subtask engineering detail with file paths and diffs. |
+| [TESTING.md](TESTING.md) | Unit + workflow + manual E2E tests, with target test file paths. |
+| [DOCUMENTATION.md](DOCUMENTATION.md) | Maintainer-facing docs to add/update alongside code. |
+
+## Status
+
+- [x] Plan drafted
+- [ ] Subtask 1: Certificate procurement (manual, Azure)
+- [ ] Subtask 2: `electron-builder` Windows config
+- [ ] Subtask 3: `dist:win*` npm scripts
+- [ ] Subtask 4: GitHub Actions workflow
+- [ ] Subtask 5: Post-build signature verification + script
+- [ ] Subtask 6: Maintainer documentation
+- [ ] Subtask 7: Tests
+- [ ] Subtask 8: Dry-run release on clean Windows VM

--- a/qcut/docs/task/windows-code-signing/README.md
+++ b/qcut/docs/task/windows-code-signing/README.md
@@ -1,27 +1,45 @@
 # Windows Code Signing — Task Folder
 
-Plan for [issue #289](https://github.com/Quriosity-agent/qcut/issues/289):
-sign the Windows installer so SmartScreen no longer says
-"Publisher: Unknown publisher".
+Plan for signing the QCut Windows installer with an Authenticode
+certificate. Path chosen 2026-04-25 after eliminating other options.
+
+**Decision:** Certum SimplySign Standard Code Signing (Organization, ~USD 200/year), purchased as Quriosity Pty Ltd. See [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) for why every other option was ruled out.
+
+Sister task: [`docs/task/macos-code-signing/`](../macos-code-signing/).
 
 ## Files in this folder
 
 | File | What it covers |
 |------|----------------|
 | [PLAN.md](PLAN.md) | Overview, subtask map, success criteria, risks. **Start here.** |
-| [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) | The "license" decision — vendor comparison and Azure Trusted Signing procurement steps. |
-| [IMPLEMENTATION.md](IMPLEMENTATION.md) | Per-subtask engineering detail with file paths and diffs. |
-| [TESTING.md](TESTING.md) | Unit + workflow + manual E2E tests, with target test file paths. |
+| [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) | Why Certum, why not Azure / SignPath / EV / Sectigo OV. Full vendor comparison + 2026 industry context. |
+| [IMPLEMENTATION.md](IMPLEMENTATION.md) | Per-subtask engineering detail with file paths and diffs. Includes the manual-signing tradeoff inherent to Certum SimplySign. |
+| [TESTING.md](TESTING.md) | Unit + workflow + manual VM verification. |
 | [DOCUMENTATION.md](DOCUMENTATION.md) | Maintainer-facing docs to add/update alongside code. |
+
+Chinese mirrors live alongside as `*.zh-CN.md`.
 
 ## Status
 
-- [x] Plan drafted
-- [ ] Subtask 1: Certificate procurement (manual, Azure)
-- [ ] Subtask 2: `electron-builder` Windows config
-- [ ] Subtask 3: `dist:win*` npm scripts
-- [ ] Subtask 4: GitHub Actions workflow
-- [ ] Subtask 5: Post-build signature verification + script
-- [ ] Subtask 6: Maintainer documentation
-- [ ] Subtask 7: Tests
-- [ ] Subtask 8: Dry-run release on clean Windows VM
+- [x] Plan drafted (revised 2026-04-25 — Azure/SignPath/EV ruled out, Certum chosen)
+- [ ] Subtask 1: Order Certum SimplySign Standard Code Signing (Organization, 1 year)
+- [ ] Subtask 2: Submit identity validation (Quriosity + D-U-N-S 893394655)
+- [ ] Subtask 3: Install SimplySign mobile app + desktop signing tool on Donghao's machine
+- [ ] Subtask 4: Update `electron-builder` Windows config (remove signing-disable flags)
+- [ ] Subtask 5: Update GitHub Actions release workflow (build unsigned in CI, sign locally before publish)
+- [ ] Subtask 6: Add local-signing helper script
+- [ ] Subtask 7: Add post-signing signature verifier
+- [ ] Subtask 8: Add SmartScreen-reality "first run" warning to Windows download page
+- [ ] Subtask 9: Maintainer documentation
+- [ ] Subtask 10: Tests
+- [ ] Subtask 11: Dry-run release on clean Windows VM
+
+## Context (why this folder was rewritten)
+
+The earlier draft of this folder went through three failed paths before landing on Certum:
+
+1. **SignPath Foundation (free, OSS-only)** — ruled out because QCut may close-source.
+2. **Azure Trusted Signing ($120/yr)** — ruled out because Australia is not in Microsoft's eligibility list AND Quriosity is < 3 years old.
+3. **SSL.com EV ($400+/yr)** — ruled out because Microsoft removed EV's instant-SmartScreen-reputation benefit in 2024. EV no longer worth the premium.
+
+See [CERTIFICATE-OPTIONS.md](CERTIFICATE-OPTIONS.md) for sources.

--- a/qcut/docs/task/windows-code-signing/README.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/README.zh-CN.md
@@ -1,29 +1,47 @@
 # Windows 代码签名 — 任务目录
 
-针对 [issue #289](https://github.com/Quriosity-agent/qcut/issues/289) 的方案：
-为 QCut 的 Windows 安装包加 Authenticode 签名，让 SmartScreen 不再显示
-"发布者：未知发布者"。
+为 QCut Windows 安装包做 Authenticode 签名的方案。路径于 2026-04-25
+确定（排除掉其他选项之后）。
+
+**决议：** Certum SimplySign Standard Code Signing（Organization 席位，
+约 USD 200/年），以 Quriosity Pty Ltd 名义购买。完整淘汰理由见
+[CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md)。
+
+姊妹任务：[`docs/task/macos-code-signing/`](../macos-code-signing/)。
 
 ## 本目录文件说明
 
 | 文件 | 内容 |
 |------|------|
 | [PLAN.zh-CN.md](PLAN.zh-CN.md) | 总体方案、子任务拆分、验收标准、风险。**先看这个。** |
-| [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md) | "License" 决策 — 各家证书供应商对比 + Azure Trusted Signing 采购流程。 |
-| [IMPLEMENTATION.zh-CN.md](IMPLEMENTATION.zh-CN.md) | 每个子任务的具体实现，含确切文件路径和 diff。 |
-| [TESTING.zh-CN.md](TESTING.zh-CN.md) | 单元测试 + 工作流测试 + 人工 E2E，含目标测试文件路径。 |
+| [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md) | 为什么选 Certum；为什么 Azure / SignPath / EV / Sectigo OV 都被排除。供应商对比 + 2026 行业现状。 |
+| [IMPLEMENTATION.zh-CN.md](IMPLEMENTATION.zh-CN.md) | 每个子任务的实现细节（含文件路径和 diff）。说明 Certum SimplySign 必须手动签名这一权衡。 |
+| [TESTING.zh-CN.md](TESTING.zh-CN.md) | 单元测试、工作流测试、人工 VM 验证。 |
 | [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) | 维护者文档，需随代码一起更新。 |
 
 英文原版位于同目录的 `README.md` / `PLAN.md` / 等等。
 
 ## 进度
 
-- [x] 方案已草拟
-- [ ] 子任务 1：购买证书（人工，Azure 控制台操作）
-- [ ] 子任务 2：`electron-builder` Windows 配置
-- [ ] 子任务 3：`dist:win*` npm 脚本
-- [ ] 子任务 4：GitHub Actions 工作流
-- [ ] 子任务 5：构建后签名校验脚本
-- [ ] 子任务 6：维护者文档
-- [ ] 子任务 7：测试
-- [ ] 子任务 8：在干净 Windows 虚拟机上做发布演练
+- [x] 方案已草拟（2026-04-25 修订 — 排除 Azure/SignPath/EV，定为 Certum）
+- [ ] 子任务 1：在 Certum 下单 SimplySign Standard Code Signing（Organization，1 年）
+- [ ] 子任务 2：提交身份验证材料（Quriosity + D-U-N-S 893394655）
+- [ ] 子任务 3：在 Donghao 的电脑上装 SimplySign 手机 App + 桌面签名工具
+- [ ] 子任务 4：改 `electron-builder` Windows 配置（去掉禁用签名的 flag）
+- [ ] 子任务 5：改 GitHub Actions 发布工作流（CI 出未签名包，本地签后再发布）
+- [ ] 子任务 6：加本地签名辅助脚本
+- [ ] 子任务 7：加签名后的签名校验脚本
+- [ ] 子任务 8：在 Windows 下载页加 SmartScreen 现实情况说明
+- [ ] 子任务 9：维护者文档
+- [ ] 子任务 10：测试
+- [ ] 子任务 11：在干净 Windows VM 上做发布演练
+
+## 背景（这份方案为什么改写）
+
+本目录的早期版本走过三条失败路径，才落到 Certum：
+
+1. **SignPath Foundation（免费，仅开源）** — 被排除，因为 QCut 之后可能闭源。
+2. **Azure Trusted Signing（$120/年）** — 被排除，因为澳洲不在微软资格名单里，加上 Quriosity 不够 3 年。
+3. **SSL.com EV（$400+/年）** — 被排除，因为微软在 2024 年取消了 EV 的"立即 SmartScreen 信誉"特权。EV 不再值这个溢价。
+
+来源见 [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md)。

--- a/qcut/docs/task/windows-code-signing/README.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/README.zh-CN.md
@@ -1,0 +1,29 @@
+# Windows 代码签名 — 任务目录
+
+针对 [issue #289](https://github.com/Quriosity-agent/qcut/issues/289) 的方案：
+为 QCut 的 Windows 安装包加 Authenticode 签名，让 SmartScreen 不再显示
+"发布者：未知发布者"。
+
+## 本目录文件说明
+
+| 文件 | 内容 |
+|------|------|
+| [PLAN.zh-CN.md](PLAN.zh-CN.md) | 总体方案、子任务拆分、验收标准、风险。**先看这个。** |
+| [CERTIFICATE-OPTIONS.zh-CN.md](CERTIFICATE-OPTIONS.zh-CN.md) | "License" 决策 — 各家证书供应商对比 + Azure Trusted Signing 采购流程。 |
+| [IMPLEMENTATION.zh-CN.md](IMPLEMENTATION.zh-CN.md) | 每个子任务的具体实现，含确切文件路径和 diff。 |
+| [TESTING.zh-CN.md](TESTING.zh-CN.md) | 单元测试 + 工作流测试 + 人工 E2E，含目标测试文件路径。 |
+| [DOCUMENTATION.zh-CN.md](DOCUMENTATION.zh-CN.md) | 维护者文档，需随代码一起更新。 |
+
+英文原版位于同目录的 `README.md` / `PLAN.md` / 等等。
+
+## 进度
+
+- [x] 方案已草拟
+- [ ] 子任务 1：购买证书（人工，Azure 控制台操作）
+- [ ] 子任务 2：`electron-builder` Windows 配置
+- [ ] 子任务 3：`dist:win*` npm 脚本
+- [ ] 子任务 4：GitHub Actions 工作流
+- [ ] 子任务 5：构建后签名校验脚本
+- [ ] 子任务 6：维护者文档
+- [ ] 子任务 7：测试
+- [ ] 子任务 8：在干净 Windows 虚拟机上做发布演练

--- a/qcut/docs/task/windows-code-signing/TESTING.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.md
@@ -1,0 +1,205 @@
+# Windows Code Signing — Testing
+
+Tests must cover the parts of the implementation we own (the verifier
+script, the workflow shape, the package.json shape). We deliberately do
+**not** unit-test `signtool.exe` itself or Microsoft's signing service —
+those are integration concerns covered by the dry-run release step in
+[`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification).
+
+## Test inventory
+
+| # | Type | File path | What it covers |
+|---|------|-----------|----------------|
+| 1 | Unit | `qcut/scripts/__tests__/verify-windows-signature.test.ts` | Verifier exits 0 on valid signtool output, non-zero on missing artifact, non-zero on publisher mismatch, no-op on non-Windows. |
+| 2 | Unit | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` `build.win` has `forceCodeSigning`, `verifyUpdateCodeSignature`, `signAndEditExecutable` all `true`, and includes `azureSignOptions` with all four required fields. |
+| 3 | Lint | `.github/workflows/release.yml` (validated via existing CI lint, plus a new assertion test) | Workflow's Windows build step does **not** contain `forceCodeSigning=false` and the env block exposes the seven Azure secrets. |
+| 4 | Manual / E2E | `qcut/docs/task/windows-code-signing/IMPLEMENTATION.md §5` | Signed installer launches on clean Windows VM with a verified publisher name. |
+
+## Test 1 — Verifier unit tests
+
+**Path:** `qcut/scripts/__tests__/verify-windows-signature.test.ts`
+
+**Framework:** Vitest (matches existing scripts test convention — see
+`qcut/scripts/__tests__/` if present, otherwise create alongside).
+
+### Cases
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("verify-windows-signature", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("no-ops on macOS/Linux", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const mod = await import("../verify-windows-signature");
+    // expect no throw, expect log warning
+  });
+
+  it("throws when dist-electron is empty", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    // mock fs.existsSync / readdirSync to return []
+    await expect(import("../verify-windows-signature")).rejects.toThrow(
+      /No QCut.*Setup.*\.exe found/,
+    );
+  });
+
+  it("throws when signtool exits non-zero", async () => {
+    // mock execFileSync to throw
+    Object.defineProperty(process, "platform", { value: "win32" });
+    await expect(import("../verify-windows-signature")).rejects.toThrow();
+  });
+
+  it("throws when expected publisher missing from signtool output", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    // mock execFileSync to return output without publisher
+    await expect(import("../verify-windows-signature")).rejects.toThrow(
+      /unexpected publisher/i,
+    );
+  });
+
+  it("succeeds on signed artifact with matching publisher", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    // mock execFileSync to return output containing "Quriosity Pty Ltd"
+    await expect(import("../verify-windows-signature")).resolves.not.toThrow();
+  });
+});
+```
+
+> **Note:** because the verifier runs at module top-level (matching
+> existing `verify-packaged-*.ts` style), the script may need a tiny
+> refactor to expose a `main()` function — do that as part of subtask 5.
+> Keeps the script ergonomic from the CLI *and* testable.
+
+### How to run
+
+```bash
+cd qcut && bun run test scripts/__tests__/verify-windows-signature.test.ts
+```
+
+## Test 2 — `package.json` shape
+
+**Path:** `qcut/scripts/__tests__/package-json-signing.test.ts`
+
+This is a guardrail test — cheap to run, prevents accidental regressions
+(e.g. someone re-adding `forceCodeSigning: false` during a merge).
+
+```ts
+import { describe, it, expect } from "vitest";
+import pkg from "../../package.json";
+
+describe("package.json Windows signing config", () => {
+  it("has all signing flags enabled", () => {
+    expect(pkg.build.win.forceCodeSigning).toBe(true);
+    expect(pkg.build.win.verifyUpdateCodeSignature).toBe(true);
+    expect(pkg.build.win.signAndEditExecutable).toBe(true);
+  });
+
+  it("has azureSignOptions with all four required fields", () => {
+    const opts = pkg.build.win.azureSignOptions;
+    expect(opts).toBeDefined();
+    expect(opts.publisherName).toBeTruthy();
+    expect(opts.endpoint).toBeTruthy();
+    expect(opts.certificateProfileName).toBeTruthy();
+    expect(opts.codeSigningAccountName).toBeTruthy();
+  });
+
+  it("dist:win:release script does not disable signing", () => {
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(
+      /forceCodeSigning=false/,
+    );
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(
+      /verifyUpdateCodeSignature=false/,
+    );
+  });
+});
+```
+
+### How to run
+
+Same Vitest invocation as Test 1.
+
+## Test 3 — Workflow YAML guardrail
+
+**Path:** `qcut/scripts/__tests__/release-workflow-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const workflowPath = join(
+  import.meta.dir,
+  "..", "..", "..", ".github", "workflows", "release.yml",
+);
+const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
+
+describe("release.yml Windows job", () => {
+  const winJob = wf.jobs["build-windows"];
+
+  it("Build Electron application step does not disable signing", () => {
+    const step = winJob.steps.find(
+      (s: any) => s.name === "Build Electron application",
+    );
+    expect(step.run).not.toMatch(/forceCodeSigning=false/);
+    expect(step.run).not.toMatch(/verifyUpdateCodeSignature=false/);
+  });
+
+  it("Build Electron application step exposes Azure secrets", () => {
+    const step = winJob.steps.find(
+      (s: any) => s.name === "Build Electron application",
+    );
+    for (const k of [
+      "AZURE_TENANT_ID",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_TRUSTED_SIGNING_ENDPOINT",
+      "AZURE_TRUSTED_SIGNING_ACCOUNT",
+      "AZURE_CERTIFICATE_PROFILE",
+      "WINDOWS_PUBLISHER_NAME",
+    ]) {
+      expect(step.env[k]).toBeDefined();
+    }
+  });
+
+  it("has a 'Verify Windows signature' step after build", () => {
+    const names = winJob.steps.map((s: any) => s.name);
+    const buildIdx = names.indexOf("Build Electron application");
+    const verifyIdx = names.indexOf("Verify Windows signature");
+    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  });
+});
+```
+
+> Add `js-yaml` and `@types/js-yaml` as dev dependencies if not already
+> present; check with `cd qcut && bun pm ls js-yaml`.
+
+### How to run
+
+Same Vitest invocation. This test runs on every dev machine and CI — it
+does **not** require Windows.
+
+## Test 4 — Manual E2E (clean VM)
+
+Documented in [`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification).
+Capture the result in the PR description as a checklist:
+
+- [ ] `Publisher: Quriosity Pty Ltd` (or actual publisher) shown in NSIS.
+- [ ] `Get-AuthenticodeSignature` → `Status: Valid`.
+- [ ] `signtool verify /pa /v` → exit 0.
+- [ ] App launches and reaches the editor route after install.
+
+## What we do not test
+
+- **`signtool.exe` correctness** — we trust Microsoft's signing tool.
+- **Azure Trusted Signing service availability** — out of our control.
+- **SmartScreen warning timing** — depends on Microsoft reputation
+  rollup, not deterministic. Track via release feedback, not unit tests.
+- **Cert chain expiration** — `verifyUpdateCodeSignature: true` will
+  cause future updates to fail loudly if the chain breaks; we prefer
+  loud production failure to brittle CI tests of cert validity windows.

--- a/qcut/docs/task/windows-code-signing/TESTING.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.md
@@ -8,6 +8,16 @@ service, or Microsoft's SmartScreen — those are integration concerns
 covered by the dry-run release in
 [`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-dry-run-release-on-clean-windows-vm).
 
+> ⚠️ **Pair these tests with the IMPLEMENTATION.md changes — do not land
+> them independently.** Today `qcut/package.json` ships with
+> `build.win.verifyUpdateCodeSignature: false` and the `dist:win:*` scripts
+> pass `--config.win.verifyUpdateCodeSignature=false`, and the `sign:win` /
+> `verify:win-signature` scripts do not yet exist. The assertions below
+> describe the **post-pivot end state** that the IMPLEMENTATION.md PR flips
+> on. If you add these test files in a separate PR before the package.json
+> and scripts are updated, Tests 3 and 4 will fail by design and block
+> unrelated CI runs.
+
 ## Test inventory
 
 | # | Type | File path | What it covers |

--- a/qcut/docs/task/windows-code-signing/TESTING.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.md
@@ -1,35 +1,30 @@
 # Windows Code Signing — Testing
 
-Tests must cover the parts of the implementation we own (the verifier
-script, the workflow shape, the `package.json` shape). We deliberately do
-**not** unit-test `signtool.exe` itself, SignPath's service, or
-Microsoft's signing service — those are integration concerns covered by
-the dry-run release step in
-[`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification-shared).
+Tests cover the parts we own — the verifier script, the local signing
+script, the `package.json` shape, and the `release.yml` shape.
 
-> **Path-aware:** Tests 2 and 3 below validate the `package.json` and
-> `release.yml` shapes. Their *expected* shape differs between Path A
-> (SignPath) and Path B (Azure). Once Subtask 1 lands, write the tests
-> against the shape of the chosen path. The skeletons below show the
-> Path B variants because they were authored first; Path A variants
-> assert the inverse (e.g. `azureSignOptions` should NOT exist; the
-> SignPath GitHub Action step SHOULD exist).
+We deliberately do **not** unit-test `signtool.exe`, Certum's SimplySign
+service, or Microsoft's SmartScreen — those are integration concerns
+covered by the dry-run release in
+[`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-dry-run-release-on-clean-windows-vm).
 
 ## Test inventory
 
 | # | Type | File path | What it covers |
 |---|------|-----------|----------------|
 | 1 | Unit | `qcut/scripts/__tests__/verify-windows-signature.test.ts` | Verifier exits 0 on valid signtool output, non-zero on missing artifact, non-zero on publisher mismatch, no-op on non-Windows. |
-| 2 | Unit | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` `build.win` has `forceCodeSigning`, `verifyUpdateCodeSignature`, `signAndEditExecutable` all `true`, and includes `azureSignOptions` with all four required fields. |
-| 3 | Lint | `.github/workflows/release.yml` (validated via existing CI lint, plus a new assertion test) | Workflow's Windows build step does **not** contain `forceCodeSigning=false` and the env block exposes the seven Azure secrets. |
-| 4 | Manual / E2E | `qcut/docs/task/windows-code-signing/IMPLEMENTATION.md §5` | Signed installer launches on clean Windows VM with a verified publisher name. |
+| 2 | Unit | `qcut/scripts/__tests__/sign-windows-release.test.ts` | Sign script: throws when `QCUT_WIN_CERT_THUMBPRINT` not set, throws when no installer found, calls `signtool sign` with correct args, regenerates `latest.yml` with new SHA512. |
+| 3 | Unit | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` `build.win` has `verifyUpdateCodeSignature: true`, `forceCodeSigning: false`, no `azureSignOptions`, and `dist:win:release` script does not contain `forceCodeSigning=false` overrides. |
+| 4 | Workflow guardrail | `qcut/scripts/__tests__/release-workflow-signing.test.ts` | `release.yml` Windows job: build step does not contain `forceCodeSigning=false`; artifact name is `windows-build-unsigned`; the aggregated release-publish step does NOT auto-attach `windows-build-unsigned` `.exe` to the Release. |
+| 5 | Manual / E2E | [`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-dry-run-release-on-clean-windows-vm) | Clean Windows VM: signed installer shows "Verified publisher: Quriosity Pty Ltd" on UAC. |
 
 ## Test 1 — Verifier unit tests
 
 **Path:** `qcut/scripts/__tests__/verify-windows-signature.test.ts`
 
-**Framework:** Vitest (matches existing scripts test convention — see
-`qcut/scripts/__tests__/` if present, otherwise create alongside).
+**Framework:** Vitest. Same pattern as existing
+`qcut/scripts/__tests__/check-boundaries.test.ts`. Mock
+`child_process.execFileSync` and `fs`.
 
 ### Cases
 
@@ -42,47 +37,40 @@ describe("verify-windows-signature", () => {
     vi.unstubAllEnvs();
   });
 
-  it("no-ops on macOS/Linux", async () => {
-    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+  it("no-ops on non-Windows hosts", async () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
-    const mod = await import("../verify-windows-signature");
-    // expect no throw, expect log warning
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    await import("../verify-windows-signature");
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("throws when dist-electron is empty", async () => {
+  it("throws when dist-electron has no QCut*Setup*.exe", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
-    // mock fs.existsSync / readdirSync to return []
-    await expect(import("../verify-windows-signature")).rejects.toThrow(
-      /No QCut.*Setup.*\.exe found/,
-    );
+    // mock fs.readdirSync to return []
+    await expect(import("../verify-windows-signature")).rejects.toThrow(/No QCut.*Setup.*\.exe found/);
   });
 
   it("throws when signtool exits non-zero", async () => {
-    // mock execFileSync to throw
     Object.defineProperty(process, "platform", { value: "win32" });
+    // mock execFileSync to throw
     await expect(import("../verify-windows-signature")).rejects.toThrow();
   });
 
   it("throws when expected publisher missing from signtool output", async () => {
     vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
-    // mock execFileSync to return output without publisher
-    await expect(import("../verify-windows-signature")).rejects.toThrow(
-      /unexpected publisher/i,
-    );
+    Object.defineProperty(process, "platform", { value: "win32" });
+    // mock execFileSync to return output without "Quriosity Pty Ltd"
+    await expect(import("../verify-windows-signature")).rejects.toThrow(/unexpected publisher/i);
   });
 
   it("succeeds on signed artifact with matching publisher", async () => {
     vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    Object.defineProperty(process, "platform", { value: "win32" });
     // mock execFileSync to return output containing "Quriosity Pty Ltd"
     await expect(import("../verify-windows-signature")).resolves.not.toThrow();
   });
 });
 ```
-
-> **Note:** because the verifier runs at module top-level (matching
-> existing `verify-packaged-*.ts` style), the script may need a tiny
-> refactor to expose a `main()` function — do that as part of subtask 5.
-> Keeps the script ergonomic from the CLI *and* testable.
 
 ### How to run
 
@@ -90,49 +78,77 @@ describe("verify-windows-signature", () => {
 cd qcut && bun run test scripts/__tests__/verify-windows-signature.test.ts
 ```
 
-## Test 2 — `package.json` shape
+## Test 2 — Sign script unit tests
+
+**Path:** `qcut/scripts/__tests__/sign-windows-release.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("sign-windows-release", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("throws when QCUT_WIN_CERT_THUMBPRINT not set", async () => {
+    await expect(import("../sign-windows-release")).rejects.toThrow(/QCUT_WIN_CERT_THUMBPRINT/);
+  });
+
+  it("throws when no QCut*Setup*.exe is present", async () => {
+    vi.stubEnv("QCUT_WIN_CERT_THUMBPRINT", "ABC123");
+    // mock fs.readdirSync to return []
+    await expect(import("../sign-windows-release")).rejects.toThrow(/No QCut.*Setup.*\.exe found/);
+  });
+
+  it("calls signtool sign with timestamp authority and SHA-256 algorithms", async () => {
+    vi.stubEnv("QCUT_WIN_CERT_THUMBPRINT", "ABC123");
+    // mock fs and child_process so signtool is called
+    // assert execFileSync called with ["sign", "/tr", ..., "/td", "sha256", "/fd", "sha256", "/sha1", "ABC123", ...]
+    expect(/* recorded args */).toContain("sha256");
+  });
+
+  it("regenerates latest.yml SHA512 after signing", async () => {
+    // mock latest.yml present, signtool succeeds
+    // assert writeFileSync called with new sha512
+  });
+});
+```
+
+## Test 3 — `package.json` shape guardrail
 
 **Path:** `qcut/scripts/__tests__/package-json-signing.test.ts`
-
-This is a guardrail test — cheap to run, prevents accidental regressions
-(e.g. someone re-adding `forceCodeSigning: false` during a merge).
 
 ```ts
 import { describe, it, expect } from "vitest";
 import pkg from "../../package.json";
 
 describe("package.json Windows signing config", () => {
-  it("has all signing flags enabled", () => {
-    expect(pkg.build.win.forceCodeSigning).toBe(true);
+  it("verifyUpdateCodeSignature is true", () => {
     expect(pkg.build.win.verifyUpdateCodeSignature).toBe(true);
-    expect(pkg.build.win.signAndEditExecutable).toBe(true);
   });
 
-  it("has azureSignOptions with all four required fields", () => {
-    const opts = pkg.build.win.azureSignOptions;
-    expect(opts).toBeDefined();
-    expect(opts.publisherName).toBeTruthy();
-    expect(opts.endpoint).toBeTruthy();
-    expect(opts.certificateProfileName).toBeTruthy();
-    expect(opts.codeSigningAccountName).toBeTruthy();
+  it("forceCodeSigning is false (we sign manually after build)", () => {
+    expect(pkg.build.win.forceCodeSigning).toBe(false);
   });
 
-  it("dist:win:release script does not disable signing", () => {
-    expect(pkg.scripts["dist:win:release"]).not.toMatch(
-      /forceCodeSigning=false/,
-    );
-    expect(pkg.scripts["dist:win:release"]).not.toMatch(
-      /verifyUpdateCodeSignature=false/,
-    );
+  it("does not configure azureSignOptions (Azure path ruled out)", () => {
+    expect((pkg.build.win as any).azureSignOptions).toBeUndefined();
+  });
+
+  it("dist:win:release script does not have signing-disable overrides (those are in package.json now)", () => {
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(/forceCodeSigning=false/);
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(/verifyUpdateCodeSignature=false/);
+  });
+
+  it("scripts include sign:win and verify:win-signature entries", () => {
+    expect(pkg.scripts["sign:win"]).toBeDefined();
+    expect(pkg.scripts["verify:win-signature"]).toBeDefined();
   });
 });
 ```
 
-### How to run
-
-Same Vitest invocation as Test 1.
-
-## Test 3 — Workflow YAML guardrail
+## Test 4 — Workflow YAML guardrail
 
 **Path:** `qcut/scripts/__tests__/release-workflow-signing.test.ts`
 
@@ -142,73 +158,53 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import yaml from "js-yaml";
 
-const workflowPath = join(
-  import.meta.dir,
-  "..", "..", "..", ".github", "workflows", "release.yml",
-);
+const workflowPath = join(import.meta.dir, "..", "..", "..", ".github", "workflows", "release.yml");
 const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
 
-describe("release.yml Windows job", () => {
+describe("release.yml Windows signing flow", () => {
   const winJob = wf.jobs["build-windows"];
 
-  it("Build Electron application step does not disable signing", () => {
-    const step = winJob.steps.find(
-      (s: any) => s.name === "Build Electron application",
-    );
+  it("Build step does not disable signing in CLI flags", () => {
+    const step = winJob.steps.find((s: any) => /Build Electron application/.test(s.name));
     expect(step.run).not.toMatch(/forceCodeSigning=false/);
     expect(step.run).not.toMatch(/verifyUpdateCodeSignature=false/);
   });
 
-  it("Build Electron application step exposes Azure secrets", () => {
-    const step = winJob.steps.find(
-      (s: any) => s.name === "Build Electron application",
-    );
-    for (const k of [
-      "AZURE_TENANT_ID",
-      "AZURE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_TRUSTED_SIGNING_ENDPOINT",
-      "AZURE_TRUSTED_SIGNING_ACCOUNT",
-      "AZURE_CERTIFICATE_PROFILE",
-      "WINDOWS_PUBLISHER_NAME",
-    ]) {
-      expect(step.env[k]).toBeDefined();
-    }
+  it("Artifact upload uses windows-build-unsigned name", () => {
+    const upload = winJob.steps.find((s: any) => s.uses?.startsWith("actions/upload-artifact"));
+    expect(upload.with.name).toBe("windows-build-unsigned");
   });
 
-  it("has a 'Verify Windows signature' step after build", () => {
-    const names = winJob.steps.map((s: any) => s.name);
-    const buildIdx = names.indexOf("Build Electron application");
-    const verifyIdx = names.indexOf("Verify Windows signature");
-    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  it("Release publish job does not auto-attach unsigned Windows .exe to Release", () => {
+    // Inspect wf.jobs.release files spec
+    const releaseJob = wf.jobs["release"];
+    const publishStep = releaseJob.steps.find((s: any) => s.uses?.includes("softprops/action-gh-release") || /release/i.test(s.name ?? ""));
+    if (publishStep && publishStep.with?.files) {
+      // The pattern matching unsigned Windows exes should not be present.
+      // Maintainer manually uploads signed .exe per release operator runbook.
+      expect(publishStep.with.files).not.toMatch(/windows-build-unsigned/);
+    }
   });
 });
 ```
 
-> Add `js-yaml` and `@types/js-yaml` as dev dependencies if not already
-> present; check with `cd qcut && bun pm ls js-yaml`.
+> If `js-yaml` and `@types/js-yaml` are not yet in dev dependencies, add them: `bun add -d js-yaml @types/js-yaml`.
 
-### How to run
+## Test 5 — Manual VM E2E
 
-Same Vitest invocation. This test runs on every dev machine and CI — it
-does **not** require Windows.
+See [`IMPLEMENTATION.md §6`](IMPLEMENTATION.md#6-dry-run-release-on-clean-windows-vm). Capture the result in PR description as a checklist:
 
-## Test 4 — Manual E2E (clean VM)
-
-Documented in [`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification).
-Capture the result in the PR description as a checklist:
-
-- [ ] `Publisher: Quriosity Pty Ltd` (or actual publisher) shown in NSIS.
-- [ ] `Get-AuthenticodeSignature` → `Status: Valid`.
-- [ ] `signtool verify /pa /v` → exit 0.
-- [ ] App launches and reaches the editor route after install.
+- [ ] CI built `windows-build-unsigned` successfully.
+- [ ] `bun run sign:win` succeeded with phone approval.
+- [ ] `bun run verify:win-signature` exits 0.
+- [ ] Manual upload to GitHub Release succeeded.
+- [ ] On clean VM: SmartScreen "More info" panel shows "Quriosity Pty Ltd".
+- [ ] On clean VM: UAC dialog is **blue** with "Verified publisher: Quriosity Pty Ltd".
+- [ ] `Get-AuthenticodeSignature` reports `Status: Valid`.
 
 ## What we do not test
 
-- **`signtool.exe` correctness** — we trust Microsoft's signing tool.
-- **Azure Trusted Signing service availability** — out of our control.
-- **SmartScreen warning timing** — depends on Microsoft reputation
-  rollup, not deterministic. Track via release feedback, not unit tests.
-- **Cert chain expiration** — `verifyUpdateCodeSignature: true` will
-  cause future updates to fail loudly if the chain breaks; we prefer
-  loud production failure to brittle CI tests of cert validity windows.
+- **`signtool.exe` correctness** — Microsoft-supplied tool.
+- **Certum SimplySign service availability** — vendor-side outages out of our control. Manual signing fails loudly with `signtool` errors when SimplySign is down; do not retry blindly.
+- **SmartScreen reputation timing** — SmartScreen is non-deterministic and depends on Microsoft reputation aggregation. Track via release feedback.
+- **Cert chain expiration** — `verifyUpdateCodeSignature: true` will cause future updates to fail loudly if the chain breaks; we prefer loud production failure to brittle CI tests of cert validity windows.

--- a/qcut/docs/task/windows-code-signing/TESTING.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.md
@@ -1,10 +1,19 @@
 # Windows Code Signing — Testing
 
 Tests must cover the parts of the implementation we own (the verifier
-script, the workflow shape, the package.json shape). We deliberately do
-**not** unit-test `signtool.exe` itself or Microsoft's signing service —
-those are integration concerns covered by the dry-run release step in
-[`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification).
+script, the workflow shape, the `package.json` shape). We deliberately do
+**not** unit-test `signtool.exe` itself, SignPath's service, or
+Microsoft's signing service — those are integration concerns covered by
+the dry-run release step in
+[`IMPLEMENTATION.md §5`](IMPLEMENTATION.md#5-dry-run-release--manual-verification-shared).
+
+> **Path-aware:** Tests 2 and 3 below validate the `package.json` and
+> `release.yml` shapes. Their *expected* shape differs between Path A
+> (SignPath) and Path B (Azure). Once Subtask 1 lands, write the tests
+> against the shape of the chosen path. The skeletons below show the
+> Path B variants because they were authored first; Path A variants
+> assert the inverse (e.g. `azureSignOptions` should NOT exist; the
+> SignPath GitHub Action step SHOULD exist).
 
 ## Test inventory
 

--- a/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
@@ -1,0 +1,204 @@
+# Windows 代码签名 — 测试方案
+
+测试只覆盖**我们自己拥有的**部分（校验脚本、工作流形态、`package.json`
+形态）。我们故意**不**单元测试 `signtool.exe` 本身，也不测试 Microsoft
+的签名服务 — 这些是集成层面的事，由
+[`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证)
+里的发布演练步骤覆盖。
+
+## 测试清单
+
+| # | 类型 | 文件路径 | 覆盖内容 |
+|---|------|----------|----------|
+| 1 | 单元 | `qcut/scripts/__tests__/verify-windows-signature.test.ts` | signtool 输出正常时退出 0；artifact 缺失时退出非零；发布者不匹配时退出非零；非 Windows 上 no-op。 |
+| 2 | 单元 | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` 的 `build.win` 里 `forceCodeSigning`、`verifyUpdateCodeSignature`、`signAndEditExecutable` 都为 `true`，`azureSignOptions` 四个必需字段都存在。 |
+| 3 | 守门 | `qcut/scripts/__tests__/release-workflow-signing.test.ts` | 工作流 Windows 构建步骤里**没有** `forceCodeSigning=false`，env 里暴露了七个 Azure secret。 |
+| 4 | 人工 / E2E | [`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证) | 干净 Windows VM 上签名安装包能正常启动并显示已验证发布者。 |
+
+## 测试 1 — 校验脚本单元测试
+
+**路径：** `qcut/scripts/__tests__/verify-windows-signature.test.ts`
+
+**框架：** Vitest（与现有 `qcut/scripts/__tests__/check-boundaries.test.ts`
+所用框架一致 — 已确认存在）。
+
+### 用例
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("verify-windows-signature", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("在 macOS/Linux 上 no-op", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const mod = await import("../verify-windows-signature");
+    // 不抛异常，应该有 warn 日志
+  });
+
+  it("dist-electron 为空时抛错", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    // mock fs.existsSync / readdirSync 返回 []
+    await expect(import("../verify-windows-signature")).rejects.toThrow(
+      /找不到 QCut.*Setup.*\.exe/,
+    );
+  });
+
+  it("signtool 退出非零时抛错", async () => {
+    // mock execFileSync 抛异常
+    Object.defineProperty(process, "platform", { value: "win32" });
+    await expect(import("../verify-windows-signature")).rejects.toThrow();
+  });
+
+  it("signtool 输出里没有期望发布者时抛错", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    // mock execFileSync 返回不包含发布者的内容
+    await expect(import("../verify-windows-signature")).rejects.toThrow(
+      /发布者不一致/,
+    );
+  });
+
+  it("签名 + 发布者匹配时通过", async () => {
+    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    // mock execFileSync 返回包含 "Quriosity Pty Ltd" 的内容
+    await expect(import("../verify-windows-signature")).resolves.not.toThrow();
+  });
+});
+```
+
+> **注意：** 因为校验脚本会在模块顶层立刻执行（与现有 `verify-packaged-*.ts`
+> 的风格一致），脚本可能要稍作重构，把主逻辑包在 `main()` 函数里 — 在
+> 子任务 5 里一并处理。这样 CLI 用得舒服，单测也好写。
+
+### 运行方式
+
+```bash
+cd qcut && bun run test scripts/__tests__/verify-windows-signature.test.ts
+```
+
+## 测试 2 — `package.json` 形态守门
+
+**路径：** `qcut/scripts/__tests__/package-json-signing.test.ts`
+
+这是一个守门测试 — 跑得很快，能防止以后合并代码时不小心把
+`forceCodeSigning: false` 又加回去。
+
+```ts
+import { describe, it, expect } from "vitest";
+import pkg from "../../package.json";
+
+describe("package.json 中的 Windows 签名配置", () => {
+  it("所有签名 flag 都打开了", () => {
+    expect(pkg.build.win.forceCodeSigning).toBe(true);
+    expect(pkg.build.win.verifyUpdateCodeSignature).toBe(true);
+    expect(pkg.build.win.signAndEditExecutable).toBe(true);
+  });
+
+  it("azureSignOptions 四个必需字段都存在", () => {
+    const opts = pkg.build.win.azureSignOptions;
+    expect(opts).toBeDefined();
+    expect(opts.publisherName).toBeTruthy();
+    expect(opts.endpoint).toBeTruthy();
+    expect(opts.certificateProfileName).toBeTruthy();
+    expect(opts.codeSigningAccountName).toBeTruthy();
+  });
+
+  it("dist:win:release 脚本里没有禁用签名的参数", () => {
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(
+      /forceCodeSigning=false/,
+    );
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(
+      /verifyUpdateCodeSignature=false/,
+    );
+  });
+});
+```
+
+### 运行方式
+
+跟测试 1 一样的 Vitest 命令。
+
+## 测试 3 — 工作流 YAML 守门
+
+**路径：** `qcut/scripts/__tests__/release-workflow-signing.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const workflowPath = join(
+  import.meta.dir,
+  "..", "..", "..", ".github", "workflows", "release.yml",
+);
+const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
+
+describe("release.yml Windows 任务", () => {
+  const winJob = wf.jobs["build-windows"];
+
+  it("'Build Electron application' 步骤没有禁用签名", () => {
+    const step = winJob.steps.find(
+      (s: any) => s.name === "Build Electron application",
+    );
+    expect(step.run).not.toMatch(/forceCodeSigning=false/);
+    expect(step.run).not.toMatch(/verifyUpdateCodeSignature=false/);
+  });
+
+  it("'Build Electron application' 步骤暴露了 Azure secret", () => {
+    const step = winJob.steps.find(
+      (s: any) => s.name === "Build Electron application",
+    );
+    for (const k of [
+      "AZURE_TENANT_ID",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_TRUSTED_SIGNING_ENDPOINT",
+      "AZURE_TRUSTED_SIGNING_ACCOUNT",
+      "AZURE_CERTIFICATE_PROFILE",
+      "WINDOWS_PUBLISHER_NAME",
+    ]) {
+      expect(step.env[k]).toBeDefined();
+    }
+  });
+
+  it("Build 之后存在 'Verify Windows signature' 步骤", () => {
+    const names = winJob.steps.map((s: any) => s.name);
+    const buildIdx = names.indexOf("Build Electron application");
+    const verifyIdx = names.indexOf("Verify Windows signature");
+    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  });
+});
+```
+
+> 如果还没装 `js-yaml` 和 `@types/js-yaml`，需要把它们加到 dev
+> dependency；用 `cd qcut && bun pm ls js-yaml` 检查一下。
+
+### 运行方式
+
+跟前面一样的 Vitest 命令。这个测试在所有开发机和 CI 上都能跑，
+**不需要** Windows。
+
+## 测试 4 — 人工 E2E（干净 VM）
+
+详细步骤见 [`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证)。
+在 PR 描述里把结果作为 checklist 留底：
+
+- [ ] NSIS 安装界面显示 `发布者：Quriosity Pty Ltd`（或实际发布者）。
+- [ ] `Get-AuthenticodeSignature` → `Status: Valid`。
+- [ ] `signtool verify /pa /v` → 退出 0。
+- [ ] 安装后程序能进到编辑器路由。
+
+## 我们故意不测的部分
+
+- **`signtool.exe` 自身的正确性** — 信任微软的签名工具。
+- **Azure Trusted Signing 服务可用性** — 不在我们控制范围内。
+- **SmartScreen 警告时机** — 取决于微软的信誉聚合，不是确定性的。
+  通过发布反馈收集，不通过单测验证。
+- **证书链过期** — `verifyUpdateCodeSignature: true` 会在签名链将来
+  失效时让线上更新明确报错；我们更愿意让生产环境直接报错，也不愿意
+  写脆弱的有效期 CI 测试。

--- a/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
@@ -1,10 +1,17 @@
 # Windows 代码签名 — 测试方案
 
 测试只覆盖**我们自己拥有的**部分（校验脚本、工作流形态、`package.json`
-形态）。我们故意**不**单元测试 `signtool.exe` 本身，也不测试 Microsoft
-的签名服务 — 这些是集成层面的事，由
-[`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证)
+形态）。我们故意**不**单元测试 `signtool.exe` 本身，也不测试 SignPath
+或 Microsoft 的签名服务 — 这些是集成层面的事，由
+[`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证共享)
 里的发布演练步骤覆盖。
+
+> **路径相关：** 下面的测试 2 和测试 3 校验 `package.json` 和
+> `release.yml` 的形态。Path A（SignPath）与 Path B（Azure）的
+> *期望*形态不同。子任务 1 落地后，按所选路径写测试。下面骨架是
+> Path B 版本（因为是先写的）；Path A 版本断言相反的内容（例如
+> `azureSignOptions` **不应**存在；SignPath GitHub Action 步骤
+> **应**存在）。
 
 ## 测试清单
 

--- a/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
+++ b/qcut/docs/task/windows-code-signing/TESTING.zh-CN.md
@@ -1,33 +1,28 @@
 # Windows 代码签名 — 测试方案
 
-测试只覆盖**我们自己拥有的**部分（校验脚本、工作流形态、`package.json`
-形态）。我们故意**不**单元测试 `signtool.exe` 本身，也不测试 SignPath
-或 Microsoft 的签名服务 — 这些是集成层面的事，由
-[`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证共享)
-里的发布演练步骤覆盖。
+测试只覆盖**我们自己拥有的**部分 — 校验脚本、本地签名脚本、
+`package.json` 形态、`release.yml` 形态。
 
-> **路径相关：** 下面的测试 2 和测试 3 校验 `package.json` 和
-> `release.yml` 的形态。Path A（SignPath）与 Path B（Azure）的
-> *期望*形态不同。子任务 1 落地后，按所选路径写测试。下面骨架是
-> Path B 版本（因为是先写的）；Path A 版本断言相反的内容（例如
-> `azureSignOptions` **不应**存在；SignPath GitHub Action 步骤
-> **应**存在）。
+我们故意**不**单元测试 `signtool.exe`、Certum SimplySign 服务、或
+微软 SmartScreen — 这些是集成层面的事，由
+[`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-在干净-windows-vm-上做发布演练)
+里的发布演练覆盖。
 
 ## 测试清单
 
 | # | 类型 | 文件路径 | 覆盖内容 |
 |---|------|----------|----------|
-| 1 | 单元 | `qcut/scripts/__tests__/verify-windows-signature.test.ts` | signtool 输出正常时退出 0；artifact 缺失时退出非零；发布者不匹配时退出非零；非 Windows 上 no-op。 |
-| 2 | 单元 | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` 的 `build.win` 里 `forceCodeSigning`、`verifyUpdateCodeSignature`、`signAndEditExecutable` 都为 `true`，`azureSignOptions` 四个必需字段都存在。 |
-| 3 | 守门 | `qcut/scripts/__tests__/release-workflow-signing.test.ts` | 工作流 Windows 构建步骤里**没有** `forceCodeSigning=false`，env 里暴露了七个 Azure secret。 |
-| 4 | 人工 / E2E | [`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证) | 干净 Windows VM 上签名安装包能正常启动并显示已验证发布者。 |
+| 1 | 单元 | `qcut/scripts/__tests__/verify-windows-signature.test.ts` | 校验脚本：signtool 正常输出时退出 0；artifact 缺失时退出非零；发布者不匹配时退出非零；非 Windows 上 no-op。 |
+| 2 | 单元 | `qcut/scripts/__tests__/sign-windows-release.test.ts` | 签名脚本：`QCUT_WIN_CERT_THUMBPRINT` 未设时抛错；找不到安装包时抛错；调用 `signtool sign` 时参数正确；签后重新生成 `latest.yml` 的 SHA512。 |
+| 3 | 单元 | `qcut/scripts/__tests__/package-json-signing.test.ts` | `qcut/package.json` 的 `build.win` 有 `verifyUpdateCodeSignature: true`、`forceCodeSigning: false`、没有 `azureSignOptions`，并且 `dist:win:release` 脚本里没有 `forceCodeSigning=false` 覆盖。 |
+| 4 | 守门 | `qcut/scripts/__tests__/release-workflow-signing.test.ts` | `release.yml` Windows 任务：build 步骤命令行**没有** `forceCodeSigning=false`；artifact 名是 `windows-build-unsigned`；聚合的 release-publish 步骤**不**自动把 `windows-build-unsigned` 的 `.exe` 挂到 Release。 |
+| 5 | 人工 / E2E | [`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-在干净-windows-vm-上做发布演练) | 干净 Windows VM：签名安装包 UAC 显示 "Verified publisher: Quriosity Pty Ltd"。 |
 
 ## 测试 1 — 校验脚本单元测试
 
 **路径：** `qcut/scripts/__tests__/verify-windows-signature.test.ts`
 
-**框架：** Vitest（与现有 `qcut/scripts/__tests__/check-boundaries.test.ts`
-所用框架一致 — 已确认存在）。
+**框架：** Vitest，跟现有 `qcut/scripts/__tests__/check-boundaries.test.ts` 一致。Mock `child_process.execFileSync` 和 `fs`。
 
 ### 用例
 
@@ -40,46 +35,40 @@ describe("verify-windows-signature", () => {
     vi.unstubAllEnvs();
   });
 
-  it("在 macOS/Linux 上 no-op", async () => {
-    vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+  it("非 Windows 主机上 no-op", async () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
-    const mod = await import("../verify-windows-signature");
-    // 不抛异常，应该有 warn 日志
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    await import("../verify-windows-signature");
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("dist-electron 为空时抛错", async () => {
+  it("dist-electron 没有 QCut*Setup*.exe 时抛错", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
-    // mock fs.existsSync / readdirSync 返回 []
-    await expect(import("../verify-windows-signature")).rejects.toThrow(
-      /找不到 QCut.*Setup.*\.exe/,
-    );
+    // mock fs.readdirSync 返回 []
+    await expect(import("../verify-windows-signature")).rejects.toThrow(/找不到 QCut.*Setup.*\.exe/);
   });
 
   it("signtool 退出非零时抛错", async () => {
-    // mock execFileSync 抛异常
     Object.defineProperty(process, "platform", { value: "win32" });
+    // mock execFileSync 抛
     await expect(import("../verify-windows-signature")).rejects.toThrow();
   });
 
   it("signtool 输出里没有期望发布者时抛错", async () => {
     vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
-    // mock execFileSync 返回不包含发布者的内容
-    await expect(import("../verify-windows-signature")).rejects.toThrow(
-      /发布者不一致/,
-    );
+    Object.defineProperty(process, "platform", { value: "win32" });
+    // mock execFileSync 返回不含 "Quriosity Pty Ltd" 的内容
+    await expect(import("../verify-windows-signature")).rejects.toThrow(/发布者不匹配/);
   });
 
   it("签名 + 发布者匹配时通过", async () => {
     vi.stubEnv("WINDOWS_PUBLISHER_NAME", "Quriosity Pty Ltd");
+    Object.defineProperty(process, "platform", { value: "win32" });
     // mock execFileSync 返回包含 "Quriosity Pty Ltd" 的内容
     await expect(import("../verify-windows-signature")).resolves.not.toThrow();
   });
 });
 ```
-
-> **注意：** 因为校验脚本会在模块顶层立刻执行（与现有 `verify-packaged-*.ts`
-> 的风格一致），脚本可能要稍作重构，把主逻辑包在 `main()` 函数里 — 在
-> 子任务 5 里一并处理。这样 CLI 用得舒服，单测也好写。
 
 ### 运行方式
 
@@ -87,49 +76,77 @@ describe("verify-windows-signature", () => {
 cd qcut && bun run test scripts/__tests__/verify-windows-signature.test.ts
 ```
 
-## 测试 2 — `package.json` 形态守门
+## 测试 2 — 签名脚本单元测试
+
+**路径：** `qcut/scripts/__tests__/sign-windows-release.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("sign-windows-release", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("QCUT_WIN_CERT_THUMBPRINT 未设时抛错", async () => {
+    await expect(import("../sign-windows-release")).rejects.toThrow(/QCUT_WIN_CERT_THUMBPRINT/);
+  });
+
+  it("找不到 QCut*Setup*.exe 时抛错", async () => {
+    vi.stubEnv("QCUT_WIN_CERT_THUMBPRINT", "ABC123");
+    // mock fs.readdirSync 返回 []
+    await expect(import("../sign-windows-release")).rejects.toThrow(/找不到 QCut.*Setup.*\.exe/);
+  });
+
+  it("调用 signtool sign 时带时间戳服务和 SHA-256 算法", async () => {
+    vi.stubEnv("QCUT_WIN_CERT_THUMBPRINT", "ABC123");
+    // mock fs 和 child_process，让 signtool 被调用
+    // 断言 execFileSync 调用参数 ["sign", "/tr", ..., "/td", "sha256", "/fd", "sha256", "/sha1", "ABC123", ...]
+    expect(/* recorded args */).toContain("sha256");
+  });
+
+  it("签完重新生成 latest.yml 的 SHA512", async () => {
+    // mock latest.yml 存在、signtool 成功
+    // 断言 writeFileSync 用新 sha512 写入
+  });
+});
+```
+
+## 测试 3 — `package.json` 形态守门
 
 **路径：** `qcut/scripts/__tests__/package-json-signing.test.ts`
-
-这是一个守门测试 — 跑得很快，能防止以后合并代码时不小心把
-`forceCodeSigning: false` 又加回去。
 
 ```ts
 import { describe, it, expect } from "vitest";
 import pkg from "../../package.json";
 
-describe("package.json 中的 Windows 签名配置", () => {
-  it("所有签名 flag 都打开了", () => {
-    expect(pkg.build.win.forceCodeSigning).toBe(true);
+describe("package.json Windows 签名配置", () => {
+  it("verifyUpdateCodeSignature 是 true", () => {
     expect(pkg.build.win.verifyUpdateCodeSignature).toBe(true);
-    expect(pkg.build.win.signAndEditExecutable).toBe(true);
   });
 
-  it("azureSignOptions 四个必需字段都存在", () => {
-    const opts = pkg.build.win.azureSignOptions;
-    expect(opts).toBeDefined();
-    expect(opts.publisherName).toBeTruthy();
-    expect(opts.endpoint).toBeTruthy();
-    expect(opts.certificateProfileName).toBeTruthy();
-    expect(opts.codeSigningAccountName).toBeTruthy();
+  it("forceCodeSigning 是 false（我们在 build 之后手工签）", () => {
+    expect(pkg.build.win.forceCodeSigning).toBe(false);
   });
 
-  it("dist:win:release 脚本里没有禁用签名的参数", () => {
-    expect(pkg.scripts["dist:win:release"]).not.toMatch(
-      /forceCodeSigning=false/,
-    );
-    expect(pkg.scripts["dist:win:release"]).not.toMatch(
-      /verifyUpdateCodeSignature=false/,
-    );
+  it("没有配 azureSignOptions（Azure 路径已排除）", () => {
+    expect((pkg.build.win as any).azureSignOptions).toBeUndefined();
+  });
+
+  it("dist:win:release 脚本里没有禁用签名的覆盖", () => {
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(/forceCodeSigning=false/);
+    expect(pkg.scripts["dist:win:release"]).not.toMatch(/verifyUpdateCodeSignature=false/);
+  });
+
+  it("scripts 包含 sign:win 和 verify:win-signature", () => {
+    expect(pkg.scripts["sign:win"]).toBeDefined();
+    expect(pkg.scripts["verify:win-signature"]).toBeDefined();
   });
 });
 ```
 
-### 运行方式
-
-跟测试 1 一样的 Vitest 命令。
-
-## 测试 3 — 工作流 YAML 守门
+## 测试 4 — 工作流 YAML 守门
 
 **路径：** `qcut/scripts/__tests__/release-workflow-signing.test.ts`
 
@@ -139,73 +156,51 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import yaml from "js-yaml";
 
-const workflowPath = join(
-  import.meta.dir,
-  "..", "..", "..", ".github", "workflows", "release.yml",
-);
+const workflowPath = join(import.meta.dir, "..", "..", "..", ".github", "workflows", "release.yml");
 const wf = yaml.load(readFileSync(workflowPath, "utf8")) as any;
 
-describe("release.yml Windows 任务", () => {
+describe("release.yml Windows 签名流程", () => {
   const winJob = wf.jobs["build-windows"];
 
-  it("'Build Electron application' 步骤没有禁用签名", () => {
-    const step = winJob.steps.find(
-      (s: any) => s.name === "Build Electron application",
-    );
+  it("Build 步骤的命令行没有禁用签名", () => {
+    const step = winJob.steps.find((s: any) => /Build Electron application/.test(s.name));
     expect(step.run).not.toMatch(/forceCodeSigning=false/);
     expect(step.run).not.toMatch(/verifyUpdateCodeSignature=false/);
   });
 
-  it("'Build Electron application' 步骤暴露了 Azure secret", () => {
-    const step = winJob.steps.find(
-      (s: any) => s.name === "Build Electron application",
-    );
-    for (const k of [
-      "AZURE_TENANT_ID",
-      "AZURE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_TRUSTED_SIGNING_ENDPOINT",
-      "AZURE_TRUSTED_SIGNING_ACCOUNT",
-      "AZURE_CERTIFICATE_PROFILE",
-      "WINDOWS_PUBLISHER_NAME",
-    ]) {
-      expect(step.env[k]).toBeDefined();
-    }
+  it("artifact 上传名是 windows-build-unsigned", () => {
+    const upload = winJob.steps.find((s: any) => s.uses?.startsWith("actions/upload-artifact"));
+    expect(upload.with.name).toBe("windows-build-unsigned");
   });
 
-  it("Build 之后存在 'Verify Windows signature' 步骤", () => {
-    const names = winJob.steps.map((s: any) => s.name);
-    const buildIdx = names.indexOf("Build Electron application");
-    const verifyIdx = names.indexOf("Verify Windows signature");
-    expect(verifyIdx).toBeGreaterThan(buildIdx);
+  it("release publish 任务不会自动把未签名 Windows .exe 挂到 Release", () => {
+    const releaseJob = wf.jobs["release"];
+    const publishStep = releaseJob.steps.find((s: any) => s.uses?.includes("softprops/action-gh-release") || /release/i.test(s.name ?? ""));
+    if (publishStep && publishStep.with?.files) {
+      // 维护者按 release operator 手册手工上传签名 .exe
+      expect(publishStep.with.files).not.toMatch(/windows-build-unsigned/);
+    }
   });
 });
 ```
 
-> 如果还没装 `js-yaml` 和 `@types/js-yaml`，需要把它们加到 dev
-> dependency；用 `cd qcut && bun pm ls js-yaml` 检查一下。
+> 如果 `js-yaml` 和 `@types/js-yaml` 还没在 dev dependency 里，加进去：`bun add -d js-yaml @types/js-yaml`。
 
-### 运行方式
+## 测试 5 — 人工 VM E2E
 
-跟前面一样的 Vitest 命令。这个测试在所有开发机和 CI 上都能跑，
-**不需要** Windows。
+详见 [`IMPLEMENTATION.zh-CN.md §6`](IMPLEMENTATION.zh-CN.md#6-在干净-windows-vm-上做发布演练)。在 PR 描述里把结果作为 checklist 留底：
 
-## 测试 4 — 人工 E2E（干净 VM）
-
-详细步骤见 [`IMPLEMENTATION.zh-CN.md §5`](IMPLEMENTATION.zh-CN.md#5-发布演练人工验证)。
-在 PR 描述里把结果作为 checklist 留底：
-
-- [ ] NSIS 安装界面显示 `发布者：Quriosity Pty Ltd`（或实际发布者）。
-- [ ] `Get-AuthenticodeSignature` → `Status: Valid`。
-- [ ] `signtool verify /pa /v` → 退出 0。
-- [ ] 安装后程序能进到编辑器路由。
+- [ ] CI 成功 build 出 `windows-build-unsigned`。
+- [ ] `bun run sign:win` 配合手机批准成功。
+- [ ] `bun run verify:win-signature` 退出 0。
+- [ ] 手工上传到 GitHub Release 成功。
+- [ ] 干净 VM 上：SmartScreen "More info" 面板里显示 "Quriosity Pty Ltd"。
+- [ ] 干净 VM 上：UAC 弹窗是**蓝色**，写 "Verified publisher: Quriosity Pty Ltd"。
+- [ ] `Get-AuthenticodeSignature` 报告 `Status: Valid`。
 
 ## 我们故意不测的部分
 
-- **`signtool.exe` 自身的正确性** — 信任微软的签名工具。
-- **Azure Trusted Signing 服务可用性** — 不在我们控制范围内。
-- **SmartScreen 警告时机** — 取决于微软的信誉聚合，不是确定性的。
-  通过发布反馈收集，不通过单测验证。
-- **证书链过期** — `verifyUpdateCodeSignature: true` 会在签名链将来
-  失效时让线上更新明确报错；我们更愿意让生产环境直接报错，也不愿意
-  写脆弱的有效期 CI 测试。
+- **`signtool.exe` 自身的正确性** — 微软提供的工具。
+- **Certum SimplySign 服务可用性** — 厂商端故障不在控制范围。SimplySign 挂掉时手工签名会因 `signtool` 报错明确失败；不要盲目重试。
+- **SmartScreen 信誉时机** — SmartScreen 是非确定性的，取决于微软信誉聚合。通过发布反馈跟踪。
+- **证书链过期** — `verifyUpdateCodeSignature: true` 会在签名链将来失效时让线上更新明确报错；我们更愿意让生产环境直接报错，也不愿意写脆弱的有效期 CI 测试。

--- a/qcut/electron/__tests__/ai-video-migration.test.ts
+++ b/qcut/electron/__tests__/ai-video-migration.test.ts
@@ -87,11 +87,12 @@ describe("getAIVideoDir", () => {
 		expect(segments).toContain("videos");
 	});
 
-	it("sanitizes the project ID by removing path separators", () => {
+	it("sanitizes the project ID by stripping path separators and parent refs", () => {
 		const result = getAIVideoDir("../malicious");
-		// Dots are preserved but slashes are replaced with underscores
-		expect(result).toContain(".._malicious");
-		expect(result).not.toContain("/malicious");
+		// `sanitizePathComponent` strips both slashes and `..` entirely, so
+		// the project ID resolves to the cleaned name with no traversal residue.
+		expect(result).not.toContain("..");
+		expect(result).toContain(`${path.sep}malicious${path.sep}`);
 	});
 
 	it("starts from Documents path", () => {

--- a/qcut/electron/__tests__/ai-video-save-handler.test.ts
+++ b/qcut/electron/__tests__/ai-video-save-handler.test.ts
@@ -65,6 +65,9 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 import { saveAIVideoToDisk } from "../ai-video-save-handler";
+import { REQUIRED_PROJECT_FOLDERS } from "../lib/project-structure";
+
+const REQUIRED_PROJECT_FOLDERS_LEN = REQUIRED_PROJECT_FOLDERS.length;
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -91,8 +94,18 @@ function tinyVideoBuffer(): ArrayBuffer {
 const PROJECT_ID = "proj-1";
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+// Snapshot the inherited env var (if any) so we can restore it in afterEach.
+// `isPathDebugEnabled()` checks `process.env.QCUT_DEBUG_PATHS === "1"` BEFORE
+// `app.isPackaged`, so a developer running tests with this set in their shell
+// would otherwise make every packaged-mode redaction test pass-through and
+// silently lose coverage.
+const originalQcutDebugPaths = process.env.QCUT_DEBUG_PATHS;
 
 beforeEach(() => {
+	// Force-clear so packaged-mode tests are deterministic regardless of
+	// whatever the host shell / CI runner has in its environment.
+	delete process.env.QCUT_DEBUG_PATHS;
+
 	writeFileMock.mockReset();
 	mkdirMock.mockReset();
 	accessMock.mockReset();
@@ -121,6 +134,12 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	// Restore (or delete) so suite teardown matches the inherited shell env.
+	if (originalQcutDebugPaths === undefined) {
+		delete process.env.QCUT_DEBUG_PATHS;
+	} else {
+		process.env.QCUT_DEBUG_PATHS = originalQcutDebugPaths;
+	}
 });
 
 // ============================================================================
@@ -154,12 +173,27 @@ describe("saveAIVideoToDisk — happy path", () => {
 
 describe("saveAIVideoToDisk — projectDir missing before write", () => {
 	it("triggers an extra ensureProjectStructure via the stat guard", async () => {
-		// First stat call (isExistingDirectory) → throw (folder missing).
-		// Subsequent stats (verify saved file) → real file.
-		statMock.mockRejectedValueOnce(enoent()).mockResolvedValue({
-			isDirectory: () => true,
-			isFile: () => true,
-			size: 4,
+		// `ensureProjectStructure` now calls `stat()` per required folder,
+		// and the stat guard inside `writeFileWithStatGuard` calls `stat()`
+		// once on `projectDir`. So total stats per save = 9 (upfront ensure)
+		// + 1 (stat guard) + 1 (verify written file) = 11 minimum.
+		//
+		// In this scenario the projectDir's stat (the guard) reports missing,
+		// triggering a SECOND ensureProjectStructure → 9 more stat calls.
+		// Then the verify-written-file stat. Expected ≥ 19 stat calls.
+		let statCallIndex = 0;
+		statMock.mockImplementation(async () => {
+			statCallIndex++;
+			// Make the writeFileWithStatGuard stat (call ~10) report missing
+			// so the recovery branch fires. Every other call reports a dir.
+			if (statCallIndex === REQUIRED_PROJECT_FOLDERS_LEN + 1) {
+				throw enoent();
+			}
+			return {
+				isDirectory: () => true,
+				isFile: () => true,
+				size: 4,
+			};
 		});
 		writeFileMock.mockResolvedValue(undefined);
 
@@ -170,9 +204,9 @@ describe("saveAIVideoToDisk — projectDir missing before write", () => {
 		});
 
 		expect(result.success).toBe(true);
-		// One ensure for the upfront call + one for the stat-guard recovery.
-		// REQUIRED_PROJECT_FOLDERS has 9 entries, accessed via `access`.
-		expect(accessMock.mock.calls.length).toBeGreaterThanOrEqual(18);
+		expect(statMock.mock.calls.length).toBeGreaterThanOrEqual(
+			REQUIRED_PROJECT_FOLDERS_LEN * 2 + 1
+		);
 		expect(writeFileMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/qcut/electron/__tests__/ai-video-save-handler.test.ts
+++ b/qcut/electron/__tests__/ai-video-save-handler.test.ts
@@ -1,0 +1,277 @@
+// @vitest-environment node
+/**
+ * Tests for `saveAIVideoToDisk` covering issue #290:
+ *   1. Happy path — single writeFile, single ensureProjectStructure.
+ *   2. `media/generated/videos` missing — pre-write stat guard triggers an
+ *      extra ensureProjectStructure before any writeFile.
+ *   3. Directory removed between mkdir and writeFile (TOCTOU) — first
+ *      writeFile fails with ENOENT, retry recreates structure and succeeds.
+ *   4. Two consecutive ENOENTs — surface failure, no third attempt.
+ *   5. Non-ENOENT writeFile error — no retry.
+ *   6. Path redaction — packaged build redacts; debug build keeps full path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const isPackagedRef = { value: true }; // mutate per-test
+
+// ---- mocks (must be before SUT import) -------------------------------------
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: vi.fn((name: string) => {
+			if (name === "documents") return "/mock/Documents";
+			if (name === "userData") return "/mock/AppData";
+			return "/mock/unknown";
+		}),
+		get isPackaged() {
+			return isPackagedRef.value;
+		},
+	},
+	ipcMain: { handle: vi.fn() },
+}));
+
+vi.mock("crypto", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("crypto")>();
+	return {
+		...actual,
+		default: actual,
+		randomBytes: vi.fn(() => ({ toString: () => "abcdef0123456789" })),
+	};
+});
+
+const writeFileMock = vi.fn();
+const mkdirMock = vi.fn();
+const accessMock = vi.fn();
+const statMock = vi.fn();
+const statfsMock = vi.fn();
+const unlinkMock = vi.fn();
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>();
+	return {
+		...actual,
+		default: actual,
+		promises: {
+			...actual.promises,
+			writeFile: (...args: any[]) => writeFileMock(...args),
+			mkdir: (...args: any[]) => mkdirMock(...args),
+			access: (...args: any[]) => accessMock(...args),
+			stat: (...args: any[]) => statMock(...args),
+			statfs: (...args: any[]) => statfsMock(...args),
+			unlink: (...args: any[]) => unlinkMock(...args),
+		},
+	};
+});
+
+import { saveAIVideoToDisk } from "../ai-video-save-handler";
+
+// ---- helpers ---------------------------------------------------------------
+
+function enoent(): Error {
+	return Object.assign(new Error("ENOENT: no such file or directory"), {
+		code: "ENOENT",
+	});
+}
+
+function tinyVideoBuffer(): ArrayBuffer {
+	return new Uint8Array([1, 2, 3, 4]).buffer;
+}
+
+const PROJECT_ID = "proj-1";
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	writeFileMock.mockReset();
+	mkdirMock.mockReset();
+	accessMock.mockReset();
+	statMock.mockReset();
+	statfsMock.mockReset();
+	unlinkMock.mockReset();
+
+	// Default: writes succeed, mkdir succeeds (so ensureProjectStructure is happy).
+	mkdirMock.mockResolvedValue(undefined);
+	// Default: access succeeds, so ensureProjectStructure reports "existing".
+	accessMock.mockResolvedValue(undefined);
+	// Default: stat for `isExistingDirectory(projectDir)` reports a real dir.
+	statMock.mockResolvedValue({
+		isDirectory: () => true,
+		isFile: () => true,
+		size: 4,
+	});
+	statfsMock.mockResolvedValue({ bavail: 1_000_000, bsize: 4096 });
+
+	isPackagedRef.value = true; // packaged production build by default
+
+	consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	vi.spyOn(console, "log").mockImplementation(() => {});
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ============================================================================
+// 1. happy path
+// ============================================================================
+
+describe("saveAIVideoToDisk — happy path", () => {
+	it("writes once and reports success", async () => {
+		writeFileMock.mockResolvedValue(undefined);
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+			modelId: "kling",
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.fileName).toContain("video-kling-");
+		expect(result.fileSize).toBe(4);
+		// Exactly one writeFile (the video). Metadata write is gated by metadata arg.
+		expect(writeFileMock).toHaveBeenCalledTimes(1);
+		// stat guard ran at least once (for the isExistingDirectory check).
+		expect(statMock).toHaveBeenCalled();
+	});
+});
+
+// ============================================================================
+// 2. issue case A — media/generated/videos missing
+// ============================================================================
+
+describe("saveAIVideoToDisk — projectDir missing before write", () => {
+	it("triggers an extra ensureProjectStructure via the stat guard", async () => {
+		// First stat call (isExistingDirectory) → throw (folder missing).
+		// Subsequent stats (verify saved file) → real file.
+		statMock
+			.mockRejectedValueOnce(enoent())
+			.mockResolvedValue({
+				isDirectory: () => true,
+				isFile: () => true,
+				size: 4,
+			});
+		writeFileMock.mockResolvedValue(undefined);
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(true);
+		// One ensure for the upfront call + one for the stat-guard recovery.
+		// REQUIRED_PROJECT_FOLDERS has 9 entries, accessed via `access`.
+		expect(accessMock.mock.calls.length).toBeGreaterThanOrEqual(18);
+		expect(writeFileMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================================
+// 3. issue case B — directory removed between mkdir and writeFile
+// ============================================================================
+
+describe("saveAIVideoToDisk — ENOENT once then success", () => {
+	it("retries writeFile exactly once and succeeds", async () => {
+		writeFileMock
+			.mockRejectedValueOnce(enoent())
+			.mockResolvedValueOnce(undefined);
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(true);
+		expect(writeFileMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================================
+// 4. ENOENT twice — no infinite retry
+// ============================================================================
+
+describe("saveAIVideoToDisk — ENOENT on both attempts", () => {
+	it("returns failure after exactly two writeFile attempts", async () => {
+		writeFileMock.mockRejectedValue(enoent());
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("Failed to write video file to disk");
+		expect(writeFileMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================================
+// 5. non-ENOENT error — no retry
+// ============================================================================
+
+describe("saveAIVideoToDisk — non-ENOENT writeFile error", () => {
+	it("does not retry on EPERM", async () => {
+		const eperm = Object.assign(new Error("EPERM: operation not permitted"), {
+			code: "EPERM",
+		});
+		writeFileMock.mockRejectedValue(eperm);
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(false);
+		expect(writeFileMock).toHaveBeenCalledTimes(1);
+		expect(result.error).toContain("EPERM");
+	});
+});
+
+// ============================================================================
+// 6. issue case C — path redaction (packaged vs debug)
+// ============================================================================
+
+describe("saveAIVideoToDisk — path redaction", () => {
+	it("redacts Documents path from IPC error AND console.error in packaged build", async () => {
+		isPackagedRef.value = true;
+		writeFileMock.mockRejectedValue(enoent());
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).not.toContain("/mock/Documents");
+		// console.error was called with the redacted message — no /mock/Documents anywhere.
+		const seenInLogs = consoleErrorSpy.mock.calls
+			.flat()
+			.map((arg) => (typeof arg === "string" ? arg : ""))
+			.join("\n");
+		expect(seenInLogs).not.toContain("/mock/Documents");
+	});
+
+	it("keeps full path in dev (app.isPackaged === false)", async () => {
+		isPackagedRef.value = false;
+		writeFileMock.mockRejectedValue(enoent());
+
+		const result = await saveAIVideoToDisk({
+			fileName: "video.mp4",
+			fileData: tinyVideoBuffer(),
+			projectId: PROJECT_ID,
+		});
+
+		expect(result.success).toBe(false);
+		// In dev mode the unredacted message is fine — it should just report ENOENT.
+		// We don't strictly require the full path to appear in this surface, but we
+		// do require that the redacted token "<project>" is NOT inserted.
+		expect(result.error).not.toContain("<project>");
+	});
+});

--- a/qcut/electron/__tests__/ai-video-save-handler.test.ts
+++ b/qcut/electron/__tests__/ai-video-save-handler.test.ts
@@ -146,13 +146,11 @@ describe("saveAIVideoToDisk — projectDir missing before write", () => {
 	it("triggers an extra ensureProjectStructure via the stat guard", async () => {
 		// First stat call (isExistingDirectory) → throw (folder missing).
 		// Subsequent stats (verify saved file) → real file.
-		statMock
-			.mockRejectedValueOnce(enoent())
-			.mockResolvedValue({
-				isDirectory: () => true,
-				isFile: () => true,
-				size: 4,
-			});
+		statMock.mockRejectedValueOnce(enoent()).mockResolvedValue({
+			isDirectory: () => true,
+			isFile: () => true,
+			size: 4,
+		});
 		writeFileMock.mockResolvedValue(undefined);
 
 		const result = await saveAIVideoToDisk({

--- a/qcut/electron/__tests__/ai-video-save-handler.test.ts
+++ b/qcut/electron/__tests__/ai-video-save-handler.test.ts
@@ -54,12 +54,12 @@ vi.mock("fs", async (importOriginal) => {
 		default: actual,
 		promises: {
 			...actual.promises,
-			writeFile: (...args: any[]) => writeFileMock(...args),
-			mkdir: (...args: any[]) => mkdirMock(...args),
-			access: (...args: any[]) => accessMock(...args),
-			stat: (...args: any[]) => statMock(...args),
-			statfs: (...args: any[]) => statfsMock(...args),
-			unlink: (...args: any[]) => unlinkMock(...args),
+			writeFile: (...args: unknown[]) => writeFileMock(...args),
+			mkdir: (...args: unknown[]) => mkdirMock(...args),
+			access: (...args: unknown[]) => accessMock(...args),
+			stat: (...args: unknown[]) => statMock(...args),
+			statfs: (...args: unknown[]) => statfsMock(...args),
+			unlink: (...args: unknown[]) => unlinkMock(...args),
 		},
 	};
 });
@@ -68,10 +68,20 @@ import { saveAIVideoToDisk } from "../ai-video-save-handler";
 
 // ---- helpers ---------------------------------------------------------------
 
-function enoent(): Error {
-	return Object.assign(new Error("ENOENT: no such file or directory"), {
-		code: "ENOENT",
-	});
+/**
+ * Build a realistic ENOENT error whose `.message` includes a path under the
+ * mocked `/mock/Documents` projects base. This is what node's fs throws — and
+ * it's the actual surface that the redaction logic has to clean up. Tests
+ * that mock a path-less ENOENT pass even when redaction is broken (CodeRabbit
+ * #3143145185), so always pass a path.
+ */
+function enoent(
+	filePath = "/mock/Documents/QCut/Projects/proj-1/media/generated/videos/video.mp4"
+): NodeJS.ErrnoException {
+	return Object.assign(
+		new Error(`ENOENT: no such file or directory, open '${filePath}'`),
+		{ code: "ENOENT", path: filePath }
+	);
 }
 
 function tinyVideoBuffer(): ArrayBuffer {
@@ -238,6 +248,10 @@ describe("saveAIVideoToDisk — non-ENOENT writeFile error", () => {
 describe("saveAIVideoToDisk — path redaction", () => {
 	it("redacts Documents path from IPC error AND console.error in packaged build", async () => {
 		isPackagedRef.value = true;
+		// Reject every writeFile attempt with an ENOENT whose message embeds
+		// the full /mock/Documents path — proving the redaction path actually
+		// strips it. (Without a real path in the error, the assertions below
+		// pass even when redaction is broken.)
 		writeFileMock.mockRejectedValue(enoent());
 
 		const result = await saveAIVideoToDisk({
@@ -247,12 +261,20 @@ describe("saveAIVideoToDisk — path redaction", () => {
 		});
 
 		expect(result.success).toBe(false);
+		// Sanity: the message we returned includes the path token (just
+		// proves the test plumbing is wired up — without the next line, this
+		// would still pass for a wholly empty error string).
+		expect(result.error).toMatch(/Failed to write video file to disk/);
+		expect(result.error).toContain("<project>");
 		expect(result.error).not.toContain("/mock/Documents");
-		// console.error was called with the redacted message — no /mock/Documents anywhere.
+
+		// console.error was also called with the redacted message — no
+		// /mock/Documents anywhere in production logs.
 		const seenInLogs = consoleErrorSpy.mock.calls
 			.flat()
 			.map((arg) => (typeof arg === "string" ? arg : ""))
 			.join("\n");
+		expect(seenInLogs).toContain("<project>");
 		expect(seenInLogs).not.toContain("/mock/Documents");
 	});
 
@@ -267,9 +289,10 @@ describe("saveAIVideoToDisk — path redaction", () => {
 		});
 
 		expect(result.success).toBe(false);
-		// In dev mode the unredacted message is fine — it should just report ENOENT.
-		// We don't strictly require the full path to appear in this surface, but we
-		// do require that the redacted token "<project>" is NOT inserted.
+		// In dev mode the unredacted absolute path MUST appear so devs can
+		// see exactly which path failed. The "<project>" token must NOT be
+		// inserted (that's a packaged-build-only substitution).
+		expect(result.error).toContain("/mock/Documents");
 		expect(result.error).not.toContain("<project>");
 	});
 });

--- a/qcut/electron/__tests__/project-structure.test.ts
+++ b/qcut/electron/__tests__/project-structure.test.ts
@@ -74,6 +74,23 @@ describe("sanitizePathComponent", () => {
 	it("preserves alphanumeric characters and hyphens/underscores/dots", () => {
 		expect(sanitizePathComponent("project_v1.0-rc")).toBe("project_v1.0-rc");
 	});
+
+	// Regression: odd-length dot runs ("...", ".....") used to leave a residual
+	// "." which `path.join(base, ".")` collapses to base. The "\.{2,}" pattern
+	// now consumes the entire run.
+	it.each([
+		["...", ""],
+		["....", ""],
+		[".....", ""],
+		["....proj", "proj"],
+		["a..b", "ab"],
+	])("collapses any run of 2+ dots: %s → %s", (input, expected) => {
+		expect(sanitizePathComponent(input)).toBe(expected);
+	});
+
+	it("preserves single dots between segments", () => {
+		expect(sanitizePathComponent("a.b.c")).toBe("a.b.c");
+	});
 });
 
 // ============================================================================
@@ -122,8 +139,20 @@ describe("getProjectRoot", () => {
 		["dotdot", ".."],
 		["slash", "/"],
 		["backslash", "\\"],
+		["triple dots", "..."],
+		["five dots", "....."],
 	])("throws on %s (sanitizes to empty)", (_label, input) => {
 		expect(() => getProjectRoot(input)).toThrow(/sanitizes to an empty/);
+	});
+
+	// Regression: inputs that sanitize to "." (e.g. "./" — slash stripped)
+	// must not be allowed; `path.join(base, ".")` resolves to `base` itself.
+	it.each([
+		["lone dot", "."],
+		["dot-slash", "./"],
+		["dot-backslash", ".\\"],
+	])("throws on %s (resolves to projects base)", (_label, input) => {
+		expect(() => getProjectRoot(input)).toThrow(/projects base directory/);
 	});
 });
 

--- a/qcut/electron/__tests__/project-structure.test.ts
+++ b/qcut/electron/__tests__/project-structure.test.ts
@@ -44,6 +44,7 @@ vi.mock("fs", async (importOriginal) => {
 import {
 	REQUIRED_PROJECT_FOLDERS,
 	ensureProjectStructure,
+	getProjectRoot,
 	getProjectsBasePath,
 	isExistingDirectory,
 	sanitizePathComponent,
@@ -103,6 +104,25 @@ describe("validatePathWithinBase", () => {
 			validatePathWithinBase(path.resolve(base, "..", "..", "etc"), base)
 		).toThrow(/Path traversal/);
 	});
+});
+
+// ============================================================================
+// getProjectRoot — reject IDs that sanitize to empty
+// ============================================================================
+
+describe("getProjectRoot", () => {
+	it("resolves a valid project ID under the base", () => {
+		expect(getProjectRoot("proj-1")).toBe(
+			path.join("/mock/Documents", "QCut", "Projects", "proj-1")
+		);
+	});
+
+	it.each([["empty string", ""], ["dotdot", ".."], ["slash", "/"], ["backslash", "\\"]])(
+		"throws on %s (sanitizes to empty)",
+		(_label, input) => {
+			expect(() => getProjectRoot(input)).toThrow(/sanitizes to an empty/);
+		}
+	);
 });
 
 // ============================================================================
@@ -195,5 +215,14 @@ describe("ensureProjectStructure", () => {
 			path.join("/mock/Documents", "QCut", "Projects", "escape")
 		);
 		expect(result.projectRoot).not.toContain("..");
+	});
+
+	it("rejects an empty project ID rather than ensuring the base directory", async () => {
+		accessMock.mockResolvedValue(undefined);
+		await expect(ensureProjectStructure("")).rejects.toThrow(/sanitizes to an empty/);
+		await expect(ensureProjectStructure("..")).rejects.toThrow(/sanitizes to an empty/);
+		// And no fs operations should have been issued.
+		expect(mkdirMock).not.toHaveBeenCalled();
+		expect(accessMock).not.toHaveBeenCalled();
 	});
 });

--- a/qcut/electron/__tests__/project-structure.test.ts
+++ b/qcut/electron/__tests__/project-structure.test.ts
@@ -117,12 +117,14 @@ describe("getProjectRoot", () => {
 		);
 	});
 
-	it.each([["empty string", ""], ["dotdot", ".."], ["slash", "/"], ["backslash", "\\"]])(
-		"throws on %s (sanitizes to empty)",
-		(_label, input) => {
-			expect(() => getProjectRoot(input)).toThrow(/sanitizes to an empty/);
-		}
-	);
+	it.each([
+		["empty string", ""],
+		["dotdot", ".."],
+		["slash", "/"],
+		["backslash", "\\"],
+	])("throws on %s (sanitizes to empty)", (_label, input) => {
+		expect(() => getProjectRoot(input)).toThrow(/sanitizes to an empty/);
+	});
 });
 
 // ============================================================================
@@ -153,7 +155,9 @@ describe("isExistingDirectory", () => {
 	});
 
 	it("returns false when stat throws", async () => {
-		statMock.mockRejectedValue(Object.assign(new Error("nope"), { code: "ENOENT" }));
+		statMock.mockRejectedValue(
+			Object.assign(new Error("nope"), { code: "ENOENT" })
+		);
 		await expect(isExistingDirectory("/anything")).resolves.toBe(false);
 	});
 });
@@ -219,8 +223,12 @@ describe("ensureProjectStructure", () => {
 
 	it("rejects an empty project ID rather than ensuring the base directory", async () => {
 		accessMock.mockResolvedValue(undefined);
-		await expect(ensureProjectStructure("")).rejects.toThrow(/sanitizes to an empty/);
-		await expect(ensureProjectStructure("..")).rejects.toThrow(/sanitizes to an empty/);
+		await expect(ensureProjectStructure("")).rejects.toThrow(
+			/sanitizes to an empty/
+		);
+		await expect(ensureProjectStructure("..")).rejects.toThrow(
+			/sanitizes to an empty/
+		);
 		// And no fs operations should have been issued.
 		expect(mkdirMock).not.toHaveBeenCalled();
 		expect(accessMock).not.toHaveBeenCalled();

--- a/qcut/electron/__tests__/project-structure.test.ts
+++ b/qcut/electron/__tests__/project-structure.test.ts
@@ -197,8 +197,10 @@ describe("isExistingDirectory", () => {
 
 describe("ensureProjectStructure", () => {
 	it("creates every required folder when none exist", async () => {
-		// access throws → not present → mkdir is called for each folder
-		accessMock.mockRejectedValue(new Error("ENOENT"));
+		// stat throws → not present → mkdir is called for each folder
+		statMock.mockRejectedValue(
+			Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		);
 		mkdirMock.mockResolvedValue(undefined);
 
 		const result = await ensureProjectStructure("proj-1");
@@ -211,8 +213,8 @@ describe("ensureProjectStructure", () => {
 		);
 	});
 
-	it("reports every folder as existing when access succeeds", async () => {
-		accessMock.mockResolvedValue(undefined);
+	it("reports every folder as existing when stat reports a directory", async () => {
+		statMock.mockResolvedValue({ isDirectory: () => true });
 
 		const result = await ensureProjectStructure("proj-1");
 
@@ -221,9 +223,31 @@ describe("ensureProjectStructure", () => {
 		expect(mkdirMock).not.toHaveBeenCalled();
 	});
 
+	// Regression: a stray FILE at a required folder path used to be
+	// classified as "existing" via fs.access, then the next write would
+	// fail with ENOTDIR with no recovery. Now we stat → isDirectory()
+	// and try to mkdir over it (which surfaces the conflict via EEXIST/
+	// ENOTDIR and is collected by omission so the caller can recover).
+	it("does NOT mark a folder as existing when a file occupies its path", async () => {
+		statMock.mockResolvedValue({ isDirectory: () => false });
+		// mkdir on top of a file fails (real ENOTDIR semantics).
+		mkdirMock.mockRejectedValue(
+			Object.assign(new Error("ENOTDIR"), { code: "ENOTDIR" })
+		);
+
+		const result = await ensureProjectStructure("proj-1");
+
+		expect(result.existing).toEqual([]);
+		expect(result.created).toEqual([]);
+		// We tried mkdir for every folder (none of them survived).
+		expect(mkdirMock).toHaveBeenCalledTimes(REQUIRED_PROJECT_FOLDERS.length);
+	});
+
 	it("collects per-folder mkdir failures by omission and keeps going", async () => {
 		// Every folder is missing.
-		accessMock.mockRejectedValue(new Error("ENOENT"));
+		statMock.mockRejectedValue(
+			Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		);
 		// First mkdir fails, the rest succeed.
 		let callCount = 0;
 		mkdirMock.mockImplementation(async () => {
@@ -240,7 +264,7 @@ describe("ensureProjectStructure", () => {
 	});
 
 	it("sanitizes the project ID before resolving the root", async () => {
-		accessMock.mockResolvedValue(undefined);
+		statMock.mockResolvedValue({ isDirectory: () => true });
 
 		const result = await ensureProjectStructure("../escape");
 
@@ -251,7 +275,7 @@ describe("ensureProjectStructure", () => {
 	});
 
 	it("rejects an empty project ID rather than ensuring the base directory", async () => {
-		accessMock.mockResolvedValue(undefined);
+		statMock.mockResolvedValue({ isDirectory: () => true });
 		await expect(ensureProjectStructure("")).rejects.toThrow(
 			/sanitizes to an empty/
 		);
@@ -260,6 +284,6 @@ describe("ensureProjectStructure", () => {
 		);
 		// And no fs operations should have been issued.
 		expect(mkdirMock).not.toHaveBeenCalled();
-		expect(accessMock).not.toHaveBeenCalled();
+		expect(statMock).not.toHaveBeenCalled();
 	});
 });

--- a/qcut/electron/__tests__/project-structure.test.ts
+++ b/qcut/electron/__tests__/project-structure.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment node
+/**
+ * Tests for the shared project structure helpers.
+ *
+ * Covers:
+ *   - sanitizePathComponent strips traversal payloads
+ *   - validatePathWithinBase rejects escapes
+ *   - ensureProjectStructure creates missing folders, leaves existing alone,
+ *     and recovers when an individual mkdir fails
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as path from "path";
+
+// Mock electron's `app` module before importing the SUT.
+vi.mock("electron", () => ({
+	app: {
+		getPath: vi.fn((name: string) => {
+			if (name === "documents") return "/mock/Documents";
+			return "/mock/unknown";
+		}),
+	},
+}));
+
+// fs spies — installed per test by `setupFsMocks`.
+const accessMock = vi.fn();
+const mkdirMock = vi.fn();
+const statMock = vi.fn();
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>();
+	return {
+		...actual,
+		default: actual,
+		promises: {
+			...actual.promises,
+			access: (...args: any[]) => accessMock(...args),
+			mkdir: (...args: any[]) => mkdirMock(...args),
+			stat: (...args: any[]) => statMock(...args),
+		},
+	};
+});
+
+import {
+	REQUIRED_PROJECT_FOLDERS,
+	ensureProjectStructure,
+	getProjectsBasePath,
+	isExistingDirectory,
+	sanitizePathComponent,
+	validatePathWithinBase,
+} from "../lib/project-structure";
+
+beforeEach(() => {
+	accessMock.mockReset();
+	mkdirMock.mockReset();
+	statMock.mockReset();
+});
+
+// ============================================================================
+// sanitizePathComponent
+// ============================================================================
+
+describe("sanitizePathComponent", () => {
+	it("strips forward and back slashes", () => {
+		expect(sanitizePathComponent("a/b\\c")).toBe("abc");
+	});
+
+	it("strips parent-directory references", () => {
+		expect(sanitizePathComponent("..foo")).toBe("foo");
+		expect(sanitizePathComponent("..\\..\\bar")).toBe("bar");
+	});
+
+	it("preserves alphanumeric characters and hyphens/underscores/dots", () => {
+		expect(sanitizePathComponent("project_v1.0-rc")).toBe("project_v1.0-rc");
+	});
+});
+
+// ============================================================================
+// validatePathWithinBase
+// ============================================================================
+
+describe("validatePathWithinBase", () => {
+	const base = path.resolve("/mock/Documents/QCut/Projects");
+
+	it("accepts a path inside the base", () => {
+		expect(() =>
+			validatePathWithinBase(path.join(base, "abc"), base)
+		).not.toThrow();
+	});
+
+	it("accepts the base itself", () => {
+		expect(() => validatePathWithinBase(base, base)).not.toThrow();
+	});
+
+	it("rejects a sibling of the base", () => {
+		expect(() =>
+			validatePathWithinBase(path.resolve("/mock/Documents/Other"), base)
+		).toThrow(/Path traversal/);
+	});
+
+	it("rejects a parent escape", () => {
+		expect(() =>
+			validatePathWithinBase(path.resolve(base, "..", "..", "etc"), base)
+		).toThrow(/Path traversal/);
+	});
+});
+
+// ============================================================================
+// getProjectsBasePath
+// ============================================================================
+
+describe("getProjectsBasePath", () => {
+	it("returns Documents/QCut/Projects", () => {
+		expect(getProjectsBasePath()).toBe(
+			path.join("/mock/Documents", "QCut", "Projects")
+		);
+	});
+});
+
+// ============================================================================
+// isExistingDirectory
+// ============================================================================
+
+describe("isExistingDirectory", () => {
+	it("returns true when stat reports a directory", async () => {
+		statMock.mockResolvedValue({ isDirectory: () => true });
+		await expect(isExistingDirectory("/anything")).resolves.toBe(true);
+	});
+
+	it("returns false when stat reports a non-directory", async () => {
+		statMock.mockResolvedValue({ isDirectory: () => false });
+		await expect(isExistingDirectory("/anything")).resolves.toBe(false);
+	});
+
+	it("returns false when stat throws", async () => {
+		statMock.mockRejectedValue(Object.assign(new Error("nope"), { code: "ENOENT" }));
+		await expect(isExistingDirectory("/anything")).resolves.toBe(false);
+	});
+});
+
+// ============================================================================
+// ensureProjectStructure
+// ============================================================================
+
+describe("ensureProjectStructure", () => {
+	it("creates every required folder when none exist", async () => {
+		// access throws → not present → mkdir is called for each folder
+		accessMock.mockRejectedValue(new Error("ENOENT"));
+		mkdirMock.mockResolvedValue(undefined);
+
+		const result = await ensureProjectStructure("proj-1");
+
+		expect(result.created).toEqual(Array.from(REQUIRED_PROJECT_FOLDERS));
+		expect(result.existing).toEqual([]);
+		expect(mkdirMock).toHaveBeenCalledTimes(REQUIRED_PROJECT_FOLDERS.length);
+		expect(result.projectRoot).toBe(
+			path.join("/mock/Documents", "QCut", "Projects", "proj-1")
+		);
+	});
+
+	it("reports every folder as existing when access succeeds", async () => {
+		accessMock.mockResolvedValue(undefined);
+
+		const result = await ensureProjectStructure("proj-1");
+
+		expect(result.created).toEqual([]);
+		expect(result.existing).toEqual(Array.from(REQUIRED_PROJECT_FOLDERS));
+		expect(mkdirMock).not.toHaveBeenCalled();
+	});
+
+	it("collects per-folder mkdir failures by omission and keeps going", async () => {
+		// Every folder is missing.
+		accessMock.mockRejectedValue(new Error("ENOENT"));
+		// First mkdir fails, the rest succeed.
+		let callCount = 0;
+		mkdirMock.mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) throw new Error("EACCES");
+			return undefined;
+		});
+
+		const result = await ensureProjectStructure("proj-1");
+
+		expect(result.created.length).toBe(REQUIRED_PROJECT_FOLDERS.length - 1);
+		expect(result.existing).toEqual([]);
+		expect(mkdirMock).toHaveBeenCalledTimes(REQUIRED_PROJECT_FOLDERS.length);
+	});
+
+	it("sanitizes the project ID before resolving the root", async () => {
+		accessMock.mockResolvedValue(undefined);
+
+		const result = await ensureProjectStructure("../escape");
+
+		expect(result.projectRoot).toBe(
+			path.join("/mock/Documents", "QCut", "Projects", "escape")
+		);
+		expect(result.projectRoot).not.toContain("..");
+	});
+});

--- a/qcut/electron/ai-video-save-handler.ts
+++ b/qcut/electron/ai-video-save-handler.ts
@@ -1,12 +1,74 @@
+/**
+ * AI Video Save Handler
+ *
+ * Persists AI-generated videos under the user's project tree at
+ * `Documents/QCut/Projects/<projectId>/media/generated/videos/`.
+ *
+ * Reliability contract:
+ *   1. Project tree is ensured via the shared `ensureProjectStructure` so this
+ *      writer agrees byte-for-byte with `project-folder:ensure-structure`.
+ *   2. A `stat` guard runs immediately before `writeFile` to handle cloud-sync
+ *      placeholder directories (OneDrive / iCloud) that report present-but-not-
+ *      hydrated.
+ *   3. A single `ENOENT` retry covers the TOCTOU race where the directory
+ *      disappears between `stat` and `writeFile`.
+ *
+ * Path-redaction policy: error strings returned over IPC and emitted via
+ * `console.error` are redacted in packaged builds (`<project>/...` instead of
+ * the absolute Documents path) so customer bug reports do not leak local
+ * filesystem layout. Dev breadcrumbs (`console.log`) are intentionally NOT
+ * redacted — they only run when a developer launches `bun run electron:dev`.
+ */
+
 import * as path from "path";
 import * as fs from "fs";
 import { app, ipcMain } from "electron";
 import { randomBytes } from "crypto";
+import {
+	ensureProjectStructure,
+	getProjectsBasePath,
+	isExistingDirectory,
+	sanitizePathComponent,
+} from "./lib/project-structure";
 
 const MAX_VIDEO_SIZE = 5 * 1024 * 1024 * 1024; // 5GB limit for AI videos
 
 /**
- * Sanitize filename to prevent path traversal attacks
+ * When true, error strings keep absolute paths (developer debugging).
+ * When false (packaged production builds), absolute paths are replaced with
+ * `<project>` so we don't leak local filesystem layout to UI/logs.
+ */
+function isPathDebugEnabled(): boolean {
+	if (process.env.QCUT_DEBUG_PATHS === "1") return true;
+	try {
+		return !app.isPackaged;
+	} catch {
+		// `app.isPackaged` may not be available in test/mock contexts.
+		return false;
+	}
+}
+
+/**
+ * Replace any occurrence of the projects base path in a message with
+ * `<project>` unless debug mode is enabled.
+ *
+ * Exported for unit tests.
+ */
+export function redactPath(message: string): string {
+	if (isPathDebugEnabled()) return message;
+	let base: string;
+	try {
+		base = getProjectsBasePath();
+	} catch {
+		return message;
+	}
+	return message.split(base).join("<project>");
+}
+
+/**
+ * Sanitize filename to prevent path traversal attacks.
+ * Used for the FILENAME portion only — for project IDs, use
+ * `sanitizePathComponent` from `./lib/project-structure`.
  */
 export function sanitizeFilename(filename: string): string {
 	return filename.replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -17,18 +79,16 @@ export function sanitizeFilename(filename: string): string {
  * Path: Documents/QCut/Projects/{projectId}/media/generated/videos/
  */
 export function getAIVideoDir(projectId: string): string {
-	const documentsPath = app.getPath("documents");
+	const sanitized = sanitizePathComponent(projectId);
 	const dir = path.join(
-		documentsPath,
-		"QCut",
-		"Projects",
-		sanitizeFilename(projectId),
+		getProjectsBasePath(),
+		sanitized,
 		"media",
 		"generated",
 		"videos"
 	);
 	console.log(
-		`[AI Video Path] getAIVideoDir("${projectId}") → ${dir} (documents=${documentsPath})`
+		`[AI Video Path] getAIVideoDir("${projectId}") → ${dir} (sanitized="${sanitized}")`
 	);
 	return dir;
 }
@@ -53,6 +113,38 @@ function generateUniqueId(): string {
 	return randomBytes(8).toString("hex");
 }
 
+/**
+ * Write a file with a pre-write `stat` guard plus a single ENOENT retry.
+ *
+ * Step A: confirms `projectDir` exists AND is a directory; if not, calls
+ *         `ensureProjectStructure(projectId)` first. This catches OneDrive
+ *         placeholder directories before the first write attempt.
+ * Step B: on `ENOENT` from `writeFile`, re-ensures the structure and retries
+ *         exactly once. Any other error propagates without retry.
+ *
+ * Exported for unit tests.
+ */
+export async function writeFileWithStatGuard(
+	filePath: string,
+	projectDir: string,
+	buffer: Buffer,
+	projectId: string
+): Promise<void> {
+	const dirOk = await isExistingDirectory(projectDir);
+	if (!dirOk) {
+		await ensureProjectStructure(projectId);
+	}
+
+	try {
+		await fs.promises.writeFile(filePath, buffer, { mode: 0o644 });
+		return;
+	} catch (err: any) {
+		if (err?.code !== "ENOENT") throw err;
+		await ensureProjectStructure(projectId);
+		await fs.promises.writeFile(filePath, buffer, { mode: 0o644 });
+	}
+}
+
 interface SaveAIVideoOptions {
 	fileName: string;
 	fileData: ArrayBuffer | Uint8Array | Buffer;
@@ -75,12 +167,22 @@ interface SaveAIVideoResult {
 }
 
 /**
+ * Report a save failure: log redacted to console.error and return a
+ * redacted-error result. The unredacted version goes nowhere unless
+ * debug mode is enabled.
+ */
+function fail(error: string): SaveAIVideoResult {
+	const redacted = redactPath(error);
+	console.error("AI Video Save Error:", redacted);
+	return { success: false, error: redacted };
+}
+
+/**
  * Save AI-generated video to permanent project storage
  * This is MANDATORY - if save fails, the entire operation must fail
  *
  * @param options - Save options including file data and project info
  * @returns Result object with local path or error
- * @throws Error if save fails - NO FALLBACKS ALLOWED
  */
 export async function saveAIVideoToDisk(
 	options: SaveAIVideoOptions
@@ -97,52 +199,39 @@ export async function saveAIVideoToDisk(
 		} else if (fileData instanceof Uint8Array) {
 			buffer = Buffer.from(fileData);
 		} else {
-			const error =
-				"Invalid file data type - must be Buffer, ArrayBuffer, or Uint8Array";
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			return fail(
+				"Invalid file data type - must be Buffer, ArrayBuffer, or Uint8Array"
+			);
 		}
 
 		// Validate file size
 		if (buffer.length > MAX_VIDEO_SIZE) {
 			const sizeInMB = (buffer.length / 1024 / 1024).toFixed(2);
-			const error = `Video file too large: ${sizeInMB}MB exceeds ${MAX_VIDEO_SIZE / 1024 / 1024 / 1024}GB limit`;
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			return fail(
+				`Video file too large: ${sizeInMB}MB exceeds ${MAX_VIDEO_SIZE / 1024 / 1024 / 1024}GB limit`
+			);
 		}
 
 		// Validate buffer is not empty
 		if (buffer.length === 0) {
-			const error = "Video file is empty - cannot save";
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			return fail("Video file is empty - cannot save");
 		}
 
-		// Create project-specific video directory (Documents-based)
+		// Resolve target directory.
 		const projectDir = getAIVideoDir(projectId);
 		console.log(
 			`[AI Video Save] Saving to projectDir: ${projectDir} (projectId="${projectId}")`
 		);
 
-		// Ensure directory exists with proper permissions
+		// Ensure the FULL project tree exists (not just the leaf videos folder).
+		// This funnels through the same code path as `project-folder:ensure-structure`
+		// so a future required folder added there is automatically created here too.
 		try {
-			await fs.promises.mkdir(projectDir, { recursive: true, mode: 0o755 });
-		} catch (mkdirError: any) {
-			const error = `Failed to create project directory: ${mkdirError.message}`;
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			await ensureProjectStructure(projectId);
+		} catch (ensureError: any) {
+			return fail(
+				`Failed to ensure project directory: ${ensureError?.message ?? String(ensureError)}`
+			);
 		}
 
 		// Generate unique filename with metadata
@@ -168,28 +257,22 @@ export async function saveAIVideoToDisk(
 			if (availableSpace < requiredSpace) {
 				const availableMB = (availableSpace / 1024 / 1024).toFixed(2);
 				const requiredMB = (requiredSpace / 1024 / 1024).toFixed(2);
-				const error = `Insufficient disk space: ${availableMB}MB available, ${requiredMB}MB required`;
-				console.error("AI Video Save Error:", error);
-				return {
-					success: false,
-					error,
-				};
+				return fail(
+					`Insufficient disk space: ${availableMB}MB available, ${requiredMB}MB required`
+				);
 			}
-		} catch (statfsError) {
+		} catch {
 			// statfs might not be available on all systems, continue anyway
 			console.warn("Could not check disk space, proceeding with save");
 		}
 
-		// Write file to disk - THIS MUST SUCCEED
+		// Write file to disk via the stat-guard + ENOENT-retry helper.
 		try {
-			await fs.promises.writeFile(filePath, buffer, { mode: 0o644 });
+			await writeFileWithStatGuard(filePath, projectDir, buffer, projectId);
 		} catch (writeError: any) {
-			const error = `Failed to write video file to disk: ${writeError.message}`;
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			return fail(
+				`Failed to write video file to disk: ${writeError?.message ?? String(writeError)}`
+			);
 		}
 
 		// Verify the file was written correctly
@@ -198,20 +281,14 @@ export async function saveAIVideoToDisk(
 			if (stats.size !== buffer.length) {
 				// File size mismatch - delete corrupted file
 				await fs.promises.unlink(filePath).catch(() => {});
-				const error = `File verification failed: size mismatch (expected ${buffer.length}, got ${stats.size})`;
-				console.error("AI Video Save Error:", error);
-				return {
-					success: false,
-					error,
-				};
+				return fail(
+					`File verification failed: size mismatch (expected ${buffer.length}, got ${stats.size})`
+				);
 			}
 		} catch (verifyError: any) {
-			const error = `Failed to verify saved file: ${verifyError.message}`;
-			console.error("AI Video Save Error:", error);
-			return {
-				success: false,
-				error,
-			};
+			return fail(
+				`Failed to verify saved file: ${verifyError?.message ?? String(verifyError)}`
+			);
 		}
 
 		// Save metadata file alongside video (optional, non-critical)
@@ -248,12 +325,9 @@ export async function saveAIVideoToDisk(
 			fileSize: buffer.length,
 		};
 	} catch (unexpectedError: any) {
-		const error = `Unexpected error saving AI video: ${unexpectedError.message}`;
-		console.error("AI Video Save CRITICAL ERROR:", error);
-		return {
-			success: false,
-			error,
-		};
+		return fail(
+			`Unexpected error saving AI video: ${unexpectedError?.message ?? String(unexpectedError)}`
+		);
 	}
 }
 

--- a/qcut/electron/ai-video-save-handler.ts
+++ b/qcut/electron/ai-video-save-handler.ts
@@ -31,7 +31,6 @@ import {
 	getProjectRoot,
 	getProjectsBasePath,
 	isExistingDirectory,
-	sanitizePathComponent,
 } from "./lib/project-structure";
 
 const MAX_VIDEO_SIZE = 5 * 1024 * 1024 * 1024; // 5GB limit for AI videos
@@ -80,20 +79,21 @@ export function sanitizeFilename(filename: string): string {
 /**
  * Get the Documents-based AI video directory for a project.
  * Path: Documents/QCut/Projects/{projectId}/media/generated/videos/
+ *
+ * Routes through `getProjectRoot` so an invalid `projectId` (empty after
+ * sanitization, or one that resolves to the projects base directory like
+ * `"."` / `"..."`) throws here instead of silently producing a path that
+ * targets the shared base.
  */
 export function getAIVideoDir(projectId: string): string {
-	const sanitized = sanitizePathComponent(projectId);
 	const dir = path.join(
-		getProjectsBasePath(),
-		sanitized,
+		getProjectRoot(projectId),
 		"media",
 		"generated",
 		"videos"
 	);
 	console.log(
-		redactPath(
-			`[AI Video Path] getAIVideoDir("${projectId}") → ${dir} (sanitized="${sanitized}")`
-		)
+		redactPath(`[AI Video Path] getAIVideoDir("${projectId}") → ${dir}`)
 	);
 	return dir;
 }
@@ -496,7 +496,20 @@ export async function migrateAIVideosToDocuments(): Promise<MigrationResult> {
 		}
 
 		result.projectsProcessed++;
-		const destDir = getAIVideoDir(projectName);
+
+		// Resolve destination — `getAIVideoDir` now throws for project names
+		// that sanitize to empty / `.` / would collapse to the Projects base
+		// (e.g. legacy folders named `..` or `.`). Skip those rather than
+		// migrating to the wrong directory.
+		let destDir: string;
+		try {
+			destDir = getAIVideoDir(projectName);
+		} catch (err) {
+			result.errors.push(
+				`Skipping legacy project ${JSON.stringify(projectName)}: invalid project ID after sanitization (${err instanceof Error ? err.message : String(err)})`
+			);
+			continue;
+		}
 
 		// Ensure destination exists
 		try {

--- a/qcut/electron/ai-video-save-handler.ts
+++ b/qcut/electron/ai-video-save-handler.ts
@@ -13,11 +13,13 @@
  *   3. A single `ENOENT` retry covers the TOCTOU race where the directory
  *      disappears between `stat` and `writeFile`.
  *
- * Path-redaction policy: error strings returned over IPC and emitted via
- * `console.error` are redacted in packaged builds (`<project>/...` instead of
- * the absolute Documents path) so customer bug reports do not leak local
- * filesystem layout. Dev breadcrumbs (`console.log`) are intentionally NOT
- * redacted — they only run when a developer launches `bun run electron:dev`.
+ * Path-redaction policy: every log message that would contain an absolute
+ * filesystem path — both `console.error` for failures and the `console.log`
+ * breadcrumbs from getAIVideoDir, save, and migration — is funneled through
+ * `redactPath()`. In packaged builds (`!app.isPackaged`) the absolute
+ * Documents path is replaced with `<project>` before reaching stdout/log
+ * capture; in dev (`bun run electron:dev`) or with `QCUT_DEBUG_PATHS=1` the
+ * full path is preserved for debugging.
  */
 
 import * as path from "path";
@@ -26,6 +28,7 @@ import { app, ipcMain } from "electron";
 import { randomBytes } from "crypto";
 import {
 	ensureProjectStructure,
+	getProjectRoot,
 	getProjectsBasePath,
 	isExistingDirectory,
 	sanitizePathComponent,
@@ -88,7 +91,9 @@ export function getAIVideoDir(projectId: string): string {
 		"videos"
 	);
 	console.log(
-		`[AI Video Path] getAIVideoDir("${projectId}") → ${dir} (sanitized="${sanitized}")`
+		redactPath(
+			`[AI Video Path] getAIVideoDir("${projectId}") → ${dir} (sanitized="${sanitized}")`
+		)
 	);
 	return dir;
 }
@@ -220,7 +225,9 @@ export async function saveAIVideoToDisk(
 		// Resolve target directory.
 		const projectDir = getAIVideoDir(projectId);
 		console.log(
-			`[AI Video Save] Saving to projectDir: ${projectDir} (projectId="${projectId}")`
+			redactPath(
+				`[AI Video Save] Saving to projectDir: ${projectDir} (projectId="${projectId}")`
+			)
 		);
 
 		// Ensure the FULL project tree exists (not just the leaf videos folder).
@@ -315,7 +322,9 @@ export async function saveAIVideoToDisk(
 		}
 
 		console.log(
-			`✅ AI Video saved successfully to disk: ${filePath} (${(buffer.length / 1024 / 1024).toFixed(2)}MB)`
+			redactPath(
+				`✅ AI Video saved successfully to disk: ${filePath} (${(buffer.length / 1024 / 1024).toFixed(2)}MB)`
+			)
 		);
 
 		return {
@@ -414,7 +423,9 @@ export function registerAIVideoHandlers(): void {
 		"ai-video:get-project-dir",
 		async (event, projectId: string): Promise<string> => {
 			const dir = getAIVideoDir(projectId);
-			console.log(`[AI Video IPC] get-project-dir("${projectId}") → ${dir}`);
+			console.log(
+				redactPath(`[AI Video IPC] get-project-dir("${projectId}") → ${dir}`)
+			);
 			return dir;
 		}
 	);
@@ -446,9 +457,11 @@ export async function migrateAIVideosToDocuments(): Promise<MigrationResult> {
 	};
 
 	const legacyRoot = path.join(app.getPath("userData"), "projects");
-	console.log(`[AI Video Migration] Legacy root: ${legacyRoot}`);
+	console.log(redactPath(`[AI Video Migration] Legacy root: ${legacyRoot}`));
 	console.log(
-		`[AI Video Migration] Documents base: ${app.getPath("documents")}`
+		redactPath(
+			`[AI Video Migration] Documents base: ${app.getPath("documents")}`
+		)
 	);
 
 	// Early return if no legacy directory

--- a/qcut/electron/lib/project-structure.ts
+++ b/qcut/electron/lib/project-structure.ts
@@ -65,10 +65,19 @@ export function getProjectsBasePath(): string {
 
 /**
  * Sanitize a single path component to prevent path traversal.
- * Strips path separators and parent-directory references.
+ *
+ * Strips path separators and any run of two-or-more dots. The two-or-more
+ * pattern (rather than just `..`) is required because a non-greedy single-pass
+ * `replace(/\.\./g, "")` of an odd-length dot run like `"..."` leaves a
+ * residual `"."` — and `path.join(base, ".")` collapses to `base` itself,
+ * which would defeat project isolation. `"\.{2,}"` consumes the entire run.
+ *
+ * A lone single dot survives (it's a legal filename char), but is rejected
+ * downstream by `getProjectRoot` (see the `path.join(...) === basePath`
+ * guard).
  */
 export function sanitizePathComponent(component: string): string {
-	return component.replace(/[/\\]/g, "").replace(/\.\./g, "");
+	return component.replace(/[/\\]/g, "").replace(/\.{2,}/g, "");
 }
 
 /**
@@ -92,10 +101,14 @@ export function validatePathWithinBase(
 
 /**
  * Resolve the absolute project root for a given project ID.
- * Validates against path traversal and rejects IDs that sanitize to empty —
- * inputs like `""`, `"/"`, `"\\"`, or `".."` would otherwise resolve to the
- * shared projects base directory and let writes from one project bleed into
- * another (or into the base itself).
+ *
+ * Defends against three classes of bad input:
+ *   1. Sanitized to empty (`""`, `"/"`, `"\\"`, `".."`, `"...."`) — explicit reject.
+ *   2. Sanitized to `"."` or any value that `path.join` collapses back to the
+ *      projects base — explicit reject so writes from one project cannot
+ *      bleed into the base directory.
+ *   3. Path traversal that escapes the base after `path.join` — caught by
+ *      `validatePathWithinBase`.
  */
 export function getProjectRoot(projectId: string): string {
 	const sanitizedProjectId = sanitizePathComponent(projectId);
@@ -106,6 +119,11 @@ export function getProjectRoot(projectId: string): string {
 	}
 	const basePath = getProjectsBasePath();
 	const projectRoot = path.join(basePath, sanitizedProjectId);
+	if (path.resolve(projectRoot) === path.resolve(basePath)) {
+		throw new Error(
+			`Invalid projectId: ${JSON.stringify(projectId)} resolves to the projects base directory`
+		);
+	}
 	validatePathWithinBase(projectRoot, basePath);
 	return projectRoot;
 }

--- a/qcut/electron/lib/project-structure.ts
+++ b/qcut/electron/lib/project-structure.ts
@@ -1,0 +1,158 @@
+/**
+ * Project Structure
+ *
+ * Shared helpers for resolving and ensuring the QCut project folder layout
+ * under the user's Documents directory.
+ *
+ * Owned by this module so that every code path that writes into a project
+ * (project-folder-handler, ai-video-save-handler, future image/audio writers)
+ * agrees on the same structure and the same sanitization rules. If you add a
+ * new required folder, add it here only — every consumer picks it up
+ * automatically.
+ *
+ * @module electron/lib/project-structure
+ */
+
+import { app } from "electron";
+import * as fs from "fs";
+import * as path from "path";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Folders that must exist under every project root for QCut to function.
+ * Order matters only for log readability — `mkdir({ recursive: true })` will
+ * create any intermediate parents.
+ */
+export const REQUIRED_PROJECT_FOLDERS = [
+	"media",
+	"media/imported",
+	"media/generated",
+	"media/generated/images",
+	"media/generated/videos",
+	"media/generated/audio",
+	"media/temp",
+	"output",
+	"cache",
+] as const;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface EnsureStructureResult {
+	/** Folders that were just created by this call. */
+	created: string[];
+	/** Folders that already existed. */
+	existing: string[];
+	/** Absolute path to the project root that was ensured. */
+	projectRoot: string;
+}
+
+// ============================================================================
+// Path utilities
+// ============================================================================
+
+/**
+ * Resolve the QCut projects base path: Documents/QCut/Projects.
+ */
+export function getProjectsBasePath(): string {
+	const documentsPath = app.getPath("documents");
+	return path.join(documentsPath, "QCut", "Projects");
+}
+
+/**
+ * Sanitize a single path component to prevent path traversal.
+ * Strips path separators and parent-directory references.
+ */
+export function sanitizePathComponent(component: string): string {
+	return component.replace(/[/\\]/g, "").replace(/\.\./g, "");
+}
+
+/**
+ * Validate that a resolved path stays within the allowed base directory.
+ * @throws Error if path traversal is detected.
+ */
+export function validatePathWithinBase(
+	resolvedPath: string,
+	basePath: string
+): void {
+	const normalizedResolved = path.resolve(resolvedPath);
+	const normalizedBase = path.resolve(basePath);
+
+	if (
+		!normalizedResolved.startsWith(normalizedBase + path.sep) &&
+		normalizedResolved !== normalizedBase
+	) {
+		throw new Error("Path traversal attempt detected");
+	}
+}
+
+/**
+ * Resolve the absolute project root for a given project ID.
+ * Validates against path traversal.
+ */
+export function getProjectRoot(projectId: string): string {
+	const sanitizedProjectId = sanitizePathComponent(projectId);
+	const basePath = getProjectsBasePath();
+	const projectRoot = path.join(basePath, sanitizedProjectId);
+	validatePathWithinBase(projectRoot, basePath);
+	return projectRoot;
+}
+
+// ============================================================================
+// Ensure structure
+// ============================================================================
+
+/**
+ * Ensure the full QCut project folder tree exists under
+ * `Documents/QCut/Projects/<sanitized projectId>/`.
+ *
+ * Idempotent and safe under concurrent calls (`mkdir({ recursive: true })`
+ * tolerates `EEXIST`). Per-folder failures are collected, not thrown — the
+ * function always resolves so callers can decide how to react.
+ */
+export async function ensureProjectStructure(
+	projectId: string
+): Promise<EnsureStructureResult> {
+	const projectRoot = getProjectRoot(projectId);
+	const created: string[] = [];
+	const existing: string[] = [];
+
+	for (const folder of REQUIRED_PROJECT_FOLDERS) {
+		const folderPath = path.join(projectRoot, folder);
+		try {
+			await fs.promises.access(folderPath);
+			existing.push(folder);
+		} catch {
+			try {
+				await fs.promises.mkdir(folderPath, { recursive: true });
+				created.push(folder);
+			} catch {
+				// Per-folder failure is collected by omission; caller can
+				// re-stat the leaf they actually need (e.g. saveAIVideoToDisk)
+				// to decide whether to continue.
+			}
+		}
+	}
+
+	return { created, existing, projectRoot };
+}
+
+/**
+ * Return true iff the path exists AND is a directory. Never throws.
+ *
+ * Intended as a pre-write guard for cloud-synced (OneDrive/iCloud) Documents
+ * folders, where a `mkdir` can succeed but the entry is a placeholder that
+ * the next `writeFile` rejects with `ENOENT` until rehydration completes.
+ */
+export async function isExistingDirectory(p: string): Promise<boolean> {
+	try {
+		const stats = await fs.promises.stat(p);
+		return stats.isDirectory();
+	} catch {
+		return false;
+	}
+}

--- a/qcut/electron/lib/project-structure.ts
+++ b/qcut/electron/lib/project-structure.ts
@@ -149,18 +149,34 @@ export async function ensureProjectStructure(
 
 	for (const folder of REQUIRED_PROJECT_FOLDERS) {
 		const folderPath = path.join(projectRoot, folder);
+		// Classify with `stat().isDirectory()` rather than `access()` so a
+		// stray file occupying a required folder's path doesn't get
+		// silently marked as "existing" — that misclassification would
+		// cause the next mkdir-then-write call to fail with ENOTDIR with
+		// no chance for the caller to recover.
+		let stats: import("fs").Stats | undefined;
 		try {
-			await fs.promises.access(folderPath);
-			existing.push(folder);
+			stats = await fs.promises.stat(folderPath);
 		} catch {
-			try {
-				await fs.promises.mkdir(folderPath, { recursive: true });
-				created.push(folder);
-			} catch {
-				// Per-folder failure is collected by omission; caller can
-				// re-stat the leaf they actually need (e.g. saveAIVideoToDisk)
-				// to decide whether to continue.
-			}
+			stats = undefined;
+		}
+
+		if (stats?.isDirectory()) {
+			existing.push(folder);
+			continue;
+		}
+
+		// Either the path is missing OR a non-directory occupies it.
+		// `mkdir({ recursive: true })` will throw EEXIST/ENOTDIR for the
+		// occupied case, which we collect-by-omission so callers can
+		// surface the real conflict.
+		try {
+			await fs.promises.mkdir(folderPath, { recursive: true });
+			created.push(folder);
+		} catch {
+			// Per-folder failure is collected by omission; caller can
+			// re-stat the leaf they actually need (e.g. saveAIVideoToDisk)
+			// to decide whether to continue.
 		}
 	}
 

--- a/qcut/electron/lib/project-structure.ts
+++ b/qcut/electron/lib/project-structure.ts
@@ -92,10 +92,18 @@ export function validatePathWithinBase(
 
 /**
  * Resolve the absolute project root for a given project ID.
- * Validates against path traversal.
+ * Validates against path traversal and rejects IDs that sanitize to empty —
+ * inputs like `""`, `"/"`, `"\\"`, or `".."` would otherwise resolve to the
+ * shared projects base directory and let writes from one project bleed into
+ * another (or into the base itself).
  */
 export function getProjectRoot(projectId: string): string {
 	const sanitizedProjectId = sanitizePathComponent(projectId);
+	if (sanitizedProjectId === "") {
+		throw new Error(
+			`Invalid projectId: ${JSON.stringify(projectId)} sanitizes to an empty path segment`
+		);
+	}
 	const basePath = getProjectsBasePath();
 	const projectRoot = path.join(basePath, sanitizedProjectId);
 	validatePathWithinBase(projectRoot, basePath);

--- a/qcut/electron/project-folder-handler.ts
+++ b/qcut/electron/project-folder-handler.ts
@@ -7,9 +7,15 @@
  * @module electron/project-folder-handler
  */
 
-import { ipcMain, app } from "electron";
+import { ipcMain } from "electron";
 import * as fs from "fs/promises";
 import * as path from "path";
+import {
+	ensureProjectStructure,
+	getProjectsBasePath,
+	sanitizePathComponent,
+	validatePathWithinBase,
+} from "./lib/project-structure";
 
 // ============================================================================
 // Types
@@ -104,54 +110,9 @@ const MEDIA_EXTENSIONS: Record<string, string[]> = {
 	image: [".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".svg"],
 };
 
-/** Required project folder structure */
-const REQUIRED_FOLDERS = [
-	"media",
-	"media/imported",
-	"media/generated",
-	"media/generated/images",
-	"media/generated/videos",
-	"media/generated/audio",
-	"media/temp",
-	"output",
-	"cache",
-];
-
 // ============================================================================
 // Path Utilities
 // ============================================================================
-
-/**
- * Get the base path for QCut projects in the user's Documents folder.
- */
-function getProjectsBasePath(): string {
-	const documentsPath = app.getPath("documents");
-	return path.join(documentsPath, "QCut", "Projects");
-}
-
-/**
- * Sanitize a path component to prevent path traversal attacks.
- * Removes path separators and parent directory references.
- */
-function sanitizePathComponent(component: string): string {
-	return component.replace(/[/\\]/g, "").replace(/\.\./g, "");
-}
-
-/**
- * Validate that a resolved path stays within the allowed base directory.
- * @throws Error if path traversal is detected
- */
-function validatePathWithinBase(resolvedPath: string, basePath: string): void {
-	const normalizedResolved = path.resolve(resolvedPath);
-	const normalizedBase = path.resolve(basePath);
-
-	if (
-		!normalizedResolved.startsWith(normalizedBase + path.sep) &&
-		normalizedResolved !== normalizedBase
-	) {
-		throw new Error("Path traversal attempt detected");
-	}
-}
 
 /**
  * Determine media type from file extension.
@@ -365,44 +326,19 @@ export function setupProjectFolderIPC(): void {
 	);
 
 	// -------------------------------------------------------------------------
-	// Ensure project folder structure exists
+	// Ensure project folder structure exists.
+	// Delegates to the shared `ensureProjectStructure` so the AI video save
+	// path and any future writers agree on REQUIRED_PROJECT_FOLDERS.
 	// -------------------------------------------------------------------------
 	ipcMain.handle(
 		"project-folder:ensure-structure",
 		async (_, projectId: string): Promise<EnsureStructureResult> => {
-			const sanitizedProjectId = sanitizePathComponent(projectId);
-			const basePath = getProjectsBasePath();
-			const projectRoot = path.join(basePath, sanitizedProjectId);
-
-			validatePathWithinBase(projectRoot, basePath);
-
-			log.info(`${LOG_PREFIX} Ensuring structure for: ${sanitizedProjectId}`);
-
-			const created: string[] = [];
-			const existing: string[] = [];
-
-			for (const folder of REQUIRED_FOLDERS) {
-				const folderPath = path.join(projectRoot, folder);
-
-				try {
-					await fs.access(folderPath);
-					existing.push(folder);
-				} catch {
-					try {
-						await fs.mkdir(folderPath, { recursive: true });
-						created.push(folder);
-						log.info(`${LOG_PREFIX} Created folder: ${folder}`);
-					} catch (mkdirError) {
-						log.error(`${LOG_PREFIX} Failed to create ${folder}:`, mkdirError);
-					}
-				}
-			}
-
+			log.info(`${LOG_PREFIX} Ensuring structure for: ${projectId}`);
+			const ensured = await ensureProjectStructure(projectId);
 			log.info(
-				`${LOG_PREFIX} Structure ensured: ${created.length} created, ${existing.length} existing`
+				`${LOG_PREFIX} Structure ensured: ${ensured.created.length} created, ${ensured.existing.length} existing`
 			);
-
-			return { created, existing };
+			return { created: ensured.created, existing: ensured.existing };
 		}
 	);
 


### PR DESCRIPTION
## Summary

This branch bundles two streams of Windows-focused desktop release work.

### #289 — Code signing roadmap
- Pivoted Windows signing approach to **Certum SimplySign** (removed Azure Trusted Signing and SignPath as fallbacks).
- Added macOS code signing task plan alongside the Windows plan.
- Corrected SSL.com eSigner pricing analysis to dual-cost (~$439–479/yr).
- Added Chinese translations of the plan, README, certificate options, and the implementation/testing/documentation guides.

### #290 — AI video save `ENOENT` on cloud-synced project folders
Customer machines (Windows + OneDrive-synced `Documents`) hit `ENOENT` writing generated `.mp4` files because the Documents directory is a cloud placeholder when `mkdir` returns success but `writeFile` runs against the not-yet-rehydrated entry.

- **NEW** `electron/lib/project-structure.ts` — shared `REQUIRED_PROJECT_FOLDERS`, `ensureProjectStructure`, `isExistingDirectory`, `sanitizePathComponent`, `validatePathWithinBase`. Both the AI video save path and `project-folder:ensure-structure` IPC now go through this single source of truth.
- `electron/ai-video-save-handler.ts` — replaced ad-hoc leaf `mkdir` with `ensureProjectStructure(projectId)`. Added `writeFileWithStatGuard`: pre-write `stat` check + single `ENOENT` retry. Added `redactPath` gated by `app.isPackaged` / `QCUT_DEBUG_PATHS=1` so error strings returned to the UI **and** emitted via `console.error` no longer leak local paths in packaged builds.
- `electron/project-folder-handler.ts` — removed inline structure constants, delegates to `ensureProjectStructure`. Shrunk 418 → 353 lines, behavior unchanged.
- 22 new tests (15 in `project-structure.test.ts`, 7 in `ai-video-save-handler.test.ts`) + 1 expectation update in the existing migration test for the stricter project-ID sanitizer.
- Plan: `docs/task/ai-video-save-enoent-fix/plan.md`.

## Test plan
- [x] `bunx vitest run electron/__tests__/` — 1383 passed, 14 skipped
- [x] `bunx vitest run electron/__tests__/project-structure.test.ts electron/__tests__/ai-video-save-handler.test.ts electron/__tests__/ai-video-migration.test.ts` — 39/39 passed
- [x] `bun run build` — clean (only pre-existing chunk-size warnings)
- [x] `bunx tsc --noEmit -p tsconfig.json` — no errors in touched files
- [ ] **Manual** (requires Windows + OneDrive-synced `Documents`): trigger an AI video generation, confirm save succeeds end-to-end and no absolute path appears in the toast on a packaged build
- [ ] **Manual** (macOS): smoke-test that AI video generation still saves under `~/Documents/QCut/Projects/<id>/media/generated/videos/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/quriosity-agent/qcut/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable AI video saving: pre-write directory guard, single ENOENT retry, stronger project-folder sanitization, redacted error paths in packaged builds, and migration now skips invalid legacy projects.

* **Refactor**
  * Centralized project-folder helpers to a shared module; save handler and IPC now use shared structure enforcement.

* **Documentation**
  * Comprehensive macOS and Windows code‑signing guides, plans, procurement, implementation, testing, and Chinese translations.

* **Tests**
  * New unit tests for AI video saving, project-structure helpers, and API-key shadowing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->