### PR TITLE
ci(release): skip release job on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,9 +298,10 @@ jobs:
             !qcut/dist-electron/builder-debug.yml
           if-no-files-found: error
 
-  # Create release with all artifacts
+  # Create release with all artifacts (only on tag pushes, never on workflow_dispatch)
   release:
     needs: [prepare, build-windows, build-macos, build-linux]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ vars.USE_BLACKSMITH == 'true' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary
- The Release workflow header documents that `workflow_dispatch` should run the three platform builds only and **skip** the GitHub Release publish step.
- In practice the `release:` job had no `if:` guard, so a manual dispatch failed with `GitHub Releases requires a tag` (run [25622628145](https://github.com/Quriosity-agent/qcut/actions/runs/25622628145/job/75212665657)).
- Add `if: startsWith(github.ref, 'refs/tags/v')` so the publish step runs only on real tag pushes.

## Test plan
- [ ] Re-dispatch Release on `master` after merge → all three build jobs succeed, `release` job is skipped (not failed)
- [ ] Next tag push (`v*`) still publishes a GitHub Release as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to execute only when version tags are pushed, preventing unintended releases from manual workflows or non-tag commits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Quriosity-agent/qcut/pull/299)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->