### PR TITLE
wip(ipad-v6): scaffold next round of iPad CLI work

### DIFF
--- a/qcut/docs/task/ipad-v6/plan.md
+++ b/qcut/docs/task/ipad-v6/plan.md
@@ -1,0 +1,47 @@
+# iPad v6 — scope TBD
+
+**Status**: 🟡 Draft — scope not yet defined
+**Branch**: `ipad-v6`
+**PR**: opens against `master`
+
+This branch was created on 2026-04-26 as a working space for the next round
+of iPad-related work, building on top of the now-complete CLI automation
+infrastructure (see [`docs/task/platform/ios-cli-automation.md`](../platform/ios-cli-automation.md)).
+
+## Setup verified (2026-04-26)
+
+- Device: Donghao's iPad (2), iPad Air 13-inch (M2), iPadOS 26.3.1
+- App: `com.qcut.videoeditor` reinstalled via `xcrun devicectl` after re-trust
+- CLI: `qcut://state` round-trip via `xcrun devicectl device process launch
+  --payload-url` confirmed to return JSON with all 6 stores attached.
+- Build pipeline: `bunx @capacitor/cli@8 sync ios` → `xcodebuild` →
+  `devicectl install`. (`@capacitor/cli` is not in `package.json` —
+  invoked via `npx -y @capacitor/cli@8` as a one-off; consider pinning if
+  this branch needs repeatable CI builds.)
+
+## Candidate workstreams (pick one or more)
+
+The reference doc flagged two unfinished items at the bottom — either is a
+sensible scope for this PR:
+
+1. **Console-bridge user-agent detection** — `apps/web/src/lib/debug/ios-console-bridge.ts`
+   currently keys on `navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1`.
+   The doc's "Remaining Work" notes that `__qcutLogs` is **not capturing on
+   physical iPad** in the current build. Investigate whether the Capacitor
+   WebView reports a different platform string and adjust the gate so
+   `qcut://console` returns the captured ring buffer on real hardware.
+
+2. **End-to-end `import-and-export` on physical device** — the
+   `qcut://cli.import-and-export` command exists but the doc says it has
+   "not yet [been] verified on physical device". Run it, capture failures,
+   add the missing pieces (e.g. file-picker autoclick, share-sheet
+   handling), and tick off Task 7's Files-app integration on a real iPad.
+
+3. **Something else entirely** — fill in here once the scope is decided.
+
+## Non-goals
+
+- No Swift CLI changes that would re-touch `QCutViewController.swift` —
+  it was just verified end-to-end and shouldn't be churned without reason.
+- No Xcode project file changes (`project.pbxproj`) — keep the PR
+  diff readable.

--- a/qcut/docs/task/ipad-v6/plan.md
+++ b/qcut/docs/task/ipad-v6/plan.md
@@ -10,14 +10,22 @@ infrastructure (see [`docs/task/platform/ios-cli-automation.md`](../platform/ios
 
 ## Setup verified (2026-04-26)
 
-- Device: Donghao's iPad (2), iPad Air 13-inch (M2), iPadOS 26.3.1
+- Device: iPad Air 13-inch (M2), iPadOS 26.3.1
 - App: `com.qcut.videoeditor` reinstalled via `xcrun devicectl` after re-trust
 - CLI: `qcut://state` round-trip via `xcrun devicectl device process launch
   --payload-url` confirmed to return JSON with all 6 stores attached.
-- Build pipeline: `bunx @capacitor/cli@8 sync ios` → `xcodebuild` →
-  `devicectl install`. (`@capacitor/cli` is not in `package.json` —
-  invoked via `npx -y @capacitor/cli@8` as a one-off; consider pinning if
-  this branch needs repeatable CI builds.)
+- Build pipeline: `npx -y @capacitor/cli@8 sync ios` → `xcodebuild` →
+  `devicectl install`.
+
+> ⚠️ `@capacitor/cli` is not pinned in `apps/web/package.json` and `bunx`
+> currently fails to resolve it (`could not determine executable to run for
+> package cap`), so the sync step has to fall back to `npx -y
+> @capacitor/cli@8` as a one-off. **This is a real gap, not a stylistic one
+> — without pinning, every contributor running this branch is exposed to
+> whatever Capacitor 8.x patch ships next.** A small follow-up should
+> `bun add -d @capacitor/cli@<exact-version>` (matching the iOS-side
+> `capacitor-swift-pm 8.2.0`) and then standardize the docs on `bunx`
+> across the board.
 
 ## Candidate workstreams (pick one or more)
 

--- a/qcut/docs/task/platform/ios-cli-automation.md
+++ b/qcut/docs/task/platform/ios-cli-automation.md
@@ -59,10 +59,10 @@ fps         → 55 FPS (164 frames/3.0s)                        PASS
 ```
 
 ### Re-verified on Physical iPad (2026-04-26)
-Device: Donghao's iPad (2), iPad Air 13-inch (M2) — `F044472A-68A8-53DA-8BC9-8DE828B714E8`
-After a fresh `bunx @capacitor/cli sync ios` + Xcode rebuild + reinstall (free dev cert
-expired since the March verification, required re-trusting `zdhpeter@gmail.com` on the
-device under Settings → General → VPN & Device Management):
+Device: iPad Air 13-inch (M2), iPadOS 26.3.1.
+After a fresh Capacitor sync + Xcode rebuild + reinstall (free dev cert
+expired since the March verification, required re-trusting the developer Apple ID
+on the device under Settings → General → VPN & Device Management):
 ```
 state → { route: "", tracks: 1, elements: 0, project: null,         PASS
           panel: { activeTab: "media", aiActiveTab: "text" },

--- a/qcut/docs/task/platform/ios-cli-automation.md
+++ b/qcut/docs/task/platform/ios-cli-automation.md
@@ -58,6 +58,20 @@ console     → No logs captured yet                             PASS
 fps         → 55 FPS (164 frames/3.0s)                        PASS
 ```
 
+### Re-verified on Physical iPad (2026-04-26)
+Device: Donghao's iPad (2), iPad Air 13-inch (M2) — `F044472A-68A8-53DA-8BC9-8DE828B714E8`
+After a fresh `bunx @capacitor/cli sync ios` + Xcode rebuild + reinstall (free dev cert
+expired since the March verification, required re-trusting `zdhpeter@gmail.com` on the
+device under Settings → General → VPN & Device Management):
+```
+state → { route: "", tracks: 1, elements: 0, project: null,         PASS
+          panel: { activeTab: "media", aiActiveTab: "text" },
+          panelView: "export",
+          export: { isExporting: false, settings: { quality: "1080p", format: "webm" } } }
+```
+Note: the project store reported empty on launch (no project auto-opened); subsequent
+`open-editor` is needed to load a project before `tracks`/`elements` populate.
+
 ---
 
 ## Implementation Plan


### PR DESCRIPTION
## Status: Draft — scope TBD

Working branch for the next round of iPad-related work, opened so it can
collect commits as the scope is decided.

## What landed in this commit
- Re-verified `qcut://state` round-trip on Donghao's iPad Air 13-inch (M2),
  iPadOS 26.3.1 — captured the result + the now-required dev-cert
  re-trust step in [\`docs/task/platform/ios-cli-automation.md\`](docs/task/platform/ios-cli-automation.md).
- Stubbed [\`docs/task/ipad-v6/plan.md\`](docs/task/ipad-v6/plan.md) as the
  per-branch task plan; pre-lists two concrete workstreams from the
  reference doc's "Remaining Work" section.

## Candidate scope (pick when ready)
1. Fix \`__qcutLogs\` not capturing on physical iPad — UA detection in
   \`apps/web/src/lib/debug/ios-console-bridge.ts\` likely needs Capacitor-WebView
   awareness.
2. Verify \`cli.import-and-export\` E2E on the physical device, fill in
   anything missing (file picker, share sheet, Files-app handoff).
3. Something else.

## Out of scope (for this PR)
- Swift CLI changes (\`QCutViewController.swift\` was just re-verified end-to-end).
- Xcode project file changes.

## Test plan
- [x] \`bunx vitest run\` locally — no app code changed yet, so existing suites pass.
- [ ] Once scope (1) or (2) lands, add the corresponding test plan items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning documentation for iPad v6 branch, including setup verification records for physical devices, known tooling constraints, and candidate investigation workstreams.
  * Updated iOS CLI automation documentation with physical device verification entry, including setup procedures and documented runtime state behavior on real hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->