### PR TITLE
[codex] Fix Daytona CLI YouTube artifacts

### DIFF
--- a/qcut/.gitignore
+++ b/qcut/.gitignore
@@ -138,6 +138,7 @@ tmp/
 playwright-report/
 playwright/.cache/
 /.playwright-mcp/
+output/playwright/
 docs/completed/test-results/
 docs/completed/test-results-raw/
 docs/completed/e2e-videos/

--- a/qcut/Dockerfile.cli
+++ b/qcut/Dockerfile.cli
@@ -31,6 +31,8 @@ FROM oven/bun:1.3.10-debian
 ARG QCUT_VERSION=dev
 ARG CODEX_CLI_VERSION=0.130.0
 ARG CLAUDE_CODE_VERSION=2.1.142
+ARG DENO_VERSION=2.7.4
+ARG YT_DLP_VERSION=2026.3.17
 ENV QCUT_VERSION=${QCUT_VERSION}
 
 # System deps: FFmpeg is the heaviest qcut runtime requirement; Node/npm
@@ -45,9 +47,30 @@ RUN apt-get update \
       openssh-client \
       nodejs \
       npm \
+      python3 \
+      python3-pip \
+      unzip \
  && npm install -g --omit=dev --no-audit --no-fund \
       "@openai/codex@${CODEX_CLI_VERSION}" \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+ && python3 -m pip install --no-cache-dir --break-system-packages \
+      "yt-dlp==${YT_DLP_VERSION}" \
+ && deno_arch="$(dpkg --print-architecture)" \
+ && case "${deno_arch}" in \
+      amd64) deno_target="x86_64-unknown-linux-gnu" ;; \
+      arm64) deno_target="aarch64-unknown-linux-gnu" ;; \
+      *) echo "unsupported deno architecture: ${deno_arch}" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL \
+      "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-${deno_target}.zip" \
+      -o /tmp/deno.zip \
+ && unzip -q /tmp/deno.zip -d /usr/local/bin \
+ && chmod 0755 /usr/local/bin/deno \
+ && printf '%s\n' \
+      '--remote-components' \
+      'ejs:github' \
+    > /etc/yt-dlp.conf \
+ && rm -f /tmp/deno.zip \
  && npm cache clean --force \
  && rm -rf /root/.npm \
  && rm -rf /var/lib/apt/lists/*

--- a/qcut/bun.lock
+++ b/qcut/bun.lock
@@ -237,6 +237,7 @@
       "name": "@qcut/license-server",
       "version": "0.0.1",
       "dependencies": {
+        "@daytona/sdk": "^0.175.0",
         "@noble/hashes": "^1.8.0",
         "@qcut/auth": "workspace:*",
         "@qcut/db": "workspace:*",
@@ -280,6 +281,7 @@
       "name": "@qcut/relay",
       "version": "0.0.1",
       "dependencies": {
+        "@daytona/sdk": "^0.175.0",
         "e2b": "^2.20.0",
         "jose": "^5.0.0",
       },

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
@@ -1,0 +1,340 @@
+# PR 10 — Agent Session Mode (Implementation Plan)
+
+> **Phase**: 3 · **Depends on**: PR 03 (schema baseline), PR 04 (agent worker), PR 05 (Daytona devcontainer) · **Estimated LOC**: ~650 across schema + license-server + worker + website
+
+This file is the step-by-step plan for shipping the persistent agent-session
+feature described in [`10-agent-session-mode.md`](10-agent-session-mode.md).
+That sibling file is the **spec** (data model, API shape, observed E2E
+results). This file is the **how-to-build-it** broken into subtasks, each ≤ 20
+minutes of focused work, each citing the file it touches.
+
+## Goal
+
+Make the website Chat Agent default to a persistent Daytona-backed Codex
+session: the same browser chat reuses one warm sandbox across many turns; the
+sandbox only goes away on idle timeout, hard TTL, or explicit "new session".
+
+Long-term properties we want this plan to preserve:
+
+- **Session ids are not capabilities** — every license-server route re-derives
+  the user from the auth token and verifies ownership by `user_id`. Stealing a
+  session id leaks nothing.
+- **The worker owns sandbox lifecycle.** License-server only mutates DB rows.
+  This keeps Daytona credentials in exactly one process and lets us swap
+  providers later without touching the website.
+- **One-shot jobs keep working unchanged.** A job without `sessionId` follows
+  the existing create / run / delete path. Sessions are purely additive.
+- **Artifacts stay job-scoped.** Only `/tmp/qcut-output` is uploaded per turn.
+  Everything else in the sandbox is the user's persistent workspace.
+
+## Files
+
+| Path | Action | Purpose |
+|------|--------|---------|
+| `packages/db/migrations/0006_agent_sessions.sql` | new | `agent_sessions` table + `agent_jobs.session_id` FK + indexes |
+| `packages/db/supabase/migrations/<ts>_agent_sessions.sql` | new | Same migration in Supabase CLI format for the prod project |
+| `packages/db/src/schema.ts` | modify | Drizzle definitions for `agent_sessions`, `session_id` column, supporting indexes |
+| `packages/license-server/src/routes/agent.ts` | modify | `POST /api/agent/sessions`, `POST /api/agent/sessions/:id/end`, `sessionId` handling in `POST /api/agent/jobs` |
+| `packages/license-server/src/routes/agent.test.ts` | modify | Route tests for create/reuse/end + job-with-session |
+| `packages/agent-worker/src/claim.ts` | modify | Load `session_id` row alongside the job |
+| `packages/agent-worker/src/run-on-daytona.ts` | modify | Reuse existing sandbox when session has `provider_session_id`; skip delete on session jobs |
+| `packages/agent-worker/src/main.ts` | modify | Idle / TTL cleanup loop |
+| `packages/agent-worker/src/run-on-daytona.test.ts` | modify | One-shot vs session sandbox lifecycle |
+| `packages/agent-worker/src/stream-events.test.ts` | modify | Per-job Codex prompt injection on reused sandbox |
+| `packages/agent-worker/src/cleanup.ts` | new (optional) | Extracted cleanup function for unit-testability |
+| `packages/agent-worker/src/cleanup.test.ts` | new | Idle/TTL/stopping cleanup paths |
+| `packages/nexusai-website/chat-agent.html` | modify | Session UI block, "New session" button |
+| `packages/nexusai-website/js/agent-chat.js` | modify | Session creation, `qcut_agent_session_id` storage, end-session call |
+| `packages/nexusai-website/js/agent-chat.test.js` | modify | Session lifecycle in the chat client |
+
+## Subtasks
+
+Each subtask is sized to fit one focused session. Mark them done as you land
+PR commits — a single PR can ship multiple subtasks, but each subtask is small
+enough that it can also stand alone behind a feature flag if needed.
+
+### Subtask 10.1 — Drizzle schema for `agent_sessions`
+
+Touches: `packages/db/src/schema.ts`.
+
+Add an `agent_sessions` table with columns matching the spec — `id`,
+`user_id`, `status` (enum `'active' | 'stopping' | 'ended' | 'error'`),
+`provider` (default `'daytona'`), `provider_session_id` (nullable),
+`image_tag`, `started_at`, `last_active_at`, `expires_at`, `ended_at`,
+`end_reason`, `runner_id`.
+
+Indexes (long-term cost control — the cleanup loop runs every 60s):
+
+- `agent_sessions_user_status_last_active_idx` on `(user_id, status, last_active_at desc)`
+- `agent_sessions_expires_active_idx` on `(expires_at)` with `status = 'active'` predicate
+
+Add nullable FK `agent_jobs.session_id → agent_sessions.id` with `on delete
+set null`. Add `agent_jobs_session_created_idx` on `(session_id, created_at
+desc)` so the per-session job feed stays cheap.
+
+Run `bunx drizzle-kit generate` from `packages/db/` to refresh the metadata
+snapshot.
+
+### Subtask 10.2 — SQL migration
+
+Touches: `packages/db/migrations/0006_agent_sessions.sql`,
+`packages/db/supabase/migrations/<ts>_agent_sessions.sql`.
+
+Write the migration by hand instead of relying purely on `drizzle-kit push`,
+because the same SQL ships to two paths:
+
+1. Local Drizzle migrations (used by tests + local Postgres).
+2. Supabase CLI migrations (applied via
+   `SUPABASE_ACCESS_TOKEN=… supabase db push` from `packages/db/`).
+
+Make the migration **idempotent and forward-only**: `create table if not
+exists`, `alter table … add column if not exists`, `create index if not
+exists`. Sessions cannot be dropped safely once the column exists in prod, so
+there is no down migration.
+
+### Subtask 10.3 — Session routes in license-server
+
+Touches: `packages/license-server/src/routes/agent.ts`.
+
+Add two new routes and extend one:
+
+- `POST /api/agent/sessions` — body `{ mode: "codex" }`. Inside a transaction:
+  pick the newest `active` session for the authenticated user where
+  `expires_at > now`; if none, insert a new one with `status='active'`,
+  `started_at=now`, `last_active_at=now`, `expires_at=now + 2h`. Return the
+  row.
+- `POST /api/agent/sessions/:sessionId/end` — load session, verify
+  `user_id == authedUser.id`, set `status='stopping'`,
+  `end_reason='user_kill'`. Worker performs the actual sandbox delete.
+- `POST /api/agent/jobs` — accept optional `sessionId`. When present: in a
+  transaction, verify the session belongs to the user and is `active`; bump
+  `last_active_at`; store `session_id` on the inserted job. Return `404` /
+  `409` on missing / inactive session instead of silently dropping.
+
+Long-term note: **never trust `sessionId` alone**. The transaction must always
+re-check `user_id`. This is the property unit tests in Subtask 10.4 will
+encode.
+
+### Subtask 10.4 — License-server route tests
+
+Touches: `packages/license-server/src/routes/agent.test.ts`.
+
+Cases to add:
+
+- `POST /api/agent/sessions` returns the same row on a second call within the
+  TTL window (reuse).
+- `POST /api/agent/sessions` issues a new row after the previous one expires.
+- `POST /api/agent/sessions/:id/end` for a session owned by another user
+  returns 404 (not 403 — do not leak existence).
+- `POST /api/agent/jobs` with `sessionId` from a different user returns 404
+  and does **not** insert a job row.
+- `POST /api/agent/jobs` with a valid `sessionId` bumps `last_active_at` and
+  stores `session_id` on the new job.
+
+Run: `bun --cwd packages/license-server test -- agent.test.ts`.
+
+### Subtask 10.5 — Worker claim loads session context
+
+Touches: `packages/agent-worker/src/claim.ts`.
+
+When a job claim succeeds, also fetch the linked `agent_sessions` row (single
+join or follow-up `select` — whichever the existing claim path prefers).
+Return a `{ job, session | null }` shape so downstream code does not need to
+re-query. Keep the no-session path identical to today.
+
+Also verify the session is still `active` at claim time. If a session went to
+`stopping` between job enqueue and claim, fail the job up-front with
+`session_inactive` rather than starting a sandbox we'll throw away.
+
+### Subtask 10.6 — Worker sandbox reuse
+
+Touches: `packages/agent-worker/src/run-on-daytona.ts`.
+
+Branching on `session` presence:
+
+- **No session**: existing path — create sandbox, run, upload, delete.
+- **With session**:
+  1. If `session.provider_session_id` is set, call `daytona.get(id)`. If it
+     returns a usable sandbox, reuse it. If Daytona says it's gone, fall
+     through to step 2.
+  2. Create a new sandbox with the session's `image_tag`. `UPDATE
+     agent_sessions SET provider_session_id = …, runner_id = $worker WHERE
+     id = $session_id AND provider_session_id IS NULL` — the conditional
+     write is what makes concurrent workers safe.
+  3. Inside the sandbox, clear `/tmp/qcut-output` before the command so
+     artifact uploads stay per-turn. Do **not** clear `/tmp/qcut-tools`,
+     `/home/qcut`, or the working directory.
+  4. Run `codex exec --skip-git-repo-check --json -` with the per-job prompt
+     piped on stdin. The prompt must come from the current job — never reuse
+     the previous job's prompt (see Subtask 10.10's test).
+  5. Upload `/tmp/qcut-output` artifacts.
+  6. **Skip the delete**. Update `last_active_at = now` on the session.
+  7. Emit an `agent_events` row with
+     `kind='agent_session_ready'`, payload `{ reused: boolean,
+     provider_session_id }`.
+
+### Subtask 10.7 — Cleanup loop
+
+Touches: `packages/agent-worker/src/main.ts`, optionally extract to
+`packages/agent-worker/src/cleanup.ts` so it can be unit-tested without
+spinning up the full worker loop.
+
+Every 60s:
+
+1. `SELECT id, provider_session_id, status FROM agent_sessions
+   WHERE status = 'active' AND (last_active_at < now - interval '20 minutes'
+   OR expires_at < now)
+   OR status = 'stopping'
+   LIMIT 50 FOR UPDATE SKIP LOCKED`.
+2. For each row: set `status='stopping'` (no-op if already), then
+   `daytona.delete(provider_session_id)` (best-effort; ignore 404).
+3. `UPDATE agent_sessions SET status='ended', ended_at=now,
+   end_reason=$reason WHERE id=$id`.
+4. Insert an `agent_events` row, `job_id=null`,
+   `kind='agent_session_ended'`, payload `{ reason }`.
+
+`FOR UPDATE SKIP LOCKED` is the long-term piece — it lets us run multiple
+workers without two of them fighting over the same cleanup row.
+
+### Subtask 10.8 — Worker tests: one-shot vs session
+
+Touches: `packages/agent-worker/src/run-on-daytona.test.ts`.
+
+Mock the Daytona client. Assert:
+
+- One-shot job (no `session_id`): `create` + `delete` both called exactly
+  once.
+- Session job, no `provider_session_id` yet: `create` called once, `delete`
+  not called, `agent_sessions.provider_session_id` is set after the call.
+- Session job, `provider_session_id` already set and Daytona returns the
+  sandbox: `create` not called, `delete` not called.
+- Session job, `provider_session_id` set but Daytona returns "gone":
+  `create` called once, `delete` not called, `provider_session_id` is
+  updated.
+
+### Subtask 10.9 — Worker tests: cleanup paths
+
+Touches: `packages/agent-worker/src/cleanup.test.ts` (new).
+
+Cases:
+
+- `active` session with `last_active_at` older than idle timeout → ends with
+  `idle_timeout`.
+- `active` session with `expires_at < now` → ends with `ttl`.
+- `stopping` session → ends with `user_kill`.
+- Daytona delete returns 404 → session still transitions to `ended` (no stuck
+  rows).
+
+### Subtask 10.10 — Stream-events test: per-job prompt isolation
+
+Touches: `packages/agent-worker/src/stream-events.test.ts`.
+
+This is the regression test for the most likely future bug: when a sandbox is
+reused, the Codex process must be invoked with **this job's** prompt, not the
+previous job's. Drive two synthetic jobs in the same session through the
+streamer and assert each Codex stdin contains exactly the current job's
+prompt.
+
+### Subtask 10.11 — Website session client
+
+Touches: `packages/nexusai-website/js/agent-chat.js`.
+
+- On first Codex send (no `qcut_agent_session_id` in `localStorage`):
+  `POST /api/agent/sessions` → store `session.id`.
+- Always pass `sessionId` in `POST /api/agent/jobs`.
+- On `agent_session_ended` SSE event with `reason !== 'user_kill'`, clear
+  `localStorage` and surface a toast — the next send will reopen a fresh
+  session.
+
+Keep image-gen mode untouched: it remains one-shot.
+
+### Subtask 10.12 — Website "New session" UI
+
+Touches: `packages/nexusai-website/chat-agent.html`,
+`packages/nexusai-website/js/agent-chat.js`.
+
+Add a header button that:
+
+1. Calls `POST /api/agent/sessions/<id>/end` (fire-and-forget; ignore 4xx).
+2. Removes `qcut_agent_session_id` from `localStorage`.
+3. Resets the in-page chat transcript.
+
+Visible session indicator: short `session.id.slice(0,8)` chip + idle countdown
+derived from `last_active_at + 20min` so the user can see why their context
+might be about to drop.
+
+### Subtask 10.13 — Website chat-client tests
+
+Touches: `packages/nexusai-website/js/agent-chat.test.js`.
+
+Cases:
+
+- First `send()` calls the sessions route and stores the id.
+- Second `send()` reuses the stored id and does **not** re-create.
+- Clicking "New session" calls the end route and clears storage.
+- `agent_session_ended` with `reason='idle_timeout'` clears storage and the
+  next `send()` creates a new session.
+
+Run: `node --test packages/nexusai-website/js/agent-chat.test.js`.
+
+### Subtask 10.14 — Verification matrix
+
+Run the same battery the production E2E in
+[`10-agent-session-mode.md`](10-agent-session-mode.md) ran:
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts stream-events.test.ts cleanup.test.ts
+bun --cwd packages/license-server test -- agent.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check \
+  packages/db/src/schema.ts \
+  packages/license-server/src/routes/agent.ts \
+  packages/license-server/src/routes/agent.test.ts \
+  packages/agent-worker/src/claim.ts \
+  packages/agent-worker/src/main.ts \
+  packages/agent-worker/src/run-on-daytona.ts \
+  packages/agent-worker/src/run-on-daytona.test.ts \
+  packages/agent-worker/src/stream-events.test.ts \
+  packages/nexusai-website/chat-agent.html
+```
+
+Manual E2E (after `supabase db push` and worker restart with the current
+`QCUT_IMAGE_TAG`):
+
+1. `POST /api/agent/sessions` from a logged-in browser → record `session.id`.
+2. Send a Codex job that writes `marker.txt` under `/tmp/qcut-tools/`.
+3. Send a second Codex job that reads `marker.txt` — it must succeed and
+   return the same value.
+4. Confirm two `agent_session_ready` events: first `reused=false`, second
+   `reused=true`, with the same `provider_session_id`.
+5. Click "New session" → confirm the `agent_session_ended` event with
+   `reason='user_kill'`, then re-send and confirm a new
+   `provider_session_id`.
+
+## Long-term considerations
+
+- **Migrations on Cloudflare Workers.** The temporary migration route used in
+  the 2026-05-15 deployment must not come back. Track the proper Supabase CLI
+  path in the follow-up list of [`10-agent-session-mode.md`](10-agent-session-mode.md).
+- **Cost ceiling.** Idle sandboxes cost money even when no one types. Defaults
+  (20 min idle, 2 h TTL) are intentionally tight. Any future "keep warm
+  longer" feature must come with a per-user credit policy — do not raise the
+  defaults globally.
+- **Provider abstraction.** `provider='daytona'` is a column on purpose. New
+  providers should be added by extending the enum + a worker dispatch, not by
+  replacing Daytona inline.
+- **Codex PTY follow-up.** The spec explicitly calls out PTY/daemon as a
+  separate PR. Do not sneak partial PTY work into this one; it needs its own
+  transport and backpressure design.
+
+## See also
+
+- [`10-agent-session-mode.md`](10-agent-session-mode.md) — spec + production
+  E2E results this plan derives from
+- [`06-sandbox-sessions-schema.md`](06-sandbox-sessions-schema.md) — earlier
+  session-schema work this builds on
+- [`04-agent-worker.md`](04-agent-worker.md) — worker baseline behavior the
+  session branch is added to
+- [`09-wzrd-terminal-ui.md`](09-wzrd-terminal-ui.md) — UI shape this plan
+  intentionally does **not** adopt (different surface, different consumer)

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
@@ -27,6 +27,57 @@ Long-term properties we want this plan to preserve:
 - **Artifacts stay job-scoped.** Only `/tmp/qcut-output` is uploaded per turn.
   Everything else in the sandbox is the user's persistent workspace.
 
+## Implementation Status - 2026-05-15
+
+Implemented and verified:
+
+- Subtasks 10.1-10.4: Drizzle schema, idempotent local SQL migration,
+  Supabase CLI migration copy, session routes, job `sessionId` handling, and
+  route tests.
+- Subtasks 10.6-10.9: Daytona sandbox reuse, persistent session sandbox
+  creation, replacement after a missing Daytona sandbox, idle cleanup, TTL
+  cleanup, user-kill cleanup, and missing-sandbox cleanup tests.
+- Subtasks 10.11-10.13: website session client, "New session" UI, artifact
+  download controls, final Codex message loading, live status polling, and
+  chat-client tests.
+- Follow-up UI tightening: the website page now supports only the persistent
+  Codex Chat Agent flow. Image and video requests should be handled inside
+  that chat, with uploaded outputs shown in the Artifacts panel.
+- Subtask 10.14: focused local tests plus real production license-server /
+  Daytona session reuse smoke.
+
+Implementation notes:
+
+- Cleanup remains in `packages/agent-worker/src/run-on-daytona.ts`; the
+  optional `cleanup.ts` extraction was not needed to make the behavior
+  testable.
+- The worker currently fetches the linked `agent_sessions` row in the Daytona
+  runner after `claim_one_agent_job` returns the job. The behavior still
+  verifies `user_id`, session `active` status, and TTL before using a sandbox.
+  A future RPC shape can join the row during claim if queue latency or an
+  extra Supabase round trip becomes measurable.
+- Production schema was already applied; the new Supabase migration file keeps
+  the repository aligned for future `supabase db push` runs.
+
+Latest verification:
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts claim.test.ts stream-events.test.ts
+bun --cwd packages/license-server test -- agent.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/license-server/src/routes/agent.test.ts
+```
+
+Live smoke:
+
+- Session `b6423733-cef4-4a94-b031-c06737d78d3b`.
+- Jobs `1f7c80da-5ff7-4201-9ffa-c6d59f1576af` and
+  `9020e69f-3606-48d1-ab2f-d92ae5da5807` both succeeded.
+- Both jobs used Daytona sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97`.
+- The second job read the marker from the first job and returned
+  `SECOND_PLAN_E2E_SAME_SANDBOX_plan-e2e-1778902437060`.
+
 ## Files
 
 | Path | Action | Purpose |
@@ -246,7 +297,9 @@ Touches: `packages/nexusai-website/js/agent-chat.js`.
   `localStorage` and surface a toast — the next send will reopen a fresh
   session.
 
-Keep image-gen mode untouched: it remains one-shot.
+The page no longer exposes a direct image-generation mode. Keep image and
+video requests inside the Codex chat path so all generated outputs use the
+same session and artifact panel.
 
 ### Subtask 10.12 — Website "New session" UI
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
@@ -379,7 +379,8 @@ Completed:
 - QCut relay supports `session_kind="agent"` tokens and creates a Daytona PTY
   for the existing agent sandbox.
 - The website uses xterm.js and sends the chat prompt as a visible
-  `codex exec --sandbox danger-full-access` command in the PTY.
+  `codex exec --dangerously-bypass-approvals-and-sandbox` command in the PTY,
+  so Codex does not stop for permission prompts inside Daytona.
 - Terminal artifacts are listed and downloaded directly from
   `/tmp/qcut-output` with session artifact endpoints.
 - Production Workers were deployed with shared `RELAY_SIGNING_SECRET` and

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.md
@@ -365,6 +365,39 @@ Manual E2E (after `supabase db push` and worker restart with the current
    `reason='user_kill'`, then re-send and confirm a new
    `provider_session_id`.
 
+## 2026-05-15 PTY Update
+
+The follow-up PTY work is now implemented in the same branch because the job
+event stream could not show real Codex messages while Codex was still running.
+`codex exec --json` emits the assistant text only at `item.completed`, so the
+website now uses a real terminal as the primary chat-agent surface.
+
+Completed:
+
+- License-server creates/reuses an `agent_sessions` Daytona sandbox and signs a
+  relay token from `POST /api/agent/sessions/:sessionId/pty-token`.
+- QCut relay supports `session_kind="agent"` tokens and creates a Daytona PTY
+  for the existing agent sandbox.
+- The website uses xterm.js and sends the chat prompt as a visible
+  `codex exec --sandbox danger-full-access` command in the PTY.
+- Terminal artifacts are listed and downloaded directly from
+  `/tmp/qcut-output` with session artifact endpoints.
+- Production Workers were deployed with shared `RELAY_SIGNING_SECRET` and
+  `DAYTONA_API_KEY`.
+
+Passing verification:
+
+```bash
+node --test packages/nexusai-website/js/agent-chat.test.js
+bun --cwd packages/license-server test -- src/routes/agent.test.ts src/services/payment-config.test.ts
+bun --cwd packages/qcut-relay test
+bun --cwd packages/agent-worker test
+bunx tsc -p packages/qcut-relay/tsconfig.json --noEmit
+```
+
+Live E2E evidence is recorded in
+[`10-agent-session-mode.md`](10-agent-session-mode.md#pty-terminal-mode---2026-05-15).
+
 ## Long-term considerations
 
 - **Migrations on Cloudflare Workers.** The temporary migration route used in
@@ -377,9 +410,9 @@ Manual E2E (after `supabase db push` and worker restart with the current
 - **Provider abstraction.** `provider='daytona'` is a column on purpose. New
   providers should be added by extending the enum + a worker dispatch, not by
   replacing Daytona inline.
-- **Codex PTY follow-up.** The spec explicitly calls out PTY/daemon as a
-  separate PR. Do not sneak partial PTY work into this one; it needs its own
-  transport and backpressure design.
+- **Codex process model.** The website now has a real PTY, but Send still uses
+  one `codex exec` per prompt. A future interactive Codex daemon can run inside
+  the same PTY if we need true process-level conversation state.
 
 ## See also
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode-plan.zh.md
@@ -1,0 +1,304 @@
+# PR 10 —— Agent Session Mode（实现计划）
+
+> **Phase**：3 · **依赖**：PR 03（库表基线）、PR 04（agent worker）、PR 05（Daytona devcontainer） · **工作量**：~650 行（schema + license-server + worker + 网站）
+
+本文件是把 [`10-agent-session-mode.md`](10-agent-session-mode.md) 里那份
+**规格说明**（数据模型、API、生产 E2E 结果）落成代码的**实施步骤**。
+每个子任务都按 ≤ 20 分钟一段拆好，并写明涉及的具体文件路径。
+
+## 目标
+
+让网站 Chat Agent 的默认模式跑在一个常驻的 Daytona Codex session 上：
+同一个浏览器对话复用同一个温热 sandbox，跨多轮对话；sandbox 只会因为
+空闲超时、硬 TTL、用户主动「新建会话」三种情况下被回收。
+
+这份计划需要长期守住的几条性质：
+
+- **session id 不是凭证**。license-server 每条路由都从 auth token 重新
+  推导出用户，并用 `user_id` 验证归属。光偷到 session id 拿不到任何东西。
+- **sandbox 生命周期由 worker 独占**。license-server 只改 DB 行，Daytona
+  credential 永远只在 worker 进程里。这样将来换供应商不用动网站。
+- **一发即焚的任务保持原样**。没有 `sessionId` 的 job 走旧路径，session
+  完全是增量加上来的。
+- **artifact 仍按 job 分隔**。每轮只上传 `/tmp/qcut-output`；sandbox 里其
+  它路径（包括 `/tmp/qcut-tools`、`/home/qcut`、工作目录）是用户的常驻
+  工作区，不动。
+
+## 涉及文件
+
+| 路径 | 动作 | 用途 |
+|------|------|------|
+| `packages/db/migrations/0006_agent_sessions.sql` | 新 | `agent_sessions` 表 + `agent_jobs.session_id` 外键 + 索引 |
+| `packages/db/supabase/migrations/<ts>_agent_sessions.sql` | 新 | 同一份 migration 的 Supabase CLI 版本（线上库用） |
+| `packages/db/src/schema.ts` | 改 | `agent_sessions`、`session_id` 列、配套索引的 Drizzle 定义 |
+| `packages/license-server/src/routes/agent.ts` | 改 | `POST /api/agent/sessions`、`POST /api/agent/sessions/:id/end`，`POST /api/agent/jobs` 加 `sessionId` |
+| `packages/license-server/src/routes/agent.test.ts` | 改 | session 创建/复用/结束 + 带 session 的 job 测试 |
+| `packages/agent-worker/src/claim.ts` | 改 | 认领 job 时同时加载 `session_id` 行 |
+| `packages/agent-worker/src/run-on-daytona.ts` | 改 | 有 `provider_session_id` 时复用 sandbox；session job 不在 job 结束后删 sandbox |
+| `packages/agent-worker/src/main.ts` | 改 | idle / TTL 清理循环 |
+| `packages/agent-worker/src/run-on-daytona.test.ts` | 改 | 一发即焚 vs session 两种 sandbox 生命周期 |
+| `packages/agent-worker/src/stream-events.test.ts` | 改 | sandbox 复用时 Codex prompt 按 job 注入（防回放旧 prompt） |
+| `packages/agent-worker/src/cleanup.ts` | 新（可选） | 把清理逻辑抽函数出来，方便单测 |
+| `packages/agent-worker/src/cleanup.test.ts` | 新 | idle / TTL / stopping 三条清理路径 |
+| `packages/nexusai-website/chat-agent.html` | 改 | session 状态 UI 块、「新建会话」按钮 |
+| `packages/nexusai-website/js/agent-chat.js` | 改 | session 创建、`qcut_agent_session_id` 存取、结束调用 |
+| `packages/nexusai-website/js/agent-chat.test.js` | 改 | 网页端 session 生命周期 |
+
+## 子任务
+
+每个子任务都按一次专注开发能干完的大小切分。每条都可以单独提 PR 上线
+（如果有 feature flag 就更稳）。
+
+### 子任务 10.1 —— Drizzle schema：`agent_sessions`
+
+涉及：`packages/db/src/schema.ts`。
+
+按规格加 `agent_sessions` 表：`id`、`user_id`、`status`（枚举
+`'active' | 'stopping' | 'ended' | 'error'`）、`provider`（默认 `'daytona'`）、
+`provider_session_id`（可空）、`image_tag`、`started_at`、`last_active_at`、
+`expires_at`、`ended_at`、`end_reason`、`runner_id`。
+
+索引（清理循环每 60s 跑一次，长期开销要扛住）：
+
+- `agent_sessions_user_status_last_active_idx`：`(user_id, status, last_active_at desc)`
+- `agent_sessions_expires_active_idx`：`(expires_at)`，带 `status = 'active'` 谓词
+
+`agent_jobs.session_id` 加上可空外键 → `agent_sessions.id`，`on delete set
+null`。再加 `agent_jobs_session_created_idx` on `(session_id, created_at
+desc)`，per-session 的 job feed 才便宜。
+
+在 `packages/db/` 下跑 `bunx drizzle-kit generate` 刷一下 metadata 快照。
+
+### 子任务 10.2 —— SQL migration
+
+涉及：`packages/db/migrations/0006_agent_sessions.sql`、
+`packages/db/supabase/migrations/<ts>_agent_sessions.sql`。
+
+不要纯靠 `drizzle-kit push`，因为同一份 SQL 要出两条路径：
+
+1. 本地 Drizzle migration（测试 + 本地 Postgres）。
+2. Supabase CLI migration（`SUPABASE_ACCESS_TOKEN=… supabase db push` 从
+   `packages/db/` 跑出去）。
+
+migration 要**幂等、单向**：`create table if not exists`、
+`alter table … add column if not exists`、`create index if not exists`。
+线上已经有这列之后不能安全下线，所以不写 down migration。
+
+### 子任务 10.3 —— license-server 的 session 路由
+
+涉及：`packages/license-server/src/routes/agent.ts`。
+
+加两条新路由，扩一条旧路由：
+
+- `POST /api/agent/sessions`：body `{ mode: "codex" }`。事务里：取当前
+  用户最新的 `active` 且 `expires_at > now` 的 session；没有就插一条新
+  行，`status='active'`、`started_at=now`、`last_active_at=now`、
+  `expires_at=now + 2h`。返回这一行。
+- `POST /api/agent/sessions/:sessionId/end`：取 session、校 `user_id ==
+  authedUser.id`，置 `status='stopping'`、`end_reason='user_kill'`。
+  真正的 sandbox 删除由 worker 完成。
+- `POST /api/agent/jobs`：接受可选 `sessionId`。给了就在事务里校验归属
+  + `active`、把 `last_active_at` 拍到 now、把 `session_id` 存到 job 上。
+  找不到 / 不 active 时返回 `404` / `409`，不要静默丢。
+
+长期注意：**永远不要单凭 `sessionId` 信任**。事务里必须重新校 `user_id`。
+这条性质 10.4 的单测会编码下来。
+
+### 子任务 10.4 —— license-server 路由测试
+
+涉及：`packages/license-server/src/routes/agent.test.ts`。
+
+要补的用例：
+
+- `POST /api/agent/sessions` 在 TTL 窗口内第二次调用返回同一行（复用）。
+- 上一条过期之后再调返回新行。
+- `POST /api/agent/sessions/:id/end` 对别人家的 session 返 404（不是 403
+  ——不暴露存在性）。
+- `POST /api/agent/jobs` 带别人家的 `sessionId` 返 404，并且**不**插入
+  job 行。
+- 合法 `sessionId` 会拍新 `last_active_at`，且 job 行落了 `session_id`。
+
+运行：`bun --cwd packages/license-server test -- agent.test.ts`。
+
+### 子任务 10.5 —— worker 认领时一起加载 session
+
+涉及：`packages/agent-worker/src/claim.ts`。
+
+认领成功后顺便取一次 `agent_sessions` 行（看现有 claim 代码选 join 还是
+跟一发 select）。返回 `{ job, session | null }` 结构，下游不再补查。
+没 session 的路径保持完全一致。
+
+另外认领瞬间再校一次 session 是不是还 `active`。如果中间被人翻成
+`stopping`，直接把 job 失败掉（`session_inactive`），别浪费一个 sandbox。
+
+### 子任务 10.6 —— worker sandbox 复用
+
+涉及：`packages/agent-worker/src/run-on-daytona.ts`。
+
+按 `session` 是否存在分叉：
+
+- **无 session**：维持现状——建、跑、上传、删。
+- **有 session**：
+  1. 若 `session.provider_session_id` 已存，先 `daytona.get(id)`；活的
+     就复用，Daytona 说没了就掉到第 2 步。
+  2. 用 `session.image_tag` 建新 sandbox。`UPDATE agent_sessions SET
+     provider_session_id = …, runner_id = $worker WHERE id = $session_id
+     AND provider_session_id IS NULL` —— 条件写是多 worker 安全的关键。
+  3. 进 sandbox 后先清 `/tmp/qcut-output`（artifact 才保持按 job 隔
+     离）。**不要**清 `/tmp/qcut-tools`、`/home/qcut`、工作目录。
+  4. 跑 `codex exec --skip-git-repo-check --json -`，stdin 注入**当前
+     job** 的 prompt——绝不能复用上一轮的（10.10 的测试会守住）。
+  5. 上传 `/tmp/qcut-output` artifact。
+  6. **跳过删除**。`UPDATE agent_sessions SET last_active_at = now`。
+  7. 写一行 `agent_events`，`kind='agent_session_ready'`，payload
+     `{ reused: boolean, provider_session_id }`。
+
+### 子任务 10.7 —— 清理循环
+
+涉及：`packages/agent-worker/src/main.ts`，可选抽到
+`packages/agent-worker/src/cleanup.ts`，单测才不用把整套 worker 拉起来。
+
+每 60s：
+
+1. `SELECT id, provider_session_id, status FROM agent_sessions
+   WHERE status = 'active' AND (last_active_at < now - interval '20 minutes'
+   OR expires_at < now)
+   OR status = 'stopping'
+   LIMIT 50 FOR UPDATE SKIP LOCKED`。
+2. 每一行：置 `status='stopping'`（已经是就 no-op），然后
+   `daytona.delete(provider_session_id)`（best-effort，404 忽略）。
+3. `UPDATE agent_sessions SET status='ended', ended_at=now,
+   end_reason=$reason WHERE id=$id`。
+4. 写一行 `agent_events`，`job_id=null`，`kind='agent_session_ended'`，
+   payload `{ reason }`。
+
+`FOR UPDATE SKIP LOCKED` 是长期性的那点 —— 多 worker 不会争同一行。
+
+### 子任务 10.8 —— worker 测试：一发即焚 vs session
+
+涉及：`packages/agent-worker/src/run-on-daytona.test.ts`。
+
+mock Daytona client，断言：
+
+- 一发即焚（无 `session_id`）：`create` + `delete` 各调一次。
+- session job 且 `provider_session_id` 还没有：`create` 调一次，`delete`
+  不调，调用结束后 `provider_session_id` 已落库。
+- session job 且 `provider_session_id` 已存、Daytona 返活的 sandbox：
+  `create` 不调，`delete` 不调。
+- session job 且 `provider_session_id` 已存、Daytona 返「没了」：
+  `create` 调一次，`delete` 不调，`provider_session_id` 被更新。
+
+### 子任务 10.9 —— worker 测试：清理路径
+
+涉及：`packages/agent-worker/src/cleanup.test.ts`（新）。
+
+用例：
+
+- `active` + `last_active_at` 早于 idle 阈值 → 标 `idle_timeout`。
+- `active` + `expires_at < now` → 标 `ttl`。
+- `stopping` → 标 `user_kill`。
+- Daytona delete 返 404 → session 仍能进 `ended`（不会卡住）。
+
+### 子任务 10.10 —— stream-events 测试：每 job 独立 prompt
+
+涉及：`packages/agent-worker/src/stream-events.test.ts`。
+
+这是「最可能将来踩坑」的回归测试：sandbox 复用时，Codex 进程要拿**这次
+的** prompt，不是上次的。构造同一个 session 上的两个合成 job 走 streamer，
+断言两次进 Codex stdin 的内容都正好是各自的当前 prompt。
+
+### 子任务 10.11 —— 网页端 session 客户端
+
+涉及：`packages/nexusai-website/js/agent-chat.js`。
+
+- 第一次 Codex 发送（`localStorage` 没 `qcut_agent_session_id`）：
+  `POST /api/agent/sessions` → 存 `session.id`。
+- 每次 `POST /api/agent/jobs` 都带 `sessionId`。
+- 收到 `agent_session_ended` SSE，`reason !== 'user_kill'` 时清
+  `localStorage`、弹个 toast 提示「下条消息会开新会话」。
+
+图生模式不动，继续一发即焚。
+
+### 子任务 10.12 —— 「新建会话」UI
+
+涉及：`packages/nexusai-website/chat-agent.html`、
+`packages/nexusai-website/js/agent-chat.js`。
+
+header 上加按钮：
+
+1. 调 `POST /api/agent/sessions/<id>/end`（发完不等结果，4xx 忽略）。
+2. 删 `qcut_agent_session_id`。
+3. 清空页面对话记录。
+
+session 状态指示：`session.id.slice(0,8)` 短码 + 一个由 `last_active_at +
+20min` 算出来的倒计时，让用户能看见上下文什么时候会丢。
+
+### 子任务 10.13 —— 网页端测试
+
+涉及：`packages/nexusai-website/js/agent-chat.test.js`。
+
+用例：
+
+- 第一次 `send()` 调 sessions 路由、把 id 落到 localStorage。
+- 第二次 `send()` 复用已有 id，**不**再调 sessions 路由。
+- 点「新建会话」调 end 路由、清 localStorage。
+- 收到 `agent_session_ended` 且 `reason='idle_timeout'`：清 localStorage，
+  下次 `send()` 会新建。
+
+运行：`node --test packages/nexusai-website/js/agent-chat.test.js`。
+
+### 子任务 10.14 —— 验证矩阵
+
+把 [`10-agent-session-mode.md`](10-agent-session-mode.md) 那次生产 E2E
+跑过的命令全跑一遍：
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts stream-events.test.ts cleanup.test.ts
+bun --cwd packages/license-server test -- agent.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check \
+  packages/db/src/schema.ts \
+  packages/license-server/src/routes/agent.ts \
+  packages/license-server/src/routes/agent.test.ts \
+  packages/agent-worker/src/claim.ts \
+  packages/agent-worker/src/main.ts \
+  packages/agent-worker/src/run-on-daytona.ts \
+  packages/agent-worker/src/run-on-daytona.test.ts \
+  packages/agent-worker/src/stream-events.test.ts \
+  packages/nexusai-website/chat-agent.html
+```
+
+手动 E2E（先 `supabase db push`、再用当前 `QCUT_IMAGE_TAG` 重启 worker）：
+
+1. 浏览器登录后 `POST /api/agent/sessions`，记下 `session.id`。
+2. 让 Codex 写一个 `marker.txt` 到 `/tmp/qcut-tools/`。
+3. 再发一条让 Codex 读 `marker.txt`，得能读到上一轮的值。
+4. 两条 `agent_session_ready` 事件：第一条 `reused=false`、第二条
+   `reused=true`，`provider_session_id` 相同。
+5. 点「新建会话」→ 看到 `agent_session_ended` 且 `reason='user_kill'`，
+   下条消息会出新的 `provider_session_id`。
+
+## 长期注意点
+
+- **Cloudflare Worker 跑 migration**。2026-05-15 那次上线临时挂的 migration
+  路由不能再回来。正经的 Supabase CLI 路径放在
+  [`10-agent-session-mode.md`](10-agent-session-mode.md) 的 follow-up 里跟。
+- **成本上限**。idle 中的 sandbox 即使没人打字也烧钱。默认值（idle 20 min、
+  TTL 2 h）刻意调紧。将来要做「让会话更久」必须配上 per-user 额度策略，
+  不要全局放宽默认。
+- **provider 抽象**。`provider='daytona'` 这一列是有意留的。将来加新供应
+  商靠扩枚举 + worker dispatch，不要把 Daytona 调用换成内联实现。
+- **Codex PTY 续作**。规格里明说 PTY/daemon 是另一个 PR。不要把半成品 PTY
+  逻辑塞进这一份；它需要自己的传输 + backpressure 设计。
+
+## 参见
+
+- [`10-agent-session-mode.md`](10-agent-session-mode.md) —— 本计划对应的
+  规格 + 生产 E2E 结果
+- [`06-sandbox-sessions-schema.md`](06-sandbox-sessions-schema.md) —— 早期
+  的 session schema 工作
+- [`04-agent-worker.md`](04-agent-worker.md) —— session 分支基于的 worker
+  基线
+- [`09-wzrd-terminal-ui.md`](09-wzrd-terminal-ui.md) —— UI 形态参考（不同
+  消费端，本计划**不**沿用）

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -501,12 +501,72 @@ Follow-up permission fix:
   prompts while the process is already running inside a disposable Daytona
   sandbox.
 
+Default connection follow-up:
+
+- The website now auto-connects the Daytona PTY after Chat Agent page
+  initialization. Users no longer need to click Connect before sending a Codex
+  prompt.
+- Local browser verification saved
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-autoconnect-local.png`
+  and confirmed the terminal reached `connected` on page load.
+
+## Terminal Artifact Download Fix - 2026-05-16
+
+Problem found in production:
+
+- Downloading artifacts from the PTY session route failed with
+  `"Buffer" is not supported: Module "buffer" is not available in the
+  "serverless" runtime`.
+- The root cause was Daytona SDK `sandbox.fs.downloadFile()` converting the
+  multipart response through Node `Buffer`, which Cloudflare Workers do not
+  provide.
+
+Implemented fix:
+
+- Added `packages/license-server/src/services/daytona-download.ts` to call
+  Daytona's lower-level `downloadFiles` API with `responseType: "arraybuffer"`.
+- Parses the multipart response with `Uint8Array`, `TextEncoder`, and
+  `TextDecoder` only; no Node `Buffer` or `require("buffer")` is used.
+- Updated the PTY terminal artifact route to return the parsed binary bytes
+  with `Content-Length`, `Content-Type`, and attachment disposition.
+- Added dedicated service tests for multipart file extraction, multipart error
+  parts, and raw non-multipart fallback.
+
+Verification:
+
+```bash
+bun --cwd packages/license-server test src/routes/agent.test.ts src/services/daytona-download.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc --noEmit --strict --moduleResolution bundler --module ESNext --target ES2022 --typeRoots /tmp/qcut-empty-types packages/license-server/src/services/daytona-download.ts
+```
+
+Result:
+
+- License-server focused tests: 27 passed.
+- Website chat client tests: 18 passed.
+- Focused service typecheck passed.
+- Full license-server typecheck is still blocked by existing unrelated
+  workspace issues: missing implicit `sharp` types and duplicate Drizzle
+  versions.
+
+Production E2E after deploying `qcut-license-server` and `qcut-relay`:
+
+| Step | Evidence |
+| --- | --- |
+| Session | `c4b059cc-d8c2-480d-8c8a-0dd07950b45d` |
+| Daytona sandbox | `960e6ecc-a2ea-4e00-9f9a-70c283ece3c9` |
+| Relay/PTY | WebSocket opened against deployed `qcut-relay` |
+| Artifact created | `/tmp/qcut-output/download-check.txt` |
+| Artifact list | returned `download-check.txt` |
+| Download route | returned `qcut artifact download ok` from the deployed license-server |
+
 ## Follow-ups
 
 - Decide whether to keep `codex exec` per Send or graduate to a long-lived
   interactive Codex process inside the PTY.
-- Stream large terminal artifact downloads through object storage instead of
-  buffering Daytona `fs.downloadFile` in the Worker.
+- For very large terminal artifacts, consider streaming or uploading through
+  object storage instead of buffering the Daytona multipart response in the
+  Worker.
 - User-visible "session will expire soon" countdown.
 - Per-session credit policy if idle warm sandboxes become costly.
 - Add a normal migration-runner path so production schema changes do not need a

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -298,6 +298,52 @@ local production-shaped worker:
 | Persistence proof | second job read the marker written by the first job and returned `SECOND_PLAN_E2E_SAME_SANDBOX_plan-e2e-1778902437060` from `codex-last-message.md` |
 | Artifact evidence | both jobs uploaded `codex-events.jsonl`, `qcut-exit.json`, `qcut-output.tar`, and `codex-last-message.md` |
 
+## Live Website E2E - 2026-05-15
+
+Production fix before the passing run:
+
+- The live license-server was creating new sessions with `image_tag='qcut-cli'`,
+  which Daytona could not pull in the cloud and produced create/start
+  timeouts.
+- Set `QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
+  in `packages/license-server/wrangler.toml` and redeployed the Cloudflare
+  Worker.
+- Increased the worker Daytona create/start timeout from 120 seconds to 300
+  seconds so first-use image pulls have enough headroom.
+
+Focused tests after the fix:
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bun --cwd packages/license-server test -- agent.test.ts
+bunx biome check packages/license-server/wrangler.toml packages/license-server/src/routes/agent.ts
+```
+
+Live UI run at `https://quriosity.com.au/chat-agent.html`:
+
+| Step | Evidence |
+| --- | --- |
+| Run id | `ui-e2e-1778904289442` |
+| Session | `2676fb3f-daed-45c3-b4c2-9be072ac2992` |
+| Sandbox | `8a7b6295-fbbf-4545-a339-ae43fbaccb36` |
+| Turn 1 job | `30d42eae-352e-4185-b524-1264918e9a4e` succeeded |
+| Turn 1 reply | `TURN1_OK_ui-e2e-1778904289442` |
+| Turn 2 job | `811dec1b-43ab-4684-b8af-e49e59c98642` succeeded |
+| Turn 2 reply | `TURN2_OK_SAME_CONVERSATION_ui-e2e-1778904289442` |
+| Turn 2 continuity proof | job prompt included the first user/assistant turn, and `agent_session_ready.reused=true` with the same sandbox |
+| Video job | `f60d3e6e-2b6d-4c48-bb94-61856b76b05c` succeeded |
+| Video artifact | `e2e-video-ui-e2e-1778904289442.mp4`, kind `video`, 40,239 bytes |
+| Download verification | artifact download endpoint returned `200`, `Content-Type: video/mp4`, `Content-Disposition: attachment; filename="e2e-video-ui-e2e-1778904289442.mp4"`, MP4 `ftyp` signature |
+
+Screenshots:
+
+- Before: `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-before.png`
+- After turn 1: `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-after-turn1.png`
+- After turn 2: `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-after-turn2.png`
+- After video artifacts:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-after-video-artifacts.png`
+
 ## Follow-ups
 
 - Persistent Codex PTY/daemon process inside the same sandbox.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -198,11 +198,53 @@ Known verification gap:
   before checking these changes because the workspace is missing the implicit
   `sharp` type definition.
 
+## Production E2E - 2026-05-15
+
+Deployment and migration:
+
+- Applied the production Supabase schema for `agent_sessions` and
+  `agent_jobs.session_id`.
+- Redeployed `qcut-license-server` to Cloudflare Workers.
+- Verified the temporary migration route was removed after use; the route now
+  returns `404`.
+- Restarted the production-shaped `qcut-agent-worker` tmux worker from the
+  current `qcut-cli-v2` checkout with
+  `QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`.
+- Verified `https://quriosity.com.au/chat-agent.html` and
+  `https://quriosity.com.au/js/agent-chat.js` include the session UI and
+  session API client code.
+
+Real session reuse test:
+
+| Step | Evidence |
+| --- | --- |
+| Create/reuse session | `b6423733-cef4-4a94-b031-c06737d78d3b` |
+| First Codex job | `970686e6-19d5-4d91-aded-dc227d01b7ae` succeeded |
+| First job behavior | Codex wrote `session-e2e-1778901412` into `/tmp/qcut-tools/session-e2e/marker.txt` |
+| First sandbox event | `agent_session_ready.reused=false`, sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97` |
+| Second Codex job | `2f488dd9-ba75-4cec-875f-ce03d6dc54d0` succeeded |
+| Second job behavior | Codex read the marker left by the first job and replied `SECOND_OK_SAME_SANDBOX_session-e2e-1778901412` |
+| Second sandbox event | `agent_session_ready.reused=true`, same sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97` |
+
+Live website test:
+
+| Step | Evidence |
+| --- | --- |
+| Website URL | `https://quriosity.com.au/chat-agent.html` |
+| UI-created Codex job | `ec2e282d-7a3a-4e9a-9a26-6c552601f19d` succeeded |
+| UI session | `b6423733-cef4-4a94-b031-c06737d78d3b` |
+| UI sandbox event | `agent_session_ready.reused=true`, sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97` |
+| UI Codex response | `WEBSITE_CODEX_SESSION_UI_OK` |
+
+Screenshot:
+
+- `/Users/peter/Desktop/code/qcut/qcut/output/playwright/live-chat-agent-session-e2e.png`
+
 ## Follow-ups
 
 - Persistent Codex PTY/daemon process inside the same sandbox.
 - Session artifact browser that can show prior job artifacts within a chat.
 - User-visible "session will expire soon" countdown.
 - Per-session credit policy if idle warm sandboxes become costly.
-- Apply `packages/db/migrations/0006_agent_sessions.sql` to production
-  Supabase before deploying the license-server/worker session routes.
+- Add a normal migration-runner path so production schema changes do not need a
+  one-off Cloudflare route when the Supabase CLI lacks the DB password.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -158,8 +158,9 @@ Chat Agent default Codex mode uses a session:
   - clears localStorage
   - creates a fresh session on next send
 
-Image-generation mode can stay one-shot for now. It does not need persistent
-Codex context.
+The website surface is intentionally Chat Agent only. Image and video requests
+go through Codex in the persistent sandbox; when the worker uploads files from
+`/tmp/qcut-output`, they appear in the Artifacts panel.
 
 ## Tests
 
@@ -168,27 +169,38 @@ Implemented coverage:
 - License-server:
   - creates/reuses active sessions
   - marks an owned session as `stopping`
+  - returns `404` when ending another user's session
   - rejects jobs with a missing/inactive session
+  - rejects jobs with another user's session id without inserting a row
   - stores `sessionId` on jobs
 - Agent worker:
   - one-shot jobs keep the old create/run/delete behavior
+  - new session jobs create a persistent sandbox with the session row's
+    `image_tag`
   - session jobs reuse `provider_session_id`
+  - session jobs replace a missing Daytona sandbox and keep the replacement
+    alive
   - session jobs do not delete the sandbox after job finish
-  - idle cleanup deletes sandbox and marks session ended
+  - idle, TTL, user-kill, and missing-sandbox cleanup paths mark sessions
+    ended
   - Codex prompt is injected per job so reused sandboxes do not replay an old
     prompt
 - Website:
   - creates a session through the license-server route
   - passes `sessionId` into Codex job creation
   - stores and clears `qcut_agent_session_id`
+  - posts to the session end route for the "New session" flow
+  - keeps the page as a single Chat Agent flow with no direct image-mode
+    selector
 
 Verified locally:
 
 ```bash
-bun --cwd packages/agent-worker test -- run-on-daytona.test.ts stream-events.test.ts
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts claim.test.ts stream-events.test.ts
 bun --cwd packages/license-server test -- agent.test.ts
 node --test packages/nexusai-website/js/agent-chat.test.js
 bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/license-server/src/routes/agent.test.ts
 bunx biome check packages/db/src/schema.ts packages/license-server/src/routes/agent.ts packages/license-server/src/routes/agent.test.ts packages/agent-worker/src/claim.ts packages/agent-worker/src/main.ts packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/agent-worker/src/stream-events.test.ts packages/nexusai-website/chat-agent.html
 ```
 
@@ -239,6 +251,52 @@ Live website test:
 Screenshot:
 
 - `/Users/peter/Desktop/code/qcut/qcut/output/playwright/live-chat-agent-session-e2e.png`
+
+## Additional Verification - 2026-05-15
+
+Implementation follow-up:
+
+- Added the Supabase CLI migration copy at
+  `packages/db/supabase/migrations/20260516000000_agent_sessions.sql`.
+- Fixed the Daytona worker so a newly created session sandbox uses
+  `agent_sessions.image_tag`, not only the worker process default.
+- Removed the website image-mode selector so the page only submits persistent
+  Codex chat jobs. Image/video outputs are expected to appear through the
+  existing Artifacts panel after upload.
+- Expanded tests for session ownership, new persistent sandbox creation,
+  replacement after Daytona says the previous sandbox is gone, TTL cleanup,
+  user-kill cleanup, missing-sandbox cleanup, and website end-session requests.
+
+Focused test run:
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts claim.test.ts stream-events.test.ts
+bun --cwd packages/license-server test -- agent.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/license-server/src/routes/agent.test.ts
+```
+
+Result:
+
+- Agent worker: 27 tests passed.
+- License server: 21 tests passed.
+- Website chat client: 14 tests passed.
+- Agent worker typecheck passed.
+- Focused Biome check passed.
+
+Real session reuse smoke against the production license-server and current
+local production-shaped worker:
+
+| Step | Evidence |
+| --- | --- |
+| Run id | `plan-e2e-1778902437060` |
+| Session | `b6423733-cef4-4a94-b031-c06737d78d3b` |
+| First Codex job | `1f7c80da-5ff7-4201-9ffa-c6d59f1576af` succeeded |
+| Second Codex job | `9020e69f-3606-48d1-ab2f-d92ae5da5807` succeeded |
+| Sandbox reuse | both jobs used sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97` |
+| Persistence proof | second job read the marker written by the first job and returned `SECOND_PLAN_E2E_SAME_SANDBOX_plan-e2e-1778902437060` from `codex-last-message.md` |
+| Artifact evidence | both jobs uploaded `codex-events.jsonl`, `qcut-exit.json`, `qcut-output.tar`, and `codex-last-message.md` |
 
 ## Follow-ups
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -431,8 +431,10 @@ Implemented fix:
   - `GET /api/agent/sessions/:sessionId/artifacts`
   - `GET /api/agent/sessions/:sessionId/artifacts/:filename/download`
 - Updated `chat-agent.html` to use xterm.js as the primary interface. The Send
-  button now writes a `codex exec --sandbox danger-full-access` command into the
-  live PTY, so the user sees real shell/Codex output in the terminal.
+  button now writes a
+  `codex exec --dangerously-bypass-approvals-and-sandbox` command into the live
+  PTY, so the user sees real shell/Codex output in the terminal without Codex
+  stopping for permission prompts inside the already isolated Daytona sandbox.
 - Fixed CORS for local website E2E by allowlisting `http://localhost:4177` and
   `http://127.0.0.1:4177`.
 - Fixed relay stdin handling: non-resize string WebSocket messages are terminal
@@ -491,6 +493,13 @@ Screenshots:
   `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-send-codex-artifact-visible.png`
 - Production page after website push:
   `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-production-pty-artifacts.png`
+
+Follow-up permission fix:
+
+- Updated both website PTY Send and agent-worker Codex jobs to start Codex with
+  `--dangerously-bypass-approvals-and-sandbox`. This avoids hanging on approval
+  prompts while the process is already running inside a disposable Daytona
+  sandbox.
 
 ## Follow-ups
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -344,10 +344,160 @@ Screenshots:
 - After video artifacts:
   `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-after-video-artifacts.png`
 
+## Live Stdout Streaming Fix - 2026-05-15
+
+Problem found during UI verification:
+
+- The page streamed Daytona/Codex lifecycle events while a job was running, but
+  shell stdout from Codex command executions only appeared later inside
+  `item.completed.aggregated_output`.
+- That made the UI feel idle during long-running commands such as `yt-dlp`,
+  `ffmpeg`, and QCut generation jobs.
+
+Implemented fix:
+
+- Added `codex-live-stdout.log` as a Daytona stream source for Codex jobs.
+  The worker polls it with the same cursor-based stream loop used for
+  `codex-events.jsonl`.
+- Updated the Codex sandbox instructions to tell long-running shell commands to
+  stream user-visible stdout with:
+
+```bash
+tee -a /tmp/qcut-output/codex-live-stdout.log
+```
+
+- Added `codex_stdout` events for live stdout rows so the website pending Codex
+  message and Events panel can show command progress while the job is still
+  `running`.
+- Split fallback `aggregated_output` from `codex-events.jsonl` into
+  `codex_stdout` rows when no live line was seen, so older/non-tee commands still
+  expose their stdout cleanly after Codex emits the completed event.
+- Added de-dupe so rows already streamed from `codex-live-stdout.log` are not
+  repeated again from final `aggregated_output`.
+
+Focused tests:
+
+```bash
+bun --cwd packages/agent-worker test -- stream-events.test.ts run-on-daytona.test.ts
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx biome check packages/agent-worker/src/stream-events.ts packages/agent-worker/src/stream-events.test.ts packages/agent-worker/src/run-container.ts packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts
+```
+
+Result:
+
+- Agent worker: 27 tests passed.
+- Website chat client: 14 tests passed.
+- Agent worker typecheck passed.
+- Focused Biome check passed.
+
+Live UI verification against `https://quriosity.com.au/chat-agent.html` with the
+local production-shaped worker restarted from this branch:
+
+| Step | Evidence |
+| --- | --- |
+| Running stdout job | `398d42a4-b6c3-4695-b05f-55d541044b37` |
+| Runner | `c6146513-2bcd-4182-945f-48ce7421098f` |
+| Session reuse | `agent_session_ready.reused=true`, sandbox `af9c00ec-e4c4-41f2-9e84-884114e3d8c8` |
+| Running UI proof | page showed `codex_stdout: LIVE_STDOUT_stdout-dedupe-1778908772404_1` while job status was still `running` |
+| Completion | job succeeded with exit `0` |
+| De-dupe proof | final API response had `eventCount=3` and `uniqueCount=3` for `_1`, `_2`, `_3` stdout rows |
+| Artifact proof | uploaded `codex-live-stdout.log`, `stdout-dedupe-stdout-dedupe-1778908772404.txt`, `qcut-output.tar`, `codex-events.jsonl`, `qcut-exit.json`, and `codex-last-message.md` |
+
+Screenshot:
+
+- Running stdout stream:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-e2e-live-stdout-dedupe-running.png`
+
+## PTY Terminal Mode - 2026-05-15
+
+Problem found after live stdout streaming:
+
+- `codex exec --json` only emits the real assistant message at
+  `item.completed`; it does not expose token-by-token assistant deltas.
+- The previous web UI could show worker events and shell stdout, but it was not
+  the same experience as a real terminal. The user could not type into a fixed
+  sandbox shell.
+
+Implemented fix:
+
+- Added a Daytona-backed PTY path to `packages/qcut-relay`. The relay now
+  accepts signed tokens for `agent_sessions`, connects to the session's Daytona
+  sandbox, creates a PTY, and bridges browser input/output over WebSocket.
+- Added `POST /api/agent/sessions/:sessionId/pty-token` in the license-server.
+  This creates or reuses the Daytona sandbox, injects saved `agent_secrets`, and
+  signs a short-lived relay token with `session_kind="agent"`.
+- Added terminal artifact endpoints:
+  - `GET /api/agent/sessions/:sessionId/artifacts`
+  - `GET /api/agent/sessions/:sessionId/artifacts/:filename/download`
+- Updated `chat-agent.html` to use xterm.js as the primary interface. The Send
+  button now writes a `codex exec --sandbox danger-full-access` command into the
+  live PTY, so the user sees real shell/Codex output in the terminal.
+- Fixed CORS for local website E2E by allowlisting `http://localhost:4177` and
+  `http://127.0.0.1:4177`.
+- Fixed relay stdin handling: non-resize string WebSocket messages are terminal
+  input, not malformed control packets.
+
+Deployment:
+
+- Deployed `qcut-license-server` to Cloudflare Workers after adding the PTY
+  token and terminal artifact routes.
+- Deployed `qcut-relay` to Cloudflare Workers after adding Daytona PTY support.
+- Set shared `RELAY_SIGNING_SECRET` on both Workers.
+- Set `DAYTONA_API_KEY` on both Workers.
+
+Focused tests:
+
+```bash
+node --test packages/nexusai-website/js/agent-chat.test.js
+bun --cwd packages/license-server test -- src/routes/agent.test.ts src/services/payment-config.test.ts
+bun --cwd packages/qcut-relay test
+bun --cwd packages/agent-worker test
+bunx tsc -p packages/qcut-relay/tsconfig.json --noEmit
+```
+
+Result:
+
+- Website chat client: 18 tests passed.
+- License server focused tests: 31 tests passed.
+- QCut relay: 9 tests passed.
+- Agent worker: 46 tests passed.
+- QCut relay typecheck passed.
+- License-server repo typecheck still has the existing unrelated
+  `Cannot find type definition file for 'sharp'` issue.
+
+Live/local E2E against deployed Workers and local website:
+
+| Step | Evidence |
+| --- | --- |
+| Session | `13a3b39a-d9fe-420a-bec3-f7dc9eb00a6d` |
+| Daytona sandbox | `9c50d534-8190-4e14-a30d-2a8350638252` |
+| PTY proof | Browser terminal accepted keyboard input and printed `direct-pty-ok` |
+| Codex proof | Send button ran real `codex exec` inside the PTY |
+| QCut CLI proof | Codex ran `qcut --help \| head -12` and output `qcut-pipeline v1.0.0 — AI content generation CLI` |
+| Artifact proof | `/tmp/qcut-output/terminal-e2e.txt` appeared in the web Artifacts panel with a Download button |
+
+Screenshots:
+
+- Connected PTY:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-pty-connected.png`
+- Direct keyboard PTY:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-pty-keyboard-direct.png`
+- Terminal artifact refresh:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-pty-artifact-refresh-confirmed.png`
+- Send button starts real Codex in PTY:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-send-codex-command-visible.png`
+- Codex result plus downloadable artifacts:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-send-codex-artifact-visible.png`
+- Production page after website push:
+  `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-production-pty-artifacts.png`
+
 ## Follow-ups
 
-- Persistent Codex PTY/daemon process inside the same sandbox.
-- Session artifact browser that can show prior job artifacts within a chat.
+- Decide whether to keep `codex exec` per Send or graduate to a long-lived
+  interactive Codex process inside the PTY.
+- Stream large terminal artifact downloads through object storage instead of
+  buffering Daytona `fs.downloadFile` in the Worker.
 - User-visible "session will expire soon" countdown.
 - Per-session credit policy if idle warm sandboxes become costly.
 - Add a normal migration-runner path so production schema changes do not need a

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -510,6 +510,34 @@ Default connection follow-up:
   `/Users/peter/Desktop/code/qcut/qcut/output/playwright/chat-agent-autoconnect-local.png`
   and confirmed the terminal reached `connected` on page load.
 
+Default Codex follow-up:
+
+- The relay now boots the PTY directly into interactive Codex instead of
+  leaving the user at a plain shell prompt.
+- Startup runs `qcut-entrypoint` first so saved QCut/Codex auth is materialized,
+  marks `/home/qcut/qcut` as a trusted Codex project, writes QCut Chat Agent
+  defaults into sandbox `AGENTS.md`, then starts an idle interactive Codex TUI:
+- Relay temporarily disables PTY input echo during bootstrap so the setup script
+  does not pollute the user's terminal scrollback.
+
+```bash
+codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen -C /home/qcut/qcut ...
+```
+
+- The sandbox `AGENTS.md` section tells Codex it is QCut's website Chat Agent,
+  points it at `/home/qcut/qcut/.claude/skills/native-cli/SKILL.md`, and
+  repeats the `/tmp/qcut-output` artifact rule. This avoids burning the first
+  interactive turn on setup instructions.
+- The website Send button now sends bracketed paste plus carriage return into
+  that persistent Codex session rather than spawning `codex exec` for every
+  message. Artifact polling still watches `/tmp/qcut-output`.
+- Production E2E confirmed the flow by sending a Codex prompt that created
+  `/tmp/qcut-output/direct-1778919565593.txt`; the deployed Artifacts API listed
+  it and the download endpoint returned matching content.
+- Artifact listing now uses Daytona `fs.listFiles()` first and falls back to a
+  `sh -lc` process namespace listing when `/tmp/qcut-output` is not visible via
+  the FS API.
+
 ## Terminal Artifact Download Fix - 2026-05-16
 
 Problem found in production:

--- a/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/10-agent-session-mode.md
@@ -1,0 +1,208 @@
+# 10 Agent Session Mode
+
+## Goal
+
+Make the website Chat Agent default to a persistent Daytona-backed Codex
+session. A user should be able to keep talking to the same sandbox, reuse files
+and working state, and only lose the sandbox after an idle timeout, a hard TTL,
+or an explicit "new session" action.
+
+This is different from the current job-only model:
+
+- **Current**: every message creates one `agent_jobs` row, one Daytona sandbox,
+  one Codex process, then deletes the sandbox after artifacts upload.
+- **Target v1**: every browser chat has one `agent_sessions` row and one warm
+  Daytona sandbox. Messages still create `agent_jobs` rows, but jobs point to
+  the session and reuse the sandbox.
+
+## Scope
+
+This task implements persistent **sandbox/session reuse**, not a long-lived
+interactive Codex PTY process. Each turn can still invoke `codex exec`, but it
+runs in the same Daytona filesystem and environment. That gives the practical
+benefit users asked for first: downloaded files, generated artifacts, temporary
+tools, repo state, and working directories survive across turns.
+
+Keeping one Codex process alive is a follow-up because it needs a PTY or daemon
+protocol, backpressure, cancellation, and a different message transport.
+
+## Data Model
+
+Add `agent_sessions`:
+
+| Column | Purpose |
+| --- | --- |
+| `id` | Browser-visible chat session id. |
+| `user_id` | Owner. Same user model as `agent_jobs`. |
+| `status` | `active`, `stopping`, `ended`, or `error`. |
+| `provider` | `daytona` for now. |
+| `provider_session_id` | Daytona sandbox id once provisioned. Nullable while waiting for first job claim. |
+| `image_tag` | Image used for the sandbox. |
+| `started_at` | First session creation time. |
+| `last_active_at` | Updated when a job is created and after a job finishes. Idle cleanup uses this. |
+| `expires_at` | Hard TTL. |
+| `ended_at` | Set when the worker cleans up or user explicitly ends the session. |
+| `end_reason` | `idle_timeout`, `ttl`, `user_kill`, or `error`. |
+| `runner_id` | Last worker that touched the session. |
+
+Add nullable `agent_jobs.session_id` referencing `agent_sessions.id`.
+
+Session ids are not trusted by themselves. License-server always scopes them by
+`user_id`; worker also verifies claimed jobs against the job's stored `user_id`.
+
+## API Shape
+
+### Create/reuse a session
+
+`POST /api/agent/sessions`
+
+Body:
+
+```json
+{
+  "mode": "codex"
+}
+```
+
+Behavior:
+
+- Return the newest active session for the user when one exists and is not
+  expired.
+- Otherwise create a new active session with no `provider_session_id` yet.
+- This route is cheap. Daytona is created lazily by the worker on the first job
+  that references the session.
+
+### End a session
+
+`POST /api/agent/sessions/:sessionId/end`
+
+Behavior:
+
+- Marks the session `stopping` with `end_reason = 'user_kill'`.
+- The worker cleanup loop deletes the Daytona sandbox and marks it `ended`.
+- If the worker is down, the next worker process will perform cleanup.
+
+### Create a job in a session
+
+`POST /api/agent/jobs`
+
+Body keeps the existing contract and adds optional `sessionId`:
+
+```json
+{
+  "command": "codex exec --skip-git-repo-check --json -",
+  "args": { "codexPrompt": "..." },
+  "sessionId": "..."
+}
+```
+
+Behavior:
+
+- If `sessionId` is provided, verify it belongs to the user and is active.
+- Store it on `agent_jobs.session_id`.
+- Update `agent_sessions.last_active_at`.
+
+## Worker Behavior
+
+For a job without `session_id`, keep current one-shot behavior: create sandbox,
+run command, upload artifacts, delete sandbox.
+
+For a job with `session_id`:
+
+1. Load the session row.
+2. If it has `provider_session_id`, try `daytona.get(...)`.
+3. If no sandbox exists or Daytona says it is gone, create a new sandbox and
+   update `agent_sessions.provider_session_id`.
+4. Run the job in that sandbox.
+5. Upload only this job's `/tmp/qcut-output` contents as artifacts.
+6. Do **not** delete the sandbox after the job.
+7. Update `last_active_at`.
+
+The command wrapper still clears `/tmp/qcut-output` per job, so artifact
+boundaries stay clean. Other paths such as `/tmp/qcut-tools`, `/home/qcut`, and
+the working directory persist for follow-up turns.
+
+## Idle Cleanup
+
+Worker owns cleanup because it already has Daytona credentials.
+
+Defaults:
+
+- Idle timeout: `20 minutes`
+- Hard TTL: `2 hours`
+- Cleanup interval: `60 seconds`
+
+Cleanup query:
+
+- active sessions where `last_active_at < now - idle_timeout`
+- active sessions where `expires_at < now`
+- sessions marked `stopping`
+
+For each match:
+
+1. Set status `stopping`.
+2. Try deleting Daytona sandbox when `provider_session_id` exists.
+3. Mark `ended`, set `ended_at` and `end_reason`.
+4. Record `agent_events` with `job_id = null`, `kind = 'agent_session_ended'`.
+
+## Website Behavior
+
+Chat Agent default Codex mode uses a session:
+
+- Keep `qcut_agent_session_id` in `localStorage`.
+- On first Codex send, call `POST /api/agent/sessions`.
+- Pass the returned `session.id` in `POST /api/agent/jobs`.
+- Show session status in the page.
+- Add a "New session" button:
+  - calls end route for the old session when possible
+  - clears localStorage
+  - creates a fresh session on next send
+
+Image-generation mode can stay one-shot for now. It does not need persistent
+Codex context.
+
+## Tests
+
+Implemented coverage:
+
+- License-server:
+  - creates/reuses active sessions
+  - marks an owned session as `stopping`
+  - rejects jobs with a missing/inactive session
+  - stores `sessionId` on jobs
+- Agent worker:
+  - one-shot jobs keep the old create/run/delete behavior
+  - session jobs reuse `provider_session_id`
+  - session jobs do not delete the sandbox after job finish
+  - idle cleanup deletes sandbox and marks session ended
+  - Codex prompt is injected per job so reused sandboxes do not replay an old
+    prompt
+- Website:
+  - creates a session through the license-server route
+  - passes `sessionId` into Codex job creation
+  - stores and clears `qcut_agent_session_id`
+
+Verified locally:
+
+```bash
+bun --cwd packages/agent-worker test -- run-on-daytona.test.ts stream-events.test.ts
+bun --cwd packages/license-server test -- agent.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc -p packages/agent-worker/tsconfig.json --noEmit
+bunx biome check packages/db/src/schema.ts packages/license-server/src/routes/agent.ts packages/license-server/src/routes/agent.test.ts packages/agent-worker/src/claim.ts packages/agent-worker/src/main.ts packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/agent-worker/src/stream-events.test.ts packages/nexusai-website/chat-agent.html
+```
+
+Known verification gap:
+
+- `bunx tsc -p packages/license-server/tsconfig.json --noEmit` currently fails
+  before checking these changes because the workspace is missing the implicit
+  `sharp` type definition.
+
+## Follow-ups
+
+- Persistent Codex PTY/daemon process inside the same sandbox.
+- Session artifact browser that can show prior job artifacts within a chat.
+- User-visible "session will expire soon" countdown.
+- Per-session credit policy if idle warm sandboxes become costly.
+- Apply `packages/db/migrations/0006_agent_sessions.sql` to production
+  Supabase before deploying the license-server/worker session routes.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -307,6 +307,49 @@ Production E2E on 2026-05-16:
 | Artifact list | returned `download-check.txt` |
 | Download proof | deployed route returned exact text `qcut artifact download ok` |
 
+## Persistent Codex-on-connect update
+
+Implementation update:
+
+- The deployed PTY design now treats Codex as the default terminal process, not
+  an optional shell command.
+- On attach, `qcut-relay` runs `qcut-entrypoint`, marks `/home/qcut/qcut` as a
+  trusted Codex project, writes QCut Chat Agent defaults into sandbox
+  `AGENTS.md`, then starts an idle interactive Codex TUI with
+  `--dangerously-bypass-approvals-and-sandbox`, `--no-alt-screen`, and
+  `-C /home/qcut/qcut`.
+- The relay temporarily disables PTY input echo while writing startup files so
+  the user does not see the `AGENTS.md` bootstrap script in terminal scrollback.
+- The `AGENTS.md` section points Codex at
+  `/home/qcut/qcut/.claude/skills/native-cli/SKILL.md` and tells it to write
+  final files to `/tmp/qcut-output` for the website Artifacts panel. This keeps
+  the first live user turn free for the actual task.
+- The website Send button now sends bracketed paste plus carriage return into
+  the persistent Codex PTY instead of spawning a new `codex exec` command per
+  turn.
+
+Focused verification:
+
+```bash
+node --test packages/nexusai-website/js/agent-chat.test.js
+bun --cwd packages/qcut-relay test
+bunx tsc -p packages/qcut-relay/tsconfig.json --noEmit
+bun --cwd packages/license-server test
+```
+
+Production E2E result:
+
+- New Daytona session connected through deployed `qcut-relay`.
+- Codex opened by default in YOLO mode, without the workspace trust prompt.
+- Bootstrap setup no longer leaked the `AGENTS.md` heredoc into terminal
+  scrollback.
+- A prompt sent through the PTY made Codex create
+  `/tmp/qcut-output/direct-1778919565593.txt`.
+- Deployed `qcut-license-server` listed that file through
+  `/api/agent/sessions/:id/artifacts` and downloaded it with matching content.
+- Artifact listing now uses Daytona `fs.listFiles()` first and falls back to a
+  `sh -lc` process namespace listing for `/tmp/qcut-output`.
+
 ## What still needs doing (gates on credentials / external services)
 
 1. **Merge the `qcut-cli-v2` follow-up branch** once the stdio artifact

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -35,6 +35,7 @@ into that architecture.
 | `ed99a4ac9` + this follow-up        | **Phase 3 verification** — GHCR owner casing fix, public `qcut-cli:v0` publish, Daytona dogfood, worker row normalization, Daytona writable output dir                                                                                | completes provider verification for PR 05's Daytona swap-in                             |
 | `ce02d4968`                         | `Dockerfile.cli` now installs pinned Codex CLI `0.130.0` and Claude Code CLI `2.1.142`; `qcut-smoke` hard-checks both binaries and versions; GHCR `v0` republished                                                                      | updates PR 02 image contract                                                           |
 | this follow-up                      | Chat Agent Codex mode: license-server accepts the fixed `codex exec --skip-git-repo-check --json -` command, worker passes prompt via base64 env, entrypoint bootstraps Codex auth from `CODEX_AUTH_JSON` or gated `OPENAI_API_KEY` | extends PR 02 + PR 04 for coding-agent sandbox jobs                                    |
+| `qcut-cli-v2` follow-up             | YouTube download support in the Daytona CLI image: preinstalls pinned `yt-dlp` `2026.03.17`, Deno `2.7.4`, and `/etc/yt-dlp.conf` with `--remote-components ejs:github`; Codex prompts now keep temp installs/cache out of `/tmp/qcut-output` | extends PR 02 image contract and PR 04 Codex artifact hygiene                          |
 
 ## Live verification (against production)
 
@@ -56,6 +57,7 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
 | GHCR native-cli skill image publish                                               | Workflow run `25902797671` republished `ghcr.io/quriosity-agent/qcut-cli:v0`; digest `sha256:2b9b8c7aa80bc2e5db874f04ccca302bbce0693a7d90274fe2b8645049fdbb7b`; pushed-image smoke verified `.claude/skills/native-cli/SKILL.md` |
 | Local Codex auth bootstrap smoke                                                  | `qcut-cli:codex-auth-smoke` built for `linux/amd64`; fake `CODEX_AUTH_JSON` wrote `~/.codex/auth.json` with mode `0600`; `QCUT_CODEX_PROMPT_B64` decoded correctly inside the image |
 | Website Codex → QCut CLI image E2E                                                | Chat Agent job `9b8a7693-00e0-4cff-8635-a7d78135d2d8` succeeded with exit `0`; Codex ran `qcut gen image ... -o /tmp/qcut-output`; uploaded JPG artifact `flux_dev_small-blue-square-icon-on-a-clean-white-background_1778827141210.jpg` |
+| Local YouTube-capable CLI image smoke                                             | `qcut-cli:youtube-fix` built for `linux/amd64`; `qcut-smoke` passed; `yt-dlp` + Deno downloaded a YouTube `.mp4` into `/tmp/qcut-output` without installing tools into the artifact directory |
 
 ## What is now done after `b536d61b2`
 
@@ -134,25 +136,121 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
     blob with the user's QCut auth token or the configured default agent
     account, then triggers a browser download without exposing Supabase
     service-role credentials to the frontend.
+15. **Daytona qcut jobs now capture CLI stdio as artifacts.**
+    E2E probes found that successful non-generation commands such as
+    `qcut system check-keys --json` returned `exit_code=0` but uploaded only
+    an empty `qcut-output.tar`, while failed commands returned `error=null`
+    with no visible reason. The Daytona runner now writes
+    `qcut-stdout.txt`, `qcut-stderr.txt`, and `qcut-exit.json` into
+    `/tmp/qcut-output` for every qcut job. The wrapper records the real CLI
+    exit code without closing the persistent Daytona session shell. Live
+    follow-up jobs verified both the failure path
+    (`575b396e-db81-480d-922d-20835650a63e`) and a real image generation
+    path (`9785346b-b385-4d45-bde1-525e8139d088`).
+16. **The next CLI image can handle YouTube download workflows.**
+    The previous Codex YouTube probe had two separate problems: the test
+    video `BaW_jenozKc` now returns `Video unavailable`, and the published
+    CLI image did not include `yt-dlp` or a JavaScript runtime, so Codex
+    installed tools inside `/tmp/qcut-output` and polluted artifacts.
+    `Dockerfile.cli` now preinstalls `yt-dlp` `2026.03.17`, Deno `2.7.4`,
+    and `/etc/yt-dlp.conf` with `--remote-components ejs:github`.
+    The Codex operating prompt also tells the sandbox to put temporary
+    tools/cache under `/tmp/qcut-tools` or `/tmp`, leaving
+    `/tmp/qcut-output` for final artifacts and small diagnostics only.
+
+## Live CLI E2E coverage and timing
+
+This round verified **9 live agent jobs** covering **5 CLI command shapes**:
+help, auth/key inspection, model listing, expected validation failure, and
+real image generation. Durations below are measured from production
+`agent_jobs.created_at`, `claimed_at`, and `finished_at`; `queue` is time
+waiting for the worker, and `run` is Daytona sandbox execution plus artifact
+download/upload.
+
+| Job | Command | Result | Total | Queue | Run | Artifacts | What it proved |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `bcec5b30` | `qcut gen image -t small-blue-square-icon-on-a-clean-white-background -m flux_dev --json` | succeeded / 0 | 12.1s | 1.1s | 11.0s | 3 | Website Chat Agent can run real image generation and return image/json/tar artifacts. |
+| `0dd0e898` | `qcut --help --json` | succeeded / 0 | 5.3s | 1.2s | 4.2s | 1 | Pre-fix probe: command succeeded but only uploaded empty tar, exposing missing stdout artifact. |
+| `c6732148` | `qcut system check-keys --json` | succeeded / 0 | 7.5s | 4.3s | 3.2s | 1 | Pre-fix probe: auth/key command succeeded but output was not visible to users. |
+| `7d823624` | `qcut system models --json` | succeeded / 0 | 10.5s | 6.7s | 3.8s | 1 | Pre-fix probe: model listing had the same missing-output problem. |
+| `d7e6813f` | `qcut gen image -m flux_dev --json` | failed / 1 | 4.8s | 0.5s | 4.3s | 1 | Pre-fix failure probe: validation failure had `error=null` and no readable reason. |
+| `575b396e` | `qcut gen image -m flux_dev --json` | failed / 1 | 235.0s | 229.0s | 6.0s | 4 | Post-fix failure probe: readable `qcut-stdout.txt` now contains `Missing --text/-t`; long total was caused by the intentionally unstuck queue. |
+| `da5a8216` | `qcut system check-keys --json` | succeeded / 0 | 6.1s | 0.9s | 5.2s | 4 | Post-fix success probe: stdout/stderr/exit artifacts are now uploaded for non-generation commands. |
+| `9785346b` | `qcut gen image -t tiny-red-circle-icon-on-white-background -m flux_dev --json` | succeeded / 0 | 13.5s | 1.1s | 12.4s | 6 | Post-fix real image generation still works; returned image/json plus stdio/exit artifacts. |
+| `899a9d6c` | `qcut --help --json` | succeeded / 0 | 7.4s | 1.3s | 6.1s | 4 | Deployed license-server source probe and post-fix help command artifact check. |
+
+Observed steady-state timing after the fix:
+
+- Light CLI commands (`help`, `check-keys`) usually finish in **6-8s total**.
+- Intentional validation failures finish in about **6s run time** once claimed.
+- Real `flux_dev` image generation finishes in about **12-14s total** in this
+  Daytona path for the tested prompts.
+- Queue time is normally about **1s** with the single live worker idle; the
+  `575b396e` row is an outlier because it sat behind a deliberately failed
+  hung-wrapper probe while the worker was restarted.
+
+## Live Codex conversation and YouTube artifact test
+
+The website Codex mode was tested as a three-turn browser session:
+
+| Job | Prompt shape | Result | Total | Queue | Run | Artifacts | What it proved |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `8bac5fba` | Remember `sapphire-bridge-481` | succeeded / 0 | 11.1s | 1.4s | 9.8s | 3 | First Codex turn returned `stored sapphire-bridge-481` and uploaded `codex-last-message.md`. |
+| `19ff765e` | Ask what phrase was remembered, without repeating it | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | Multi-turn context works in the current implementation: the page rebuilt the prompt from prior messages and Codex answered `sapphire-bridge-481`. |
+| `619d2ec1` | Download the public youtube-dl test video `BaW_jenozKc` into `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Codex executed shell steps and uploaded diagnostics, but YouTube/yt-dlp returned `Video unavailable`; no `.mp4` artifact was produced. |
+
+Current Codex conversation behavior:
+
+- Multi-turn works while the browser page remains open because the frontend
+  includes previous user/assistant messages in the next `codexPrompt`.
+- It is **not yet a persistent Codex session**. Each turn is a new Daytona
+  job, and refresh loses the in-memory conversation unless job history is
+  reloaded later.
+- Codex file artifacts work: `codex-events.jsonl`, `codex-last-message.md`,
+  and any files written to `/tmp/qcut-output` are uploaded.
+
+YouTube download result:
+
+- The job created `youtube-download-summary.json`,
+  `youtube-download-stdout.txt`, and `youtube-download-error.txt`.
+- `youtube-download-summary.json` reported `exit_status: 1`,
+  `downloaded_filename: ""`, and `byte_size: 0`.
+- `youtube-download-error.txt` contained
+  `ERROR: [youtube] BaW_jenozKc: Video unavailable`.
+- No `.mp4` appeared in artifacts because the download did not complete.
+- Follow-up fix implemented locally: the CLI image now includes `yt-dlp`
+  and Deno, with EJS remote components enabled. A clean
+  `qcut-cli:youtube-fix` container downloaded
+  `https://www.youtube.com/watch?v=jNQXAC9IVRw` to
+  `/tmp/qcut-output/youtube-test.mp4` (312 KB) after running
+  `qcut-smoke`.
+- Still to verify live: publish that refreshed image to GHCR, point the
+  Daytona worker at the new tag/digest, and rerun the website Chat Agent
+  YouTube prompt. The previous `BaW_jenozKc` URL should not be reused as
+  the success probe because it now returns unavailable independently of
+  QCut.
 
 ## What still needs doing (gates on credentials / external services)
 
-1. **Merge/deploy the worker fixes** from this follow-up. The provider
-   path is verified locally against production services; deployed worker
-   code needs the same row-normalization and Daytona output-dir fixes.
+1. **Merge the `qcut-cli-v2` follow-up branch** once the stdio artifact
+   capture, YouTube image fix, and E2E notes are reviewed.
 2. **Set/confirm license-server secrets** (`wrangler secret put`):
    `E2B_API_KEY`, `RELAY_SIGNING_SECRET`, `RELAY_HOST`, `QCUT_IMAGE_TAG`.
-3. **Deploy/confirm `@qcut/relay`** via `wrangler deploy` in
+3. **Publish the refreshed CLI image to GHCR and rerun live Chat Agent
+   YouTube E2E.** Manual `docker push` was blocked by the local GHCR token
+   missing package write scope, so use `.github/workflows/cli-image.yml`
+   from `qcut-cli-v2` or publish after merge.
+4. **Deploy/confirm `@qcut/relay`** via `wrangler deploy` in
    `packages/qcut-relay`.
-4. **Rotate the leaked Supabase PAT** (`sbp_b303...`) — it has been seen
+5. **Rotate the leaked Supabase PAT** (`sbp_b303...`) — it has been seen
    by GitHub's secret scanner. Generate a new one at
    supabase.com/dashboard/account/tokens.
-5. **Wire QCut login into wzrdagentstudio.** SandboxPage currently reads
+6. **Wire QCut login into wzrdagentstudio.** SandboxPage currently reads
    `localStorage.qcut_auth_token` as a v0 stash — replace with a real
    QCut sign-in component.
-6. **Refund on spawn failure.** PR 12's `routes/sandbox.ts` deducts
+7. **Refund on spawn failure.** PR 12's `routes/sandbox.ts` deducts
    credits up-front but does not refund yet if E2B fails after billing.
-7. **Capture stderr properly when docker is missing.** PR 11 worker
+8. **Capture stderr properly when docker is missing.** PR 11 worker
    `exit_code` lands but `error` column stays null if execa cannot
    spawn.
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -112,7 +112,7 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
     license-server only accepts the fixed stdin-based Codex command, the
     prompt travels as `args.codexPrompt`, the worker base64-encodes it into
     `QCUT_CODEX_PROMPT_B64`, and Daytona runs:
-    `codex exec --skip-git-repo-check --sandbox danger-full-access --json --output-last-message ... -`.
+    `codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --json --output-last-message ... -`.
     The explicit sandbox mode is required because Daytona already provides
     the external sandbox; Codex's default command sandbox can fail before a
     shell starts inside this image.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -58,6 +58,8 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
 | Local Codex auth bootstrap smoke                                                  | `qcut-cli:codex-auth-smoke` built for `linux/amd64`; fake `CODEX_AUTH_JSON` wrote `~/.codex/auth.json` with mode `0600`; `QCUT_CODEX_PROMPT_B64` decoded correctly inside the image |
 | Website Codex → QCut CLI image E2E                                                | Chat Agent job `9b8a7693-00e0-4cff-8635-a7d78135d2d8` succeeded with exit `0`; Codex ran `qcut gen image ... -o /tmp/qcut-output`; uploaded JPG artifact `flux_dev_small-blue-square-icon-on-a-clean-white-background_1778827141210.jpg` |
 | Local YouTube-capable CLI image smoke                                             | `qcut-cli:youtube-fix` built for `linux/amd64`; `qcut-smoke` passed; `yt-dlp` + Deno downloaded a YouTube `.mp4` into `/tmp/qcut-output` without installing tools into the artifact directory |
+| GHCR YouTube-capable image publish                                                | Workflow run `25949183927` published `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`; digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`; pushed-image and local pull smoke passed |
+| Website Codex → YouTube artifact E2E                                              | Chat Agent job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` succeeded with exit `0`; Codex used `yt-dlp` with cache under `/tmp/qcut-tools`; artifacts include downloadable `youtube-e2e.mp4` (464.8 KB) and summary JSON |
 
 ## What is now done after `b536d61b2`
 
@@ -157,6 +159,10 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
     The Codex operating prompt also tells the sandbox to put temporary
     tools/cache under `/tmp/qcut-tools` or `/tmp`, leaving
     `/tmp/qcut-output` for final artifacts and small diagnostics only.
+    Workflow run `25949183927` published this as
+    `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`; the Daytona
+    runner default image digest has been updated to
+    `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`.
 
 ## Live CLI E2E coverage and timing
 
@@ -197,7 +203,8 @@ The website Codex mode was tested as a three-turn browser session:
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
 | `8bac5fba` | Remember `sapphire-bridge-481` | succeeded / 0 | 11.1s | 1.4s | 9.8s | 3 | First Codex turn returned `stored sapphire-bridge-481` and uploaded `codex-last-message.md`. |
 | `19ff765e` | Ask what phrase was remembered, without repeating it | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | Multi-turn context works in the current implementation: the page rebuilt the prompt from prior messages and Codex answered `sapphire-bridge-481`. |
-| `619d2ec1` | Download the public youtube-dl test video `BaW_jenozKc` into `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Codex executed shell steps and uploaded diagnostics, but YouTube/yt-dlp returned `Video unavailable`; no `.mp4` artifact was produced. |
+| `619d2ec1` | Download the public youtube-dl test video `BaW_jenozKc` into `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Pre-fix probe: Codex executed shell steps and uploaded diagnostics, but YouTube/yt-dlp returned `Video unavailable`; no `.mp4` artifact was produced. |
+| `3b19b2cd` | Download currently available YouTube URL `jNQXAC9IVRw` into `/tmp/qcut-output` | succeeded / 0 | ~2m | live website poll | live Daytona run | 5 | Post-fix E2E: Codex used preinstalled `yt-dlp` + Deno and wrote `youtube-e2e.mp4` plus summary JSON. The website Download button fetched the MP4 successfully. |
 
 Current Codex conversation behavior:
 
@@ -218,17 +225,21 @@ YouTube download result:
 - `youtube-download-error.txt` contained
   `ERROR: [youtube] BaW_jenozKc: Video unavailable`.
 - No `.mp4` appeared in artifacts because the download did not complete.
-- Follow-up fix implemented locally: the CLI image now includes `yt-dlp`
-  and Deno, with EJS remote components enabled. A clean
-  `qcut-cli:youtube-fix` container downloaded
-  `https://www.youtube.com/watch?v=jNQXAC9IVRw` to
-  `/tmp/qcut-output/youtube-test.mp4` (312 KB) after running
-  `qcut-smoke`.
-- Still to verify live: publish that refreshed image to GHCR, point the
-  Daytona worker at the new tag/digest, and rerun the website Chat Agent
-  YouTube prompt. The previous `BaW_jenozKc` URL should not be reused as
-  the success probe because it now returns unavailable independently of
-  QCut.
+- Follow-up fix verified end-to-end: workflow run `25949183927` published
+  the refreshed image, the local worker was restarted with
+  `QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`,
+  and website job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` produced:
+  - `youtube-e2e.mp4` (`video`, 464.8 KB)
+  - `youtube-e2e-summary.json` (`json`, 96 bytes, `exit_status: 0`)
+  - `qcut-output.tar` (480.0 KB)
+  - `codex-last-message.md`
+  - `codex-events.jsonl`
+- The website artifact download route also works for the MP4: clicking the
+  `youtube-e2e.mp4` Download button fetched
+  `/api/agent/jobs/3b19b2cd-cb17-4576-add0-89ba9aca2e4e/artifacts/.../download`
+  with HTTP 200 and saved `youtube-e2e.mp4` in the Playwright session.
+- The previous `BaW_jenozKc` URL should not be reused as a success probe
+  because it now returns unavailable independently of QCut.
 
 ## What still needs doing (gates on credentials / external services)
 
@@ -236,10 +247,10 @@ YouTube download result:
    capture, YouTube image fix, and E2E notes are reviewed.
 2. **Set/confirm license-server secrets** (`wrangler secret put`):
    `E2B_API_KEY`, `RELAY_SIGNING_SECRET`, `RELAY_HOST`, `QCUT_IMAGE_TAG`.
-3. **Publish the refreshed CLI image to GHCR and rerun live Chat Agent
-   YouTube E2E.** Manual `docker push` was blocked by the local GHCR token
-   missing package write scope, so use `.github/workflows/cli-image.yml`
-   from `qcut-cli-v2` or publish after merge.
+3. **After merge, decide whether to republish `v0`/`latest` or keep the
+   verified digest pin.** The tested image is currently available as
+   `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`, and the worker
+   default pin points at its digest.
 4. **Deploy/confirm `@qcut/relay`** via `wrangler deploy` in
    `packages/qcut-relay`.
 5. **Rotate the leaked Supabase PAT** (`sbp_b303...`) — it has been seen

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -36,6 +36,7 @@ into that architecture.
 | `ce02d4968`                         | `Dockerfile.cli` now installs pinned Codex CLI `0.130.0` and Claude Code CLI `2.1.142`; `qcut-smoke` hard-checks both binaries and versions; GHCR `v0` republished                                                                      | updates PR 02 image contract                                                           |
 | this follow-up                      | Chat Agent Codex mode: license-server accepts the fixed `codex exec --skip-git-repo-check --json -` command, worker passes prompt via base64 env, entrypoint bootstraps Codex auth from `CODEX_AUTH_JSON` or gated `OPENAI_API_KEY` | extends PR 02 + PR 04 for coding-agent sandbox jobs                                    |
 | `qcut-cli-v2` follow-up             | YouTube download support in the Daytona CLI image: preinstalls pinned `yt-dlp` `2026.03.17`, Deno `2.7.4`, and `/etc/yt-dlp.conf` with `--remote-components ejs:github`; Codex prompts now keep temp installs/cache out of `/tmp/qcut-output` | extends PR 02 image contract and PR 04 Codex artifact hygiene                          |
+| `qcut-cli-v2` follow-up             | Daytona jobs now stream live `agent_events` while the sandbox command is still running; the website Codex pending bubble summarizes recent lifecycle/Codex events; internal `.qcut-agent-*` control files are excluded from uploaded artifacts | updates PR 04 worker telemetry and the Chat Agent website                              |
 
 ## Live verification (against production)
 
@@ -60,6 +61,8 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
 | Local YouTube-capable CLI image smoke                                             | `qcut-cli:youtube-fix` built for `linux/amd64`; `qcut-smoke` passed; `yt-dlp` + Deno downloaded a YouTube `.mp4` into `/tmp/qcut-output` without installing tools into the artifact directory |
 | GHCR YouTube-capable image publish                                                | Workflow run `25949183927` published `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`; digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`; pushed-image and local pull smoke passed |
 | Website Codex → YouTube artifact E2E                                              | Chat Agent job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` succeeded with exit `0`; Codex used `yt-dlp` with cache under `/tmp/qcut-tools`; artifacts include downloadable `youtube-e2e.mp4` (464.8 KB) and summary JSON |
+| Website Codex realtime streaming E2E                                              | Chat Agent job `9d870b84-f2ba-4b43-b9df-c5ac9c2d14a9` succeeded with exit `0`; while the job was still running, the pending Codex bubble showed `daytona_command_started`, `thread.started`, `turn.started`, and `item.started`; artifacts included `ui-stream-summary.json` |
+| Daytona artifact-control-file hygiene                                             | `qcut --help --json` job `229f19e9-50ad-40f7-a83d-84df1f454c77` succeeded with exit `0`; uploaded artifacts are `qcut-exit.json`, `qcut-stdout.txt`, `qcut-stderr.txt`, and `qcut-output.tar`, with internal `.qcut-agent-*` files excluded |
 
 ## What is now done after `b536d61b2`
 
@@ -163,6 +166,23 @@ ap-southeast-2) and `qcutlove@qcut.app` user `79bf60b02770d2cc510da53e471590f4`:
     `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`; the Daytona
     runner default image digest has been updated to
     `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`.
+17. **Daytona jobs now stream while they run.**
+    The worker starts the sandbox command in the background, polls the
+    relevant output files every 2 seconds, and inserts new complete lines into
+    `agent_events` before the job reaches a terminal state. Codex jobs stream
+    `codex-events.jsonl`; direct qcut jobs stream `qcut-stdout.txt` and
+    `qcut-stderr.txt`. The main worker marks Daytona results as already
+    streamed so it does not duplicate stderr after completion. A live probe
+    caught an async-start shell bug (`&;`); the runner now uses a valid
+    background command, records start failures immediately, and avoids a fake
+    30-minute "running" state.
+18. **Chat Agent shows live Codex progress in the conversation.**
+    The website still renders the full Events panel, and now also updates the
+    pending Codex chat bubble with a short rolling summary of recent events.
+    Job `9d870b84-f2ba-4b43-b9df-c5ac9c2d14a9` verified the user-visible
+    behavior: before completion, the bubble showed the Daytona session event
+    plus Codex `thread.started`, `turn.started`, and `item.started`; after
+    completion it was replaced by `UI_STREAM_DONE /tmp/qcut-output/ui-stream-summary.json`.
 
 ## Live CLI E2E coverage and timing
 
@@ -205,6 +225,8 @@ The website Codex mode was tested as a three-turn browser session:
 | `19ff765e` | Ask what phrase was remembered, without repeating it | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | Multi-turn context works in the current implementation: the page rebuilt the prompt from prior messages and Codex answered `sapphire-bridge-481`. |
 | `619d2ec1` | Download the public youtube-dl test video `BaW_jenozKc` into `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Pre-fix probe: Codex executed shell steps and uploaded diagnostics, but YouTube/yt-dlp returned `Video unavailable`; no `.mp4` artifact was produced. |
 | `3b19b2cd` | Download currently available YouTube URL `jNQXAC9IVRw` into `/tmp/qcut-output` | succeeded / 0 | ~2m | live website poll | live Daytona run | 5 | Post-fix E2E: Codex used preinstalled `yt-dlp` + Deno and wrote `youtube-e2e.mp4` plus summary JSON. The website Download button fetched the MP4 successfully. |
+| `4ceb713b` | Realtime streaming E2E: create `realtime-stream-summary.json` after a 4-step shell loop | succeeded / 0 | ~31s | live website poll | live Daytona run | 5 | Worker streamed Daytona lifecycle events and Codex JSONL events before completion; final reply was `STREAM_TEST_DONE /tmp/qcut-output/realtime-stream-summary.json`. |
+| `9d870b84` | Realtime UI smoke: create `ui-stream-summary.json` after a 2-step shell loop | succeeded / 0 | ~18s | live website poll | live Daytona run | 5 | Website pending Codex bubble updated while running with recent `daytona_command_started` and `codex_event` summaries, then resolved to `UI_STREAM_DONE ...`. |
 
 Current Codex conversation behavior:
 
@@ -244,7 +266,8 @@ YouTube download result:
 ## What still needs doing (gates on credentials / external services)
 
 1. **Merge the `qcut-cli-v2` follow-up branch** once the stdio artifact
-   capture, YouTube image fix, and E2E notes are reviewed.
+   capture, YouTube image fix, realtime streaming worker changes, website
+   progress UI, and E2E notes are reviewed.
 2. **Set/confirm license-server secrets** (`wrangler secret put`):
    `E2B_API_KEY`, `RELAY_SIGNING_SECRET`, `RELAY_HOST`, `QCUT_IMAGE_TAG`.
 3. **After merge, decide whether to republish `v0`/`latest` or keep the

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.md
@@ -263,6 +263,50 @@ YouTube download result:
 - The previous `BaW_jenozKc` URL should not be reused as a success probe
   because it now returns unavailable independently of QCut.
 
+## Terminal session artifact download fix
+
+Production bug:
+
+- The PTY session artifact route
+  `/api/agent/sessions/:sessionId/artifacts/:filename/download` failed in
+  Cloudflare Workers with
+  `"Buffer" is not supported: Module "buffer" is not available in the
+  "serverless" runtime`.
+- Cause: Daytona SDK `sandbox.fs.downloadFile()` parses the download multipart
+  body through Node `Buffer`; the Worker runtime does not expose that module.
+
+Fix shipped:
+
+- `packages/license-server/src/services/daytona-download.ts` now calls
+  Daytona's lower-level `downloadFiles` API with `responseType: "arraybuffer"`.
+- The license-server parses Daytona's multipart response with Web-standard
+  `Uint8Array`/`TextEncoder`/`TextDecoder` only, then returns the artifact bytes
+  directly from the session download route.
+- `packages/license-server/src/routes/agent.test.ts` now asserts the session
+  download path does **not** call `sandbox.fs.downloadFile()`.
+- `packages/license-server/src/services/daytona-download.test.ts` covers
+  multipart file extraction, multipart error parts, and raw byte fallback.
+
+Verification:
+
+```bash
+bun --cwd packages/license-server test src/routes/agent.test.ts src/services/daytona-download.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc --noEmit --strict --moduleResolution bundler --module ESNext --target ES2022 --typeRoots /tmp/qcut-empty-types packages/license-server/src/services/daytona-download.ts
+```
+
+Production E2E on 2026-05-16:
+
+| Step | Evidence |
+| --- | --- |
+| Deployed license-server | version `0c0f9734-0bdc-4632-a62a-eb7b9696bb4f` |
+| Deployed relay | version `3d0ec83e-5aa1-477d-aafa-09115e27ab68` |
+| Session | `c4b059cc-d8c2-480d-8c8a-0dd07950b45d` |
+| Daytona sandbox | `960e6ecc-a2ea-4e00-9f9a-70c283ece3c9` |
+| PTY proof | WebSocket opened, then wrote `/tmp/qcut-output/download-check.txt` |
+| Artifact list | returned `download-check.txt` |
+| Download proof | deployed route returned exact text `qcut artifact download ok` |
+
 ## What still needs doing (gates on credentials / external services)
 
 1. **Merge the `qcut-cli-v2` follow-up branch** once the stdio artifact

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -105,7 +105,7 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
     website 的 Chat Agent 页现在可以提交 Codex 模式任务。license-server
     只接受固定的 stdin 版 Codex command；prompt 走 `args.codexPrompt`；
     worker 把它 base64 成 `QCUT_CODEX_PROMPT_B64`；Daytona 里实际跑：
-    `codex exec --skip-git-repo-check --sandbox danger-full-access --json --output-last-message ... -`。
+    `codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --json --output-last-message ... -`。
     这里显式指定 sandbox mode，是因为 Daytona 已经提供外层隔离；
     Codex 默认命令 sandbox 在这个镜像里可能会在 shell 启动前失败。
 11. **Codex 登录只在运行时处理。**

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -56,6 +56,8 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
 | 本地 Codex auth bootstrap smoke                                           | `qcut-cli:codex-auth-smoke` 按 `linux/amd64` 构建；假的 `CODEX_AUTH_JSON` 能写成权限 `0600` 的 `~/.codex/auth.json`；`QCUT_CODEX_PROMPT_B64` 在镜像内能正确解码 |
 | Website Codex → QCut CLI 图片 E2E                                         | Chat Agent job `9b8a7693-00e0-4cff-8635-a7d78135d2d8` 成功，exit `0`；Codex 实际跑了 `qcut gen image ... -o /tmp/qcut-output`；上传了 JPG artifact `flux_dev_small-blue-square-icon-on-a-clean-white-background_1778827141210.jpg` |
 | 本地 YouTube-capable CLI 镜像 smoke                                      | `qcut-cli:youtube-fix` 按 `linux/amd64` 构建；`qcut-smoke` 通过；`yt-dlp` + Deno 能把 YouTube `.mp4` 下载进 `/tmp/qcut-output`，且不会把工具安装到 artifact 目录 |
+| GHCR YouTube-capable 镜像发布                                             | workflow run `25949183927` 发布 `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`；digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`；推后 smoke 和本地 pull smoke 都通过 |
+| Website Codex → YouTube artifact E2E                                      | Chat Agent job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` 成功，exit `0`；Codex 用 `/tmp/qcut-tools` 做 cache 跑预装 `yt-dlp`；artifacts 包含可下载的 `youtube-e2e.mp4`（464.8 KB）和 summary JSON |
 
 ## `b536d61b2` 之后已经完成的事
 
@@ -143,6 +145,10 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
     `/etc/yt-dlp.conf` 的 `--remote-components ejs:github`。Codex 的运行
     prompt 也要求临时工具 / cache 放到 `/tmp/qcut-tools` 或 `/tmp`，
     `/tmp/qcut-output` 只放最终产物和小诊断文件。
+    workflow run `25949183927` 已把这个镜像发布成
+    `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`；Daytona
+    runner 的默认镜像 digest 已更新到
+    `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`。
 
 ## Live CLI E2E 覆盖和耗时
 
@@ -180,7 +186,8 @@ website Codex 模式用真实浏览器跑了三轮：
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
 | `8bac5fba` | 让 Codex 记住 `sapphire-bridge-481` | succeeded / 0 | 11.1s | 1.4s | 9.8s | 3 | 第一轮回复 `stored sapphire-bridge-481`，并上传 `codex-last-message.md`。 |
 | `19ff765e` | 不重复短语，直接问上一轮记住了什么 | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | 当前多轮上下文可用：前端把历史消息重新拼进下一轮 `codexPrompt`，Codex 回答了 `sapphire-bridge-481`。 |
-| `619d2ec1` | 把公开的 youtube-dl 测试视频 `BaW_jenozKc` 下载到 `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Codex 执行了 shell 步骤并上传诊断文件，但 YouTube/yt-dlp 返回 `Video unavailable`；没有生成 `.mp4` artifact。 |
+| `619d2ec1` | 把公开的 youtube-dl 测试视频 `BaW_jenozKc` 下载到 `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | 修复前 probe：Codex 执行了 shell 步骤并上传诊断文件，但 YouTube/yt-dlp 返回 `Video unavailable`；没有生成 `.mp4` artifact。 |
+| `3b19b2cd` | 把当前可访问的 YouTube URL `jNQXAC9IVRw` 下载到 `/tmp/qcut-output` | succeeded / 0 | 约 2m | live website poll | live Daytona run | 5 | 修复后 E2E：Codex 用预装 `yt-dlp` + Deno 写出 `youtube-e2e.mp4` 和 summary JSON；website Download 按钮也成功下载 MP4。 |
 
 当前 Codex 对话行为：
 
@@ -200,13 +207,20 @@ YouTube 下载结果：
 - `youtube-download-error.txt` 里是
   `ERROR: [youtube] BaW_jenozKc: Video unavailable`。
 - 因为下载没有完成，所以 artifacts 里没有 `.mp4`。
-- 本地 follow-up 修复已完成：CLI 镜像现在包含 `yt-dlp` 和 Deno，并打开
-  EJS remote components。干净的 `qcut-cli:youtube-fix` 容器先通过
-  `qcut-smoke`，再把 `https://www.youtube.com/watch?v=jNQXAC9IVRw`
-  下载成 `/tmp/qcut-output/youtube-test.mp4`（312 KB）。
-- 还要做一次 live 验证：把刷新后的镜像发布到 GHCR，让 Daytona worker
-  指向新的 tag/digest，然后从 website Chat Agent 重跑 YouTube prompt。
-  之前的 `BaW_jenozKc` 不能再当成功 probe，因为它现在脱离 QCut 也会返回
+- follow-up 修复已端到端验证：workflow run `25949183927` 发布刷新后的
+  镜像；本地 worker 用
+  `QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
+  重启；website job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` 产出：
+  - `youtube-e2e.mp4`（`video`，464.8 KB）
+  - `youtube-e2e-summary.json`（`json`，96 bytes，`exit_status: 0`）
+  - `qcut-output.tar`（480.0 KB）
+  - `codex-last-message.md`
+  - `codex-events.jsonl`
+- website artifact 下载接口也验证过：点击 `youtube-e2e.mp4` 的 Download
+  按钮会请求
+  `/api/agent/jobs/3b19b2cd-cb17-4576-add0-89ba9aca2e4e/artifacts/.../download`，
+  返回 HTTP 200，并在 Playwright session 保存 `youtube-e2e.mp4`。
+- 之前的 `BaW_jenozKc` 不能再当成功 probe，因为它现在脱离 QCut 也会返回
   unavailable。
 
 ## 还没做的（依赖外部凭证 / 服务）
@@ -215,10 +229,10 @@ YouTube 下载结果：
    capture、YouTube 镜像修复和这轮 E2E 记录进主线。
 2. **设 / 确认 license-server 密钥**（`wrangler secret put`）：
    `E2B_API_KEY`、`RELAY_SIGNING_SECRET`、`RELAY_HOST`、`QCUT_IMAGE_TAG`。
-3. **发布刷新后的 CLI 镜像到 GHCR，并重跑 live Chat Agent YouTube E2E。**
-   本地手动 `docker push` 被 GHCR 拒了，因为当前 token 没有 package write
-   scope；所以要用 `qcut-cli-v2` 上的 `.github/workflows/cli-image.yml`
-   发临时 tag，或合并后再发布。
+3. **合并后决定是重发 `v0` / `latest`，还是保留已验证 digest pin。**
+   当前测过的镜像 tag 是
+   `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`，worker 默认 pin
+   已指向它的 digest。
 4. **部署 / 确认 `@qcut/relay`**：`packages/qcut-relay` 下
    `wrangler deploy`。
 5. **轮换泄露的 Supabase PAT**（`sbp_b303...`）——GitHub secret

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -34,6 +34,7 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
 | `ce02d4968`                            | `Dockerfile.cli` 现在安装固定版本 Codex CLI `0.130.0` 和 Claude Code CLI `2.1.142`；`qcut-smoke` 会硬检查两个 binary 和版本；GHCR `v0` 已重新发布                                              | 更新 PR 02 镜像契约                                       |
 | 本轮 follow-up                         | Chat Agent Codex 模式：license-server 只接受固定的 `codex exec --skip-git-repo-check --json -`，worker 用 base64 env 传 prompt，entrypoint 从 `CODEX_AUTH_JSON` 或受控 `OPENAI_API_KEY` 启动 Codex 登录 | 扩展 PR 02 + PR 04，支持 coding-agent sandbox 任务         |
 | `qcut-cli-v2` follow-up                | Daytona CLI 镜像补 YouTube 下载能力：预装固定版本 `yt-dlp` `2026.03.17`、Deno `2.7.4`，并写入 `/etc/yt-dlp.conf` 的 `--remote-components ejs:github`；Codex prompt 也要求临时安装/cache 不要写进 `/tmp/qcut-output` | 扩展 PR 02 镜像契约和 PR 04 Codex artifact 卫生            |
+| `qcut-cli-v2` follow-up                | Daytona job 现在会在 sandbox command 仍在运行时实时写 `agent_events`；website 的 Codex pending 气泡会摘要最近的 lifecycle / Codex events；上传 artifact 时会排除内部 `.qcut-agent-*` 控制文件             | 更新 PR 04 worker telemetry 和 Chat Agent website          |
 
 ## 生产环境实测
 
@@ -58,6 +59,8 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
 | 本地 YouTube-capable CLI 镜像 smoke                                      | `qcut-cli:youtube-fix` 按 `linux/amd64` 构建；`qcut-smoke` 通过；`yt-dlp` + Deno 能把 YouTube `.mp4` 下载进 `/tmp/qcut-output`，且不会把工具安装到 artifact 目录 |
 | GHCR YouTube-capable 镜像发布                                             | workflow run `25949183927` 发布 `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`；digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`；推后 smoke 和本地 pull smoke 都通过 |
 | Website Codex → YouTube artifact E2E                                      | Chat Agent job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` 成功，exit `0`；Codex 用 `/tmp/qcut-tools` 做 cache 跑预装 `yt-dlp`；artifacts 包含可下载的 `youtube-e2e.mp4`（464.8 KB）和 summary JSON |
+| Website Codex realtime streaming E2E                                      | Chat Agent job `9d870b84-f2ba-4b43-b9df-c5ac9c2d14a9` 成功，exit `0`；job 仍在 running 时，Codex pending 气泡已经显示 `daytona_command_started`、`thread.started`、`turn.started`、`item.started`；artifact 包含 `ui-stream-summary.json` |
+| Daytona artifact 控制文件清理                                             | `qcut --help --json` job `229f19e9-50ad-40f7-a83d-84df1f454c77` 成功，exit `0`；上传 artifact 是 `qcut-exit.json`、`qcut-stdout.txt`、`qcut-stderr.txt`、`qcut-output.tar`，内部 `.qcut-agent-*` 文件不再暴露 |
 
 ## `b536d61b2` 之后已经完成的事
 
@@ -149,6 +152,22 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
     `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`；Daytona
     runner 的默认镜像 digest 已更新到
     `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`。
+17. **Daytona job 现在边跑边 stream。**
+    worker 会把 sandbox command 放到后台运行，每 2 秒轮询相关输出文件，
+    把新增的完整行实时插入 `agent_events`，不再等 job 结束才一次性写。
+    Codex job stream `codex-events.jsonl`；直接 qcut job stream
+    `qcut-stdout.txt` 和 `qcut-stderr.txt`。主 worker 会识别 Daytona
+    runner 已经 stream 过 events，结束时不会再重复写 stderr。这轮 live
+    probe 抓到了一个 async start 的 shell bug（生成了 `&;`）；现在已经改成
+    合法后台命令，并且 start command 非 0 会立刻写
+    `daytona_command_start_failed`，不会再假 running 30 分钟。
+18. **Chat Agent 会在对话里显示 live Codex 进度。**
+    website 原来的 Events panel 继续保留；现在 pending 的 Codex 回复气泡
+    也会显示最近 events 的滚动摘要。job
+    `9d870b84-f2ba-4b43-b9df-c5ac9c2d14a9` 已验证：完成前气泡显示了
+    Daytona session event 和 Codex 的 `thread.started`、`turn.started`、
+    `item.started`；完成后替换成
+    `UI_STREAM_DONE /tmp/qcut-output/ui-stream-summary.json`。
 
 ## Live CLI E2E 覆盖和耗时
 
@@ -188,6 +207,8 @@ website Codex 模式用真实浏览器跑了三轮：
 | `19ff765e` | 不重复短语，直接问上一轮记住了什么 | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | 当前多轮上下文可用：前端把历史消息重新拼进下一轮 `codexPrompt`，Codex 回答了 `sapphire-bridge-481`。 |
 | `619d2ec1` | 把公开的 youtube-dl 测试视频 `BaW_jenozKc` 下载到 `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | 修复前 probe：Codex 执行了 shell 步骤并上传诊断文件，但 YouTube/yt-dlp 返回 `Video unavailable`；没有生成 `.mp4` artifact。 |
 | `3b19b2cd` | 把当前可访问的 YouTube URL `jNQXAC9IVRw` 下载到 `/tmp/qcut-output` | succeeded / 0 | 约 2m | live website poll | live Daytona run | 5 | 修复后 E2E：Codex 用预装 `yt-dlp` + Deno 写出 `youtube-e2e.mp4` 和 summary JSON；website Download 按钮也成功下载 MP4。 |
+| `4ceb713b` | Realtime streaming E2E：4 步 shell loop 后写 `realtime-stream-summary.json` | succeeded / 0 | 约 31s | live website poll | live Daytona run | 5 | worker 在完成前已经 stream Daytona lifecycle events 和 Codex JSONL events；最终回复 `STREAM_TEST_DONE /tmp/qcut-output/realtime-stream-summary.json`。 |
+| `9d870b84` | Realtime UI smoke：2 步 shell loop 后写 `ui-stream-summary.json` | succeeded / 0 | 约 18s | live website poll | live Daytona run | 5 | website pending Codex 气泡在 running 中显示最近的 `daytona_command_started` 和 `codex_event` 摘要，完成后解析成 `UI_STREAM_DONE ...`。 |
 
 当前 Codex 对话行为：
 
@@ -226,7 +247,8 @@ YouTube 下载结果：
 ## 还没做的（依赖外部凭证 / 服务）
 
 1. **review 后合并 `qcut-cli-v2` follow-up 分支**，把 stdio artifact
-   capture、YouTube 镜像修复和这轮 E2E 记录进主线。
+   capture、YouTube 镜像修复、realtime streaming worker、website
+   progress UI 和这轮 E2E 记录进主线。
 2. **设 / 确认 license-server 密钥**（`wrangler secret put`）：
    `E2B_API_KEY`、`RELAY_SIGNING_SECRET`、`RELAY_HOST`、`QCUT_IMAGE_TAG`。
 3. **合并后决定是重发 `v0` / `latest`，还是保留已验证 digest pin。**

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -287,6 +287,48 @@ bunx tsc --noEmit --strict --moduleResolution bundler --module ESNext --target E
 | Artifact list | 返回 `download-check.txt` |
 | Download 证明 | 已部署接口返回精确文本 `qcut artifact download ok` |
 
+## Connect 后默认进入 Codex 的更新
+
+实现更新：
+
+- PTY 现在把 Codex 当成默认 terminal process，不再只是给用户一个普通
+  shell prompt。
+- attach 时，`qcut-relay` 会先跑 `qcut-entrypoint`，把
+  `/home/qcut/qcut` 写入 Codex trusted project，再把 QCut Chat Agent 默认
+  指令写入 sandbox 里的 `AGENTS.md`，最后启动 idle 状态的 interactive
+  Codex，并带上 `--dangerously-bypass-approvals-and-sandbox`、
+  `--no-alt-screen`、`-C /home/qcut/qcut`。
+- relay 写启动文件时会临时关闭 PTY input echo，避免用户在 terminal
+  scrollback 里看到 `AGENTS.md` bootstrap 脚本。
+- `AGENTS.md` 里的 section 会明确告诉 Codex：
+  `/home/qcut/qcut/.claude/skills/native-cli/SKILL.md` 是 QCut native CLI
+  skill，并要求最终文件写入 `/tmp/qcut-output`，这样 website Artifacts
+  面板可以列出和下载。这样第一条真实用户消息不会被启动 prompt 占掉。
+- website 的 Send 按钮现在会用 bracketed paste 加 carriage return 把用户
+  消息提交到这个 persistent Codex PTY，不再每轮生成一个新的 `codex exec`
+  shell command。
+
+聚焦验证：
+
+```bash
+node --test packages/nexusai-website/js/agent-chat.test.js
+bun --cwd packages/qcut-relay test
+bunx tsc -p packages/qcut-relay/tsconfig.json --noEmit
+bun --cwd packages/license-server test
+```
+
+生产 E2E 结果：
+
+- 新 Daytona session 通过已部署的 `qcut-relay` 成功连接。
+- Codex 默认以 YOLO mode 打开，没有 workspace trust prompt。
+- bootstrap 不再把 `AGENTS.md` heredoc 泄漏到 terminal scrollback。
+- 通过 PTY 发 prompt 后，Codex 真实创建了
+  `/tmp/qcut-output/direct-1778919565593.txt`。
+- 已部署的 `qcut-license-server` 能通过
+  `/api/agent/sessions/:id/artifacts` 列出该文件，并且 download 内容匹配。
+- Artifact listing 现在先走 Daytona `fs.listFiles()`，为空时 fallback 到
+  `sh -lc` 在 process namespace 里列 `/tmp/qcut-output`。
+
 ## 还没做的（依赖外部凭证 / 服务）
 
 1. **review 后合并 `qcut-cli-v2` follow-up 分支**，把 stdio artifact

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -33,6 +33,7 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
 | `ed99a4ac9` + 本轮 follow-up           | **Phase 3 verification** —— GHCR owner 大小写修复、public `qcut-cli:v0` 发布、Daytona dogfood、worker row normalize、Daytona 可写输出目录                                                  | 完成 PR 05 Daytona swap-in 的 provider 验证                |
 | `ce02d4968`                            | `Dockerfile.cli` 现在安装固定版本 Codex CLI `0.130.0` 和 Claude Code CLI `2.1.142`；`qcut-smoke` 会硬检查两个 binary 和版本；GHCR `v0` 已重新发布                                              | 更新 PR 02 镜像契约                                       |
 | 本轮 follow-up                         | Chat Agent Codex 模式：license-server 只接受固定的 `codex exec --skip-git-repo-check --json -`，worker 用 base64 env 传 prompt，entrypoint 从 `CODEX_AUTH_JSON` 或受控 `OPENAI_API_KEY` 启动 Codex 登录 | 扩展 PR 02 + PR 04，支持 coding-agent sandbox 任务         |
+| `qcut-cli-v2` follow-up                | Daytona CLI 镜像补 YouTube 下载能力：预装固定版本 `yt-dlp` `2026.03.17`、Deno `2.7.4`，并写入 `/etc/yt-dlp.conf` 的 `--remote-components ejs:github`；Codex prompt 也要求临时安装/cache 不要写进 `/tmp/qcut-output` | 扩展 PR 02 镜像契约和 PR 04 Codex artifact 卫生            |
 
 ## 生产环境实测
 
@@ -54,6 +55,7 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
 | GHCR native-cli skill 镜像发布                                             | workflow run `25902797671` 重新发布 `ghcr.io/quriosity-agent/qcut-cli:v0`；digest `sha256:2b9b8c7aa80bc2e5db874f04ccca302bbce0693a7d90274fe2b8645049fdbb7b`；推后 smoke 验到 `.claude/skills/native-cli/SKILL.md` |
 | 本地 Codex auth bootstrap smoke                                           | `qcut-cli:codex-auth-smoke` 按 `linux/amd64` 构建；假的 `CODEX_AUTH_JSON` 能写成权限 `0600` 的 `~/.codex/auth.json`；`QCUT_CODEX_PROMPT_B64` 在镜像内能正确解码 |
 | Website Codex → QCut CLI 图片 E2E                                         | Chat Agent job `9b8a7693-00e0-4cff-8635-a7d78135d2d8` 成功，exit `0`；Codex 实际跑了 `qcut gen image ... -o /tmp/qcut-output`；上传了 JPG artifact `flux_dev_small-blue-square-icon-on-a-clean-white-background_1778827141210.jpg` |
+| 本地 YouTube-capable CLI 镜像 smoke                                      | `qcut-cli:youtube-fix` 按 `linux/amd64` 构建；`qcut-smoke` 通过；`yt-dlp` + Deno 能把 YouTube `.mp4` 下载进 `/tmp/qcut-output`，且不会把工具安装到 artifact 目录 |
 
 ## `b536d61b2` 之后已经完成的事
 
@@ -123,24 +125,110 @@ Worker 上**、schema 是 **Drizzle 管 Hyperdrive 后面的 Postgres**
     给每个 artifact 渲染 Download 按钮，用用户的 QCut auth token 或服务端
     配置的默认 agent account 去 fetch blob，然后触发浏览器下载；Supabase
     service-role key 不会暴露到前端。
+15. **Daytona qcut job 现在会把 CLI stdout/stderr 也作为 artifact 保存。**
+    E2E 探测发现：`qcut system check-keys --json` 这类非生成命令虽然
+    `exit_code=0`，但只上传空的 `qcut-output.tar`；失败命令也会出现
+    `error=null`、用户看不到失败原因。Daytona runner 现在会给每个 qcut
+    job 写入 `qcut-stdout.txt`、`qcut-stderr.txt` 和 `qcut-exit.json`。
+    wrapper 会记录真实 CLI exit code，但不会主动关闭 Daytona persistent
+    session shell。live 回归已验证失败路径
+    `575b396e-db81-480d-922d-20835650a63e` 和真实图片生成路径
+    `9785346b-b385-4d45-bde1-525e8139d088`。
+16. **下一版 CLI 镜像可以跑 YouTube 下载工作流。**
+    上一次 Codex YouTube probe 有两个独立问题：测试视频 `BaW_jenozKc`
+    现在本身就返回 `Video unavailable`；同时已发布的 CLI 镜像没有
+    `yt-dlp` 和 JavaScript runtime，导致 Codex 临时把工具装进
+    `/tmp/qcut-output`，污染 artifact。现在 `Dockerfile.cli` 会预装
+    `yt-dlp` `2026.03.17`、Deno `2.7.4`，并写入
+    `/etc/yt-dlp.conf` 的 `--remote-components ejs:github`。Codex 的运行
+    prompt 也要求临时工具 / cache 放到 `/tmp/qcut-tools` 或 `/tmp`，
+    `/tmp/qcut-output` 只放最终产物和小诊断文件。
+
+## Live CLI E2E 覆盖和耗时
+
+这一轮一共验证了 **9 个 live agent job**，覆盖 **5 类 CLI 命令形态**：
+help、auth/key 检查、model 列表、预期内参数校验失败、真实图片生成。
+下面的耗时来自生产 `agent_jobs.created_at`、`claimed_at`、`finished_at`：
+`queue` 是等 worker claim 的时间，`run` 是 Daytona sandbox 执行加 artifact
+下载 / 上传时间。
+
+| Job | Command | 结果 | 总耗时 | Queue | Run | Artifacts | 验证点 |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `bcec5b30` | `qcut gen image -t small-blue-square-icon-on-a-clean-white-background -m flux_dev --json` | succeeded / 0 | 12.1s | 1.1s | 11.0s | 3 | Website Chat Agent 可以跑真实图片生成，并返回 image/json/tar artifacts。 |
+| `0dd0e898` | `qcut --help --json` | succeeded / 0 | 5.3s | 1.2s | 4.2s | 1 | 修复前探测：命令成功但只有空 tar，暴露 stdout artifact 缺失。 |
+| `c6732148` | `qcut system check-keys --json` | succeeded / 0 | 7.5s | 4.3s | 3.2s | 1 | 修复前探测：auth/key 命令成功，但用户看不到输出。 |
+| `7d823624` | `qcut system models --json` | succeeded / 0 | 10.5s | 6.7s | 3.8s | 1 | 修复前探测：model 列表也有同样的输出不可见问题。 |
+| `d7e6813f` | `qcut gen image -m flux_dev --json` | failed / 1 | 4.8s | 0.5s | 4.3s | 1 | 修复前失败探测：参数校验失败时 `error=null`，没有可读原因。 |
+| `575b396e` | `qcut gen image -m flux_dev --json` | failed / 1 | 235.0s | 229.0s | 6.0s | 4 | 修复后失败探测：`qcut-stdout.txt` 现在能看到 `Missing --text/-t`；总耗时长是因为它排在一个被手动失败的 hung-wrapper probe 后面。 |
+| `da5a8216` | `qcut system check-keys --json` | succeeded / 0 | 6.1s | 0.9s | 5.2s | 4 | 修复后成功探测：非生成命令现在会上传 stdout/stderr/exit artifacts。 |
+| `9785346b` | `qcut gen image -t tiny-red-circle-icon-on-white-background -m flux_dev --json` | succeeded / 0 | 13.5s | 1.1s | 12.4s | 6 | 修复后真实图片生成仍然正常；返回 image/json 加 stdout/stderr/exit artifacts。 |
+| `899a9d6c` | `qcut --help --json` | succeeded / 0 | 7.4s | 1.3s | 6.1s | 4 | 已部署 license-server source probe，同时验证修复后的 help command artifact。 |
+
+修复后的稳定耗时大概是：
+
+- 轻量 CLI（`help`、`check-keys`）总耗时通常 **6-8 秒**。
+- 预期内参数校验失败被 claim 后大概 **6 秒 run time**。
+- 真实 `flux_dev` 图片生成在这条 Daytona 路径里大概 **12-14 秒总耗时**。
+- 单 worker 空闲时 queue 通常约 **1 秒**；`575b396e` 是异常值，因为它排在
+  我们故意打出来的 hung-wrapper probe 后面，中间重启过 worker。
+
+## Live Codex 多轮对话和 YouTube artifact 测试
+
+website Codex 模式用真实浏览器跑了三轮：
+
+| Job | Prompt 形态 | 结果 | 总耗时 | Queue | Run | Artifacts | 验证点 |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `8bac5fba` | 让 Codex 记住 `sapphire-bridge-481` | succeeded / 0 | 11.1s | 1.4s | 9.8s | 3 | 第一轮回复 `stored sapphire-bridge-481`，并上传 `codex-last-message.md`。 |
+| `19ff765e` | 不重复短语，直接问上一轮记住了什么 | succeeded / 0 | 12.7s | 1.0s | 11.8s | 3 | 当前多轮上下文可用：前端把历史消息重新拼进下一轮 `codexPrompt`，Codex 回答了 `sapphire-bridge-481`。 |
+| `619d2ec1` | 把公开的 youtube-dl 测试视频 `BaW_jenozKc` 下载到 `/tmp/qcut-output` | succeeded / 0 | 104.4s | 1.4s | 103.0s | 7 | Codex 执行了 shell 步骤并上传诊断文件，但 YouTube/yt-dlp 返回 `Video unavailable`；没有生成 `.mp4` artifact。 |
+
+当前 Codex 对话行为：
+
+- 页面不刷新时，多轮对话是可用的，因为前端会把之前的 user/assistant
+  messages 拼进下一次 `codexPrompt`。
+- 这还不是持久化 Codex session。每一轮仍然是新的 Daytona job；刷新页面后，
+  内存里的历史会丢，除非后续补 job history reload。
+- Codex 文件 artifact 是通的：`codex-events.jsonl`、`codex-last-message.md`
+  和写进 `/tmp/qcut-output` 的文件都会上传。
+
+YouTube 下载结果：
+
+- 这轮生成了 `youtube-download-summary.json`、
+  `youtube-download-stdout.txt`、`youtube-download-error.txt`。
+- `youtube-download-summary.json` 里是 `exit_status: 1`、
+  `downloaded_filename: ""`、`byte_size: 0`。
+- `youtube-download-error.txt` 里是
+  `ERROR: [youtube] BaW_jenozKc: Video unavailable`。
+- 因为下载没有完成，所以 artifacts 里没有 `.mp4`。
+- 本地 follow-up 修复已完成：CLI 镜像现在包含 `yt-dlp` 和 Deno，并打开
+  EJS remote components。干净的 `qcut-cli:youtube-fix` 容器先通过
+  `qcut-smoke`，再把 `https://www.youtube.com/watch?v=jNQXAC9IVRw`
+  下载成 `/tmp/qcut-output/youtube-test.mp4`（312 KB）。
+- 还要做一次 live 验证：把刷新后的镜像发布到 GHCR，让 Daytona worker
+  指向新的 tag/digest，然后从 website Chat Agent 重跑 YouTube prompt。
+  之前的 `BaW_jenozKc` 不能再当成功 probe，因为它现在脱离 QCut 也会返回
+  unavailable。
 
 ## 还没做的（依赖外部凭证 / 服务）
 
-1. **merge/deploy 本轮 worker 修复**。provider 路径已经用生产服务
-   本地验证；部署态 worker 也需要同样的 row normalize 和 Daytona
-   output dir 修复。
+1. **review 后合并 `qcut-cli-v2` follow-up 分支**，把 stdio artifact
+   capture、YouTube 镜像修复和这轮 E2E 记录进主线。
 2. **设 / 确认 license-server 密钥**（`wrangler secret put`）：
    `E2B_API_KEY`、`RELAY_SIGNING_SECRET`、`RELAY_HOST`、`QCUT_IMAGE_TAG`。
-3. **部署 / 确认 `@qcut/relay`**：`packages/qcut-relay` 下
+3. **发布刷新后的 CLI 镜像到 GHCR，并重跑 live Chat Agent YouTube E2E。**
+   本地手动 `docker push` 被 GHCR 拒了，因为当前 token 没有 package write
+   scope；所以要用 `qcut-cli-v2` 上的 `.github/workflows/cli-image.yml`
+   发临时 tag，或合并后再发布。
+4. **部署 / 确认 `@qcut/relay`**：`packages/qcut-relay` 下
    `wrangler deploy`。
-4. **轮换泄露的 Supabase PAT**（`sbp_b303...`）——GitHub secret
+5. **轮换泄露的 Supabase PAT**（`sbp_b303...`）——GitHub secret
    scanner 已看到。去 supabase.com/dashboard/account/tokens 新建一个。
-5. **wzrdagentstudio 接 QCut 登录**。SandboxPage 当前读
+6. **wzrdagentstudio 接 QCut 登录**。SandboxPage 当前读
    `localStorage.qcut_auth_token` 作为 v0 暂存——换成真正的 QCut
    sign-in 组件。
-6. **spawn 失败时退费**。PR 12 的 `routes/sandbox.ts` 先扣费，但
+7. **spawn 失败时退费**。PR 12 的 `routes/sandbox.ts` 先扣费，但
    E2B 失败后没退。
-7. **docker 不在时 stderr 抓不到**。PR 11 worker 退出码会落 DB，
+8. **docker 不在时 stderr 抓不到**。PR 11 worker 退出码会落 DB，
    但 `error` 列在 execa 起不来时是 null。
 
 ## 怎么读各 spec

--- a/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/ACTUAL.zh.md
@@ -244,6 +244,49 @@ YouTube 下载结果：
 - 之前的 `BaW_jenozKc` 不能再当成功 probe，因为它现在脱离 QCut 也会返回
   unavailable。
 
+## Terminal session artifact 下载修复
+
+生产 bug：
+
+- PTY session artifact 下载接口
+  `/api/agent/sessions/:sessionId/artifacts/:filename/download` 在
+  Cloudflare Workers 里失败，错误是：
+  `"Buffer" is not supported: Module "buffer" is not available in the
+  "serverless" runtime`。
+- 根因是 Daytona SDK 的 `sandbox.fs.downloadFile()` 会用 Node `Buffer`
+  解析下载 multipart body；Worker runtime 没有这个模块。
+
+已上线的修复：
+
+- 新增 `packages/license-server/src/services/daytona-download.ts`，改为调用
+  Daytona 底层 `downloadFiles` API，并指定 `responseType: "arraybuffer"`。
+- license-server 用 Web 标准的 `Uint8Array` / `TextEncoder` /
+  `TextDecoder` 解析 Daytona multipart response，不再碰 Node `Buffer`。
+- `packages/license-server/src/routes/agent.test.ts` 现在明确断言 session
+  下载路径不会调用 `sandbox.fs.downloadFile()`。
+- `packages/license-server/src/services/daytona-download.test.ts` 覆盖
+  multipart 文件提取、multipart error part、非 multipart 原始 bytes fallback。
+
+验证命令：
+
+```bash
+bun --cwd packages/license-server test src/routes/agent.test.ts src/services/daytona-download.test.ts
+node --test packages/nexusai-website/js/agent-chat.test.js
+bunx tsc --noEmit --strict --moduleResolution bundler --module ESNext --target ES2022 --typeRoots /tmp/qcut-empty-types packages/license-server/src/services/daytona-download.ts
+```
+
+2026-05-16 生产 E2E：
+
+| 步骤 | 证据 |
+| --- | --- |
+| license-server 部署 | version `0c0f9734-0bdc-4632-a62a-eb7b9696bb4f` |
+| relay 部署 | version `3d0ec83e-5aa1-477d-aafa-09115e27ab68` |
+| Session | `c4b059cc-d8c2-480d-8c8a-0dd07950b45d` |
+| Daytona sandbox | `960e6ecc-a2ea-4e00-9f9a-70c283ece3c9` |
+| PTY 证明 | WebSocket 成功 open，并写入 `/tmp/qcut-output/download-check.txt` |
+| Artifact list | 返回 `download-check.txt` |
+| Download 证明 | 已部署接口返回精确文本 `qcut artifact download ok` |
+
 ## 还没做的（依赖外部凭证 / 服务）
 
 1. **review 后合并 `qcut-cli-v2` follow-up 分支**，把 stdio artifact

--- a/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.md
@@ -11,6 +11,7 @@ three paths and what's done / not done.
 | ----------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `qcut-cli:agents-smoke` (local Docker image)          | local Docker daemon       | ✅ built for `linux/amd64`; `qcut-smoke` verifies qcut, Codex CLI `0.130.0`, and Claude Code `2.1.142`                                                                                                          | n/a                                |
 | `qcut-cli:codex-auth-smoke` (local Docker image)      | local Docker daemon       | ✅ built for `linux/amd64`; verifies qcut smoke plus runtime Codex auth bootstrap from `CODEX_AUTH_JSON` and prompt env decoding                                                                                 | n/a                                |
+| `qcut-cli:youtube-fix` (local Docker image)           | local Docker daemon       | ✅ built for `linux/amd64`; `qcut-smoke` verifies `yt-dlp` `2026.03.17`, Deno `2.7.4`, Codex, Claude, and native-cli; real YouTube `.mp4` download writes to `/tmp/qcut-output`                                 | n/a                                |
 | `qcut-cli:dev` (local Docker image)                   | local Docker daemon       | ✅ built, **verified end-to-end** against prod                                                                                                                                                                   | n/a                                |
 | `ghcr.io/quriosity-agent/qcut-cli:v0`                 | GitHub Container Registry | ✅ republished by workflow run `25902797671`; pushed-image `qcut-smoke` verifies qcut, Codex CLI `0.130.0`, Claude Code `2.1.142`, `native-cli` skill, and the latest entrypoint                                 | ✅ public, anonymous pull verified |
 | E2B template `qcut-cli` (ID `<your-e2b-template-id>`) | E2B's build cluster       | ⚠️ **built but with bugs** — `Sandbox.create()` works, but the `qcut` wrapper script's shebang is mangled (`#!/usr/bin/env bashnexec ...`). Needs rebuild with the `echo`-based wrapper now in `e2b.Dockerfile`. | n/a (E2B private)                  |
@@ -40,6 +41,10 @@ Current working:
   and Claude Code `2.1.142`. The local `linux/amd64`
   `qcut-cli:agents-smoke` image proves both binaries launch inside the
   same architecture Daytona consumes.
+- `Dockerfile.cli` now also installs pinned YouTube tooling: `yt-dlp`
+  `2026.03.17`, Deno `2.7.4`, and `/etc/yt-dlp.conf` with
+  `--remote-components ejs:github`. This lets Codex use `yt-dlp` directly
+  in Daytona without installing Python packages into `/tmp/qcut-output`.
 - `electron/native-pipeline/container/entrypoint.sh` now bootstraps Codex
   auth at runtime. `CODEX_AUTH_JSON` is validated with `jq`, written to
   `~/.codex/auth.json` with mode `0600`, and never enters
@@ -87,9 +92,22 @@ Verified provider runs:
   - auth file mode verified as `0600`
   - `QCUT_CODEX_PROMPT_B64` decoded inside the image without shell
     interpolation
+- Local YouTube image smoke succeeded:
+  - image `qcut-cli:youtube-fix`
+  - platform `linux/amd64`
+  - `qcut-smoke` verified `yt-dlp`, Deno, Codex, Claude, and native-cli
+  - `yt-dlp` downloaded `https://www.youtube.com/watch?v=jNQXAC9IVRw` to
+    `/tmp/qcut-output/youtube-test.mp4` (312 KB)
+  - the previous `BaW_jenozKc` probe should be considered invalid now
+    because YouTube returns `Video unavailable` for that ID independently
+    of QCut
 
 Currently still needs external provider work:
 
+- GHCR/Daytona: publish the refreshed `Dockerfile.cli` image with the
+  GitHub Actions workflow and point `QCUT_IMAGE_TAG` or the worker env to
+  the new tag/digest before the live website YouTube E2E. Manual local
+  `docker push` was blocked by a GHCR token missing package write scope.
 - E2B: if rebuilding the browser-sandbox template, re-run
   `e2b template create qcut-cli -d e2b.Dockerfile --cpu-count 2
 --memory-mb 4096` after moving workspace `node_modules` out (see
@@ -99,13 +117,19 @@ Currently still needs external provider work:
 ## Next subtask
 
 The GHCR/Daytona image path is proven, and GHCR `v0` now includes the
-Codex auth bootstrap. Next, continue Phase 3 product hardening:
+Codex auth bootstrap. The YouTube fix is verified locally in
+`qcut-cli:youtube-fix`; next, publish that image through GHCR and run the
+same prompt from the live Chat Agent page.
 
-1. Merge/deploy the worker changes that normalize Supabase rows and use
-   `/tmp/qcut-output` for Daytona.
-2. Implement credit refund on failed sandbox spawn.
-3. Design and migrate `agent_secrets.value` encryption.
-4. Replace the wzrdagentstudio `/sandbox` localStorage token shim with
+1. Dispatch `.github/workflows/cli-image.yml` from `qcut-cli-v2` with a
+   temporary tag such as `youtube-fix-2026-05-16`.
+2. Restart the local worker with `QCUT_IMAGE_TAG` set to that GHCR tag or
+   digest.
+3. Rerun the website Chat Agent YouTube download E2E with a currently
+   available, authorized video URL.
+4. Implement credit refund on failed sandbox spawn.
+5. Design and migrate `agent_secrets.value` encryption.
+6. Replace the wzrdagentstudio `/sandbox` localStorage token shim with
    the real QCut sign-in flow.
 
 ## Path A — local Docker (fastest, dev only)

--- a/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.md
@@ -14,6 +14,7 @@ three paths and what's done / not done.
 | `qcut-cli:youtube-fix` (local Docker image)           | local Docker daemon       | ✅ built for `linux/amd64`; `qcut-smoke` verifies `yt-dlp` `2026.03.17`, Deno `2.7.4`, Codex, Claude, and native-cli; real YouTube `.mp4` download writes to `/tmp/qcut-output`                                 | n/a                                |
 | `qcut-cli:dev` (local Docker image)                   | local Docker daemon       | ✅ built, **verified end-to-end** against prod                                                                                                                                                                   | n/a                                |
 | `ghcr.io/quriosity-agent/qcut-cli:v0`                 | GitHub Container Registry | ✅ republished by workflow run `25902797671`; pushed-image `qcut-smoke` verifies qcut, Codex CLI `0.130.0`, Claude Code `2.1.142`, `native-cli` skill, and the latest entrypoint                                 | ✅ public, anonymous pull verified |
+| `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516` | GitHub Container Registry | ✅ published by workflow run `25949183927`; digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`; pushed-image and local pull smoke passed; website YouTube E2E passed             | ✅ public, anonymous pull verified |
 | E2B template `qcut-cli` (ID `<your-e2b-template-id>`) | E2B's build cluster       | ⚠️ **built but with bugs** — `Sandbox.create()` works, but the `qcut` wrapper script's shebang is mangled (`#!/usr/bin/env bashnexec ...`). Needs rebuild with the `echo`-based wrapper now in `e2b.Dockerfile`. | n/a (E2B private)                  |
 
 Current working:
@@ -101,13 +102,26 @@ Verified provider runs:
   - the previous `BaW_jenozKc` probe should be considered invalid now
     because YouTube returns `Video unavailable` for that ID independently
     of QCut
+- GHCR YouTube image publish succeeded:
+  - workflow run `25949183927`
+  - image `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
+  - digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`
+  - pushed-image smoke passed in CI, and local pull + `qcut-smoke` passed
+- Website Chat Agent YouTube E2E succeeded:
+  - job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e`
+  - runner `aca4aa3b-941b-41cd-9ca9-fb28235c16ac`
+  - status `succeeded`, exit code `0`
+  - artifacts include downloadable `youtube-e2e.mp4` (464.8 KB),
+    `youtube-e2e-summary.json`, `qcut-output.tar`, `codex-last-message.md`,
+    and `codex-events.jsonl`
+  - Playwright clicked the MP4 Download button and saved
+    `.playwright-cli/youtube-e2e.mp4`
 
 Currently still needs external provider work:
 
-- GHCR/Daytona: publish the refreshed `Dockerfile.cli` image with the
-  GitHub Actions workflow and point `QCUT_IMAGE_TAG` or the worker env to
-  the new tag/digest before the live website YouTube E2E. Manual local
-  `docker push` was blocked by a GHCR token missing package write scope.
+- GHCR/Daytona: after merge, either republish the verified image as `v0`
+  / `latest`, or keep the Daytona runner pinned to the verified digest
+  above.
 - E2B: if rebuilding the browser-sandbox template, re-run
   `e2b template create qcut-cli -d e2b.Dockerfile --cpu-count 2
 --memory-mb 4096` after moving workspace `node_modules` out (see
@@ -116,20 +130,15 @@ Currently still needs external provider work:
 
 ## Next subtask
 
-The GHCR/Daytona image path is proven, and GHCR `v0` now includes the
-Codex auth bootstrap. The YouTube fix is verified locally in
-`qcut-cli:youtube-fix`; next, publish that image through GHCR and run the
-same prompt from the live Chat Agent page.
+The GHCR/Daytona image path is proven, GHCR `v0` includes the Codex auth
+bootstrap, and the YouTube-capable image is now verified through the live
+Chat Agent page.
 
-1. Dispatch `.github/workflows/cli-image.yml` from `qcut-cli-v2` with a
-   temporary tag such as `youtube-fix-2026-05-16`.
-2. Restart the local worker with `QCUT_IMAGE_TAG` set to that GHCR tag or
-   digest.
-3. Rerun the website Chat Agent YouTube download E2E with a currently
-   available, authorized video URL.
-4. Implement credit refund on failed sandbox spawn.
-5. Design and migrate `agent_secrets.value` encryption.
-6. Replace the wzrdagentstudio `/sandbox` localStorage token shim with
+1. Merge `qcut-cli-v2`, then decide whether to publish this digest as
+   `v0` / `latest` or continue with the digest pin.
+2. Implement credit refund on failed sandbox spawn.
+3. Design and migrate `agent_secrets.value` encryption.
+4. Replace the wzrdagentstudio `/sandbox` localStorage token shim with
    the real QCut sign-in flow.
 
 ## Path A — local Docker (fastest, dev only)

--- a/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.zh.md
@@ -13,6 +13,7 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
 | `qcut-cli:youtube-fix`（本地 Docker 镜像）        | 本地 Docker daemon        | ✅ 按 `linux/amd64` 构建；`qcut-smoke` 验过 `yt-dlp` `2026.03.17`、Deno `2.7.4`、Codex、Claude 和 native-cli；真实 YouTube `.mp4` 能写到 `/tmp/qcut-output` | n/a                         |
 | `qcut-cli:dev`（本地 Docker 镜像）                 | 本地 Docker daemon        | ✅ 已构建、**对生产端到端验证过**                                                                                                                           | n/a                         |
 | `ghcr.io/quriosity-agent/qcut-cli:v0`              | GitHub Container Registry | ✅ workflow run `25902797671` 已重新发布；推后 `qcut-smoke` 验过 qcut、Codex CLI `0.130.0`、Claude Code `2.1.142`、`native-cli` skill、最新 entrypoint            | ✅ public，匿名 pull 已验证 |
+| `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516` | GitHub Container Registry | ✅ workflow run `25949183927` 已发布；digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`；推后 smoke、本地 pull smoke、website YouTube E2E 都通过 | ✅ public，匿名 pull 已验证 |
 | E2B 模板 `qcut-cli`（ID `<your-e2b-template-id>`） | E2B 构建集群              | ⚠️ **建好了但有 bug** —— `Sandbox.create()` 能用，但 `qcut` 包装脚本的 shebang 被搞坏（`#!/usr/bin/env bashnexec ...`）。需要按现在 `e2b.Dockerfile` 重建。 | n/a（E2B 私有）             |
 
 当前能用：
@@ -94,13 +95,25 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
     下载成 `/tmp/qcut-output/youtube-test.mp4`（312 KB）
   - 之前的 `BaW_jenozKc` probe 现在应视为无效，因为 YouTube 对这个 ID
     本身就返回 `Video unavailable`，跟 QCut 无关
+- GHCR YouTube 镜像发布已通过：
+  - workflow run `25949183927`
+  - image `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
+  - digest `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`
+  - CI 里的 pushed-image smoke 通过，本地 pull + `qcut-smoke` 也通过
+- Website Chat Agent YouTube E2E 已通过：
+  - job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e`
+  - runner `aca4aa3b-941b-41cd-9ca9-fb28235c16ac`
+  - status `succeeded`，exit code `0`
+  - artifacts 包含可下载的 `youtube-e2e.mp4`（464.8 KB）、
+    `youtube-e2e-summary.json`、`qcut-output.tar`、`codex-last-message.md`
+    和 `codex-events.jsonl`
+  - Playwright 点击 MP4 Download 按钮后保存了
+    `.playwright-cli/youtube-e2e.mp4`
 
 当前还需要外部 provider 工作：
 
-- GHCR / Daytona：用 GitHub Actions workflow 发布刷新后的
-  `Dockerfile.cli` 镜像，再把 `QCUT_IMAGE_TAG` 或 worker env 指到新的
-  tag/digest，然后才能做 live website YouTube E2E。本地手动
-  `docker push` 被 GHCR 拒了，因为当前 token 没有 package write scope。
+- GHCR / Daytona：合并后决定是把已验证镜像重发成 `v0` / `latest`，还是
+  继续使用上面的 digest pin。
 - E2B：如果要刷新浏览器沙箱模板，移走 workspace `node_modules`
   后重跑 `e2b template create qcut-cli -d e2b.Dockerfile
 --cpu-count 2 --memory-mb 4096`（见下面 "绕路"）。现在
@@ -109,17 +122,13 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
 ## 下一个子任务
 
 GHCR/Daytona 镜像路径已经证明能跑，GHCR `v0` 现在也已经带 Codex auth
-bootstrap。YouTube 修复已在本地 `qcut-cli:youtube-fix` 验过；下一步是把
-这个镜像通过 GHCR 发布，再从 live Chat Agent 页面跑同一类 prompt。
+bootstrap；YouTube-capable 镜像也已经通过 live Chat Agent 页面验证。
 
-1. 从 `qcut-cli-v2` dispatch `.github/workflows/cli-image.yml`，用临时
-   tag，例如 `youtube-fix-2026-05-16`。
-2. 用新的 GHCR tag 或 digest 重启本地 worker，设置 `QCUT_IMAGE_TAG`。
-3. 用当前可访问、且有授权下载的视频 URL，从 website Chat Agent 重跑
-   YouTube 下载 E2E。
-4. 实现 sandbox spawn 失败时退 credit。
-5. 设计并迁移 `agent_secrets.value` 加密。
-6. 把 wzrdagentstudio `/sandbox` 的 localStorage token 占位换成真的
+1. 合并 `qcut-cli-v2`，然后决定把这个 digest 发布成 `v0` / `latest`，
+   还是继续使用 digest pin。
+2. 实现 sandbox spawn 失败时退 credit。
+3. 设计并迁移 `agent_secrets.value` 加密。
+4. 把 wzrdagentstudio `/sandbox` 的 localStorage token 占位换成真的
    QCut 登录流。
 
 ## 路径 A —— 本地 Docker（最快，仅开发）

--- a/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.zh.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/IMAGE-BOOTSTRAP.zh.md
@@ -10,6 +10,7 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
 | -------------------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | `qcut-cli:agents-smoke`（本地 Docker 镜像）        | 本地 Docker daemon        | ✅ 按 `linux/amd64` 构建；`qcut-smoke` 验过 qcut、Codex CLI `0.130.0`、Claude Code `2.1.142`                                                                 | n/a                         |
 | `qcut-cli:codex-auth-smoke`（本地 Docker 镜像）   | 本地 Docker daemon        | ✅ 按 `linux/amd64` 构建；验证 qcut smoke、`CODEX_AUTH_JSON` 运行时 Codex 登录启动、prompt env 解码                                                           | n/a                         |
+| `qcut-cli:youtube-fix`（本地 Docker 镜像）        | 本地 Docker daemon        | ✅ 按 `linux/amd64` 构建；`qcut-smoke` 验过 `yt-dlp` `2026.03.17`、Deno `2.7.4`、Codex、Claude 和 native-cli；真实 YouTube `.mp4` 能写到 `/tmp/qcut-output` | n/a                         |
 | `qcut-cli:dev`（本地 Docker 镜像）                 | 本地 Docker daemon        | ✅ 已构建、**对生产端到端验证过**                                                                                                                           | n/a                         |
 | `ghcr.io/quriosity-agent/qcut-cli:v0`              | GitHub Container Registry | ✅ workflow run `25902797671` 已重新发布；推后 `qcut-smoke` 验过 qcut、Codex CLI `0.130.0`、Claude Code `2.1.142`、`native-cli` skill、最新 entrypoint            | ✅ public，匿名 pull 已验证 |
 | E2B 模板 `qcut-cli`（ID `<your-e2b-template-id>`） | E2B 构建集群              | ⚠️ **建好了但有 bug** —— `Sandbox.create()` 能用，但 `qcut` 包装脚本的 shebang 被搞坏（`#!/usr/bin/env bashnexec ...`）。需要按现在 `e2b.Dockerfile` 重建。 | n/a（E2B 私有）             |
@@ -37,6 +38,10 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
   `0.130.0` 和 Claude Code `2.1.142`。本地 `linux/amd64`
   `qcut-cli:agents-smoke` 镜像已经证明这两个 binary 能在 Daytona
   使用的同架构里启动。
+- `Dockerfile.cli` 现在也会安装固定版本 YouTube 工具：`yt-dlp`
+  `2026.03.17`、Deno `2.7.4`，并写入 `/etc/yt-dlp.conf` 的
+  `--remote-components ejs:github`。这样 Codex 在 Daytona 里可以直接用
+  `yt-dlp`，不会把 Python 工具临时装进 `/tmp/qcut-output`。
 - `electron/native-pipeline/container/entrypoint.sh` 现在会在运行时启动
   Codex 登录。`CODEX_AUTH_JSON` 会先用 `jq` 校验，再写到权限 `0600`
   的 `~/.codex/auth.json`，不会进入 `~/.qcut/.env`。如果 Codex 任务
@@ -81,9 +86,21 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
   - fake `CODEX_AUTH_JSON` 能写入 `~/.codex/auth.json`
   - auth 文件权限验证为 `0600`
   - `QCUT_CODEX_PROMPT_B64` 能在镜像内解码，不经过 shell 插值
+- 本地 YouTube 镜像 smoke 已通过：
+  - image `qcut-cli:youtube-fix`
+  - platform `linux/amd64`
+  - `qcut-smoke` 验过 `yt-dlp`、Deno、Codex、Claude 和 native-cli
+  - `yt-dlp` 已把 `https://www.youtube.com/watch?v=jNQXAC9IVRw`
+    下载成 `/tmp/qcut-output/youtube-test.mp4`（312 KB）
+  - 之前的 `BaW_jenozKc` probe 现在应视为无效，因为 YouTube 对这个 ID
+    本身就返回 `Video unavailable`，跟 QCut 无关
 
 当前还需要外部 provider 工作：
 
+- GHCR / Daytona：用 GitHub Actions workflow 发布刷新后的
+  `Dockerfile.cli` 镜像，再把 `QCUT_IMAGE_TAG` 或 worker env 指到新的
+  tag/digest，然后才能做 live website YouTube E2E。本地手动
+  `docker push` 被 GHCR 拒了，因为当前 token 没有 package write scope。
 - E2B：如果要刷新浏览器沙箱模板，移走 workspace `node_modules`
   后重跑 `e2b template create qcut-cli -d e2b.Dockerfile
 --cpu-count 2 --memory-mb 4096`（见下面 "绕路"）。现在
@@ -92,13 +109,17 @@ E2B 三家都吃同一个 `Dockerfile.cli`，但**各自实体化成不同的产
 ## 下一个子任务
 
 GHCR/Daytona 镜像路径已经证明能跑，GHCR `v0` 现在也已经带 Codex auth
-bootstrap。下一步继续 Phase 3 的产品硬化：
+bootstrap。YouTube 修复已在本地 `qcut-cli:youtube-fix` 验过；下一步是把
+这个镜像通过 GHCR 发布，再从 live Chat Agent 页面跑同一类 prompt。
 
-1. merge/deploy worker 修复：Supabase row normalize、Daytona 使用
-   `/tmp/qcut-output`。
-2. 实现 sandbox spawn 失败时退 credit。
-3. 设计并迁移 `agent_secrets.value` 加密。
-4. 把 wzrdagentstudio `/sandbox` 的 localStorage token 占位换成真的
+1. 从 `qcut-cli-v2` dispatch `.github/workflows/cli-image.yml`，用临时
+   tag，例如 `youtube-fix-2026-05-16`。
+2. 用新的 GHCR tag 或 digest 重启本地 worker，设置 `QCUT_IMAGE_TAG`。
+3. 用当前可访问、且有授权下载的视频 URL，从 website Chat Agent 重跑
+   YouTube 下载 E2E。
+4. 实现 sandbox spawn 失败时退 credit。
+5. 设计并迁移 `agent_secrets.value` 加密。
+6. 把 wzrdagentstudio `/sandbox` 的 localStorage token 占位换成真的
    QCut 登录流。
 
 ## 路径 A —— 本地 Docker（最快，仅开发）

--- a/qcut/electron/native-pipeline/container/smoke.sh
+++ b/qcut/electron/native-pipeline/container/smoke.sh
@@ -22,6 +22,12 @@ git --version
 echo "▶ ffmpeg -version (first line)"
 ffmpeg -version | head -n 1
 
+echo "▶ yt-dlp --version"
+yt-dlp --version
+
+echo "▶ deno --version"
+deno --version | head -n 1
+
 echo "▶ which qcut"
 which qcut
 

--- a/qcut/packages/agent-worker/src/claim.ts
+++ b/qcut/packages/agent-worker/src/claim.ts
@@ -114,6 +114,11 @@ export function normalizeAgentJob({
 	return {
 		id,
 		userId,
+		sessionId: getNullableString({
+			row,
+			camelKey: "sessionId",
+			snakeKey: "session_id",
+		}),
 		status: status as AgentJob["status"],
 		command,
 		args: getArgs({ row }),

--- a/qcut/packages/agent-worker/src/main.ts
+++ b/qcut/packages/agent-worker/src/main.ts
@@ -12,6 +12,7 @@
  *   QCUT_IMAGE_TAG   (default: qcut-cli:dev)
  *   DAYTONA_API_KEY  (when present, the run path swaps in run-on-daytona)
  *   IDLE_POLL_MS     (default: 5000)
+ *   AGENT_SESSION_CLEANUP_MS (default: 60000)
  *
  * The worker keeps a Realtime subscription to agent_jobs INSERTs as a
  * wake-up hint, and falls back to polling so a network blip doesn't
@@ -35,6 +36,9 @@ import { uploadArtifacts } from "./upload-artifacts.js";
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const IDLE_POLL_MS = Number(process.env.IDLE_POLL_MS ?? "5000");
+const AGENT_SESSION_CLEANUP_MS = Number(
+	process.env.AGENT_SESSION_CLEANUP_MS ?? "60000"
+);
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
 	console.error(
@@ -77,6 +81,24 @@ async function chooseRunner(job: AgentJob): Promise<ContainerResult> {
 		return runOnDaytona({ supabase, job });
 	}
 	return runContainer(supabase, job);
+}
+
+async function cleanupAgentSessions(): Promise<void> {
+	if (!process.env.DAYTONA_API_KEY) {
+		return;
+	}
+	try {
+		const { cleanupDaytonaAgentSessions } = await import("./run-on-daytona.js");
+		const count = await cleanupDaytonaAgentSessions({
+			supabase,
+			runnerId: RUNNER_ID,
+		});
+		if (count > 0) {
+			console.log(`[agent-worker] cleaned up ${count} agent session(s)`);
+		}
+	} catch (err) {
+		console.error("[agent-worker] agent session cleanup failed:", err);
+	}
 }
 
 async function executeJob(job: AgentJob): Promise<void> {
@@ -163,10 +185,15 @@ const channel = supabase
 	});
 
 const idleTimer = setInterval(() => void tryDrain(), IDLE_POLL_MS);
+const sessionCleanupTimer = setInterval(
+	() => void cleanupAgentSessions(),
+	AGENT_SESSION_CLEANUP_MS
+);
 
 async function shutdown(sig: string): Promise<void> {
 	console.log(`[agent-worker ${RUNNER_ID}] ${sig}, draining…`);
 	clearInterval(idleTimer);
+	clearInterval(sessionCleanupTimer);
 	await channel.unsubscribe();
 	process.exit(0);
 }
@@ -175,3 +202,4 @@ process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
 // Kick once on startup so a row queued before subscription gets picked up.
 void tryDrain();
+void cleanupAgentSessions();

--- a/qcut/packages/agent-worker/src/main.ts
+++ b/qcut/packages/agent-worker/src/main.ts
@@ -84,7 +84,9 @@ async function executeJob(job: AgentJob): Promise<void> {
 	try {
 		const result = await chooseRunner(job);
 		outputDir = result.outputDir;
-		await streamEvents(supabase, job, result.stderr);
+		if (!result.eventsStreamed) {
+			await streamEvents(supabase, job, result.stderr);
+		}
 		await uploadArtifacts({ supabase, job, dir: result.outputDir });
 
 		const status = result.exitCode === 0 ? "succeeded" : "failed";

--- a/qcut/packages/agent-worker/src/run-container.ts
+++ b/qcut/packages/agent-worker/src/run-container.ts
@@ -30,6 +30,7 @@ const CODEX_SANDBOX_CONTEXT = [
 	`Related native-cli references live under ${NATIVE_CLI_SKILL_DIR}/references and editor docs live under ${NATIVE_CLI_SKILL_DIR}/editor.`,
 	"Read that skill before running nontrivial QCut CLI workflows or when command syntax is unclear.",
 	"yt-dlp and deno are available for authorized video download probes.",
+	"For long-running shell commands, stream user-visible stdout with tee -a /tmp/qcut-output/codex-live-stdout.log.",
 	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
 	"Write only final user-requested files and small diagnostic summaries/logs under /tmp/qcut-output.",
 ].join("\n");

--- a/qcut/packages/agent-worker/src/run-container.ts
+++ b/qcut/packages/agent-worker/src/run-container.ts
@@ -117,7 +117,7 @@ export function buildCodexShellCommand({
 	return [
 		"set -o pipefail",
 		`mkdir -p ${outputDir}`,
-		`printf '%s' "$${CODEX_PROMPT_ENV}" | base64 -d | /usr/local/bin/qcut-entrypoint codex exec --skip-git-repo-check --sandbox danger-full-access --json --output-last-message ${outputDir}/codex-last-message.md - > ${outputDir}/codex-events.jsonl`,
+		`printf '%s' "$${CODEX_PROMPT_ENV}" | base64 -d | /usr/local/bin/qcut-entrypoint codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --json --output-last-message ${outputDir}/codex-last-message.md - > ${outputDir}/codex-events.jsonl`,
 	].join("; ");
 }
 

--- a/qcut/packages/agent-worker/src/run-container.ts
+++ b/qcut/packages/agent-worker/src/run-container.ts
@@ -45,6 +45,8 @@ export interface ContainerResult {
 	stderr: string;
 	exitCode: number;
 	outputDir: string;
+	/** True when the runner already streamed agent_events during execution. */
+	eventsStreamed?: boolean;
 	/** True when outputDir holds a stand-in (e.g. downloadDir failed), not real artifacts. */
 	artifactsFallback?: boolean;
 }

--- a/qcut/packages/agent-worker/src/run-container.ts
+++ b/qcut/packages/agent-worker/src/run-container.ts
@@ -29,6 +29,9 @@ const CODEX_SANDBOX_CONTEXT = [
 	`The QCut native CLI skill is available at ${NATIVE_CLI_SKILL_PATH}.`,
 	`Related native-cli references live under ${NATIVE_CLI_SKILL_DIR}/references and editor docs live under ${NATIVE_CLI_SKILL_DIR}/editor.`,
 	"Read that skill before running nontrivial QCut CLI workflows or when command syntax is unclear.",
+	"yt-dlp and deno are available for authorized video download probes.",
+	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
+	"Write only final user-requested files and small diagnostic summaries/logs under /tmp/qcut-output.",
 ].join("\n");
 
 // Anything beyond simple whitespace-separated tokens with the usual

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -656,6 +656,215 @@ describe("runOnDaytona", () => {
 		await rm(outputDir, { recursive: true, force: true });
 	});
 
+	it("creates a persistent sandbox for a new agent session and leaves it running", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, insertedEvents, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "active",
+					provider_session_id: null,
+					image_tag: "qcut-cli:session-row",
+					last_active_at: "2026-05-14T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: null,
+				},
+			],
+		});
+		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
+		const createCalls: unknown[] = [];
+		const deleteCalls: string[] = [];
+		const sandbox = {
+			id: "sandbox-new-session",
+			process: {
+				createSession() {
+					return Promise.resolve();
+				},
+				deleteSession() {
+					return Promise.resolve();
+				},
+				executeSessionCommand(
+					_sessionId: string,
+					request: { command: string }
+				) {
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				},
+			},
+			fs: {
+				downloadFile() {
+					return Promise.resolve();
+				},
+			},
+		};
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.reject(new Error("no existing sandbox"));
+			}
+
+			create(params: unknown) {
+				createCalls.push(params);
+				return Promise.resolve(sandbox);
+			}
+
+			delete(target: { id: string }) {
+				deleteCalls.push(target.id);
+				return Promise.resolve();
+			}
+		}
+
+		await runOnDaytona({
+			supabase: client,
+			job: makeJob({ sessionId: "agent-session-1" }),
+			deps: {
+				DaytonaClient: FakeDaytonaClient,
+				makeOutputDir: () => Promise.resolve(outputDir),
+				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
+				extractArchive: () => Promise.resolve(),
+			},
+		});
+
+		expect(createCalls).toEqual([
+			expect.objectContaining({
+				image: "qcut-cli:session-row",
+				autoStopInterval: 120,
+			}),
+		]);
+		expect(deleteCalls).toEqual([]);
+		expect(sessionUpdates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					provider_session_id: "sandbox-new-session",
+					runner_id: "runner-1",
+				}),
+			])
+		);
+		expect(
+			flattenInsertedEvents({ insertedEvents }).find(
+				(event) => event.kind === "agent_session_ready"
+			)?.payload
+		).toMatchObject({
+			sessionId: "agent-session-1",
+			sandboxId: "sandbox-new-session",
+			reused: false,
+		});
+
+		await rm(outputDir, { recursive: true, force: true });
+	});
+
+	it("replaces a missing persisted agent session sandbox without deleting the replacement", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { client, insertedEvents, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "active",
+					provider_session_id: "sandbox-gone",
+					image_tag: "qcut-cli:session-row",
+					last_active_at: "2026-05-14T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: null,
+				},
+			],
+		});
+		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
+		const createCalls: unknown[] = [];
+		const deleteCalls: string[] = [];
+		const sandbox = {
+			id: "sandbox-replacement",
+			process: {
+				createSession() {
+					return Promise.resolve();
+				},
+				deleteSession() {
+					return Promise.resolve();
+				},
+				executeSessionCommand(
+					_sessionId: string,
+					request: { command: string }
+				) {
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				},
+			},
+			fs: {
+				downloadFile() {
+					return Promise.resolve();
+				},
+			},
+		};
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.reject(new Error("sandbox not found"));
+			}
+
+			create(params: unknown) {
+				createCalls.push(params);
+				return Promise.resolve(sandbox);
+			}
+
+			delete(target: { id: string }) {
+				deleteCalls.push(target.id);
+				return Promise.resolve();
+			}
+		}
+
+		await runOnDaytona({
+			supabase: client,
+			job: makeJob({ sessionId: "agent-session-1" }),
+			deps: {
+				DaytonaClient: FakeDaytonaClient,
+				makeOutputDir: () => Promise.resolve(outputDir),
+				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
+				extractArchive: () => Promise.resolve(),
+			},
+		});
+
+		expect(createCalls).toEqual([
+			expect.objectContaining({ image: "qcut-cli:session-row" }),
+		]);
+		expect(deleteCalls).toEqual([]);
+		expect(sessionUpdates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					provider_session_id: "sandbox-replacement",
+				}),
+			])
+		);
+		expect(
+			flattenInsertedEvents({ insertedEvents }).find(
+				(event) => event.kind === "agent_session_ready"
+			)?.payload
+		).toMatchObject({ reused: false, sandboxId: "sandbox-replacement" });
+
+		await rm(outputDir, { recursive: true, force: true });
+	});
+
 	it("cleans up idle Daytona agent sessions", async () => {
 		process.env.DAYTONA_API_KEY = "daytona-test";
 		const { client, insertedEvents, sessionUpdates } = makeSupabase({
@@ -728,5 +937,149 @@ describe("runOnDaytona", () => {
 		expect(
 			flattenInsertedEvents({ insertedEvents }).map((event) => event.kind)
 		).toContain("agent_session_ended");
+	});
+
+	it("marks expired sessions with the ttl cleanup reason", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "active",
+					provider_session_id: null,
+					image_tag: "qcut-cli",
+					last_active_at: "2099-01-01T00:00:00.000Z",
+					expires_at: "2000-01-01T00:00:00.000Z",
+					end_reason: null,
+				},
+			],
+		});
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.reject(new Error("get should not run without sandbox"));
+			}
+
+			create() {
+				return Promise.reject(
+					new Error("create should not run during cleanup")
+				);
+			}
+
+			delete() {
+				return Promise.reject(
+					new Error("delete should not run without sandbox")
+				);
+			}
+		}
+
+		const count = await cleanupDaytonaAgentSessions({
+			supabase: client,
+			runnerId: "runner-cleanup",
+			deps: { DaytonaClient: FakeDaytonaClient },
+		});
+
+		expect(count).toBe(1);
+		expect(sessionUpdates).toEqual([
+			expect.objectContaining({ status: "ended", end_reason: "ttl" }),
+		]);
+	});
+
+	it("marks stopping sessions with the user_kill cleanup reason", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "stopping",
+					provider_session_id: null,
+					image_tag: "qcut-cli",
+					last_active_at: "2099-01-01T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: "user_kill",
+				},
+			],
+		});
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.reject(new Error("get should not run without sandbox"));
+			}
+
+			create() {
+				return Promise.reject(
+					new Error("create should not run during cleanup")
+				);
+			}
+
+			delete() {
+				return Promise.reject(
+					new Error("delete should not run without sandbox")
+				);
+			}
+		}
+
+		const count = await cleanupDaytonaAgentSessions({
+			supabase: client,
+			runnerId: "runner-cleanup",
+			deps: { DaytonaClient: FakeDaytonaClient },
+		});
+
+		expect(count).toBe(1);
+		expect(sessionUpdates).toEqual([
+			expect.objectContaining({ status: "ended", end_reason: "user_kill" }),
+		]);
+	});
+
+	it("ends cleanup rows even when Daytona delete reports the sandbox is gone", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { client, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "stopping",
+					provider_session_id: "sandbox-gone",
+					image_tag: "qcut-cli",
+					last_active_at: "2099-01-01T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: "user_kill",
+				},
+			],
+		});
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.reject(new Error("404 sandbox not found"));
+			}
+
+			create() {
+				return Promise.reject(
+					new Error("create should not run during cleanup")
+				);
+			}
+
+			delete() {
+				return Promise.reject(new Error("delete should not run after 404"));
+			}
+		}
+
+		const count = await cleanupDaytonaAgentSessions({
+			supabase: client,
+			runnerId: "runner-cleanup",
+			deps: { DaytonaClient: FakeDaytonaClient },
+		});
+
+		expect(count).toBe(1);
+		expect(sessionUpdates).toEqual([
+			expect.objectContaining({
+				status: "ended",
+				end_reason: "user_kill",
+				runner_id: "runner-cleanup",
+			}),
+		]);
 	});
 });

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -220,6 +220,11 @@ describe("buildDaytonaCommand", () => {
 				"tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
 			streams: [
 				{
+					path: "/tmp/qcut-output/codex-live-stdout.log",
+					kind: "codex_stdout",
+					source: "codex-live-stdout.log",
+				},
+				{
 					path: "/tmp/qcut-output/codex-events.jsonl",
 					kind: "codex_event",
 					source: "codex-events.jsonl",
@@ -449,6 +454,115 @@ describe("runOnDaytona", () => {
 			"daytona_command_finished",
 		]);
 		expect(stdoutReads).toBeGreaterThan(1);
+
+		await rm(outputDir, { recursive: true, force: true });
+	});
+
+	it("streams Codex live stdout without duplicating final aggregated output", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, insertedEvents } = makeSupabase();
+		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
+		const codexEvent = JSON.stringify({
+			item: {
+				id: "item_0",
+				type: "command_execution",
+				status: "completed",
+				command:
+					"/bin/bash -lc 'echo LIVE_1 | tee -a /tmp/qcut-output/codex-live-stdout.log'",
+				exit_code: 0,
+				aggregated_output: "LIVE_1\n",
+			},
+			type: "item.completed",
+		});
+		const sandbox = {
+			id: "sandbox-1",
+			process: {
+				createSession() {
+					return Promise.resolve();
+				},
+				deleteSession() {
+					return Promise.resolve();
+				},
+				executeSessionCommand(
+					_sessionId: string,
+					request: { command: string }
+				) {
+					if (request.command.includes("codex-live-stdout.log")) {
+						return Promise.resolve({
+							stdout: "LIVE_1\n",
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (request.command.includes("codex-events.jsonl")) {
+						return Promise.resolve({
+							stdout: `${codexEvent}\n`,
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (request.command.includes(".qcut-agent-wrapper-stderr")) {
+						return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					return Promise.resolve({ stdout: "ok", stderr: "", exitCode: 0 });
+				},
+			},
+			fs: {
+				downloadFile() {
+					return Promise.resolve();
+				},
+			},
+		};
+
+		class FakeDaytonaClient {
+			create() {
+				return Promise.resolve(sandbox);
+			}
+
+			get() {
+				return Promise.reject(
+					new Error("get should not run for one-shot jobs")
+				);
+			}
+
+			delete() {
+				return Promise.resolve();
+			}
+		}
+
+		await runOnDaytona({
+			supabase: client,
+			job: makeJob({
+				command: CODEX_AGENT_COMMAND,
+				args: { codexPrompt: "Run a streaming probe." },
+			}),
+			deps: {
+				DaytonaClient: FakeDaytonaClient,
+				makeOutputDir: () => Promise.resolve(outputDir),
+				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
+				extractArchive: () => Promise.resolve(),
+			},
+		});
+
+		const stdoutEvents = flattenInsertedEvents({ insertedEvents }).filter(
+			(event) => event.kind === "codex_stdout"
+		);
+		expect(stdoutEvents).toHaveLength(1);
+		expect(stdoutEvents[0]?.payload).toMatchObject({
+			message: "LIVE_1",
+			source: "codex-live-stdout.log",
+		});
 
 		await rm(outputDir, { recursive: true, force: true });
 	});

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -15,6 +15,22 @@ import {
 
 const originalDaytonaApiKey = process.env.DAYTONA_API_KEY;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
+const EXPECTED_QCUT_DOCTOR_DAYTONA_COMMAND = [
+	"mkdir -p /tmp/qcut-output",
+	"set +e",
+	"/usr/local/bin/qcut-entrypoint qcut system doctor --json --skip-health -o /tmp/qcut-output > /tmp/qcut-output/qcut-stdout.txt 2> /tmp/qcut-output/qcut-stderr.txt",
+	"exit_code=$?",
+	'printf \'{"exitCode":%s}\\n\' "$exit_code" > /tmp/qcut-output/qcut-exit.json',
+	'[ "$exit_code" -eq 0 ]',
+].join("; ");
+const EXPECTED_QCUT_IMAGE_DAYTONA_COMMAND = [
+	"mkdir -p /tmp/qcut-output",
+	"set +e",
+	"/usr/local/bin/qcut-entrypoint qcut gen image -t icon,logo -m flux_dev --json -o /tmp/qcut-output > /tmp/qcut-output/qcut-stdout.txt 2> /tmp/qcut-output/qcut-stderr.txt",
+	"exit_code=$?",
+	'printf \'{"exitCode":%s}\\n\' "$exit_code" > /tmp/qcut-output/qcut-exit.json',
+	'[ "$exit_code" -eq 0 ]',
+].join("; ");
 
 afterEach(() => {
 	process.env.DAYTONA_API_KEY = originalDaytonaApiKey;
@@ -80,8 +96,7 @@ describe("buildDaytonaCommand", () => {
 				command: "qcut system doctor --json --skip-health",
 			})
 		).toEqual({
-			command:
-				"mkdir -p /tmp/qcut-output && /usr/local/bin/qcut-entrypoint qcut system doctor --json --skip-health -o /tmp/qcut-output",
+			command: EXPECTED_QCUT_DOCTOR_DAYTONA_COMMAND,
 			archiveCommand: "tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
 		});
 	});
@@ -92,8 +107,7 @@ describe("buildDaytonaCommand", () => {
 				command: "qcut gen image -t icon,logo -m flux_dev --json",
 			})
 		).toEqual({
-			command:
-				"mkdir -p /tmp/qcut-output && /usr/local/bin/qcut-entrypoint qcut gen image -t icon,logo -m flux_dev --json -o /tmp/qcut-output",
+			command: EXPECTED_QCUT_IMAGE_DAYTONA_COMMAND,
 			archiveCommand: "tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
 		});
 	});
@@ -252,7 +266,7 @@ describe("runOnDaytona", () => {
 			},
 		]);
 		expect(sessionCalls).toContain(
-			"session-1:mkdir -p /tmp/qcut-output && /usr/local/bin/qcut-entrypoint qcut system doctor --json --skip-health -o /tmp/qcut-output:1800"
+			`session-1:${EXPECTED_QCUT_DOCTOR_DAYTONA_COMMAND}:1800`
 		);
 		expect(sessionCalls).toContain(
 			"session-1:tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .:1800"

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -255,7 +255,7 @@ describe("runOnDaytona", () => {
 		expect(createCalls).toEqual([
 			{
 				image:
-					"ghcr.io/quriosity-agent/qcut-cli@sha256:2b9b8c7aa80bc2e5db874f04ccca302bbce0693a7d90274fe2b8645049fdbb7b",
+					"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923",
 				envVars: {
 					QCUT_SESSION_ROLE: "agent",
 					OPENAI_API_KEY: "sk-test",

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -10,6 +10,7 @@ import type { AgentJob } from "@qcut/db";
 import {
 	buildDaytonaCommand,
 	buildDaytonaEnv,
+	cleanupDaytonaAgentSessions,
 	runOnDaytona,
 } from "./run-on-daytona";
 
@@ -41,6 +42,7 @@ function makeJob(overrides: Partial<AgentJob> = {}): AgentJob {
 	return {
 		id: "job-1",
 		userId: "user-1",
+		sessionId: null,
 		status: "running",
 		command: "qcut system doctor --json --skip-health",
 		args: {},
@@ -56,13 +58,17 @@ function makeJob(overrides: Partial<AgentJob> = {}): AgentJob {
 
 function makeSupabase({
 	secrets = [{ key: "OPENAI_API_KEY", value: "sk-test" }],
+	agentSessions = [],
 }: {
 	secrets?: Array<{ key: string; value: string }>;
+	agentSessions?: Array<Record<string, unknown>>;
 } = {}): {
 	client: SupabaseClient;
 	insertedEvents: unknown[];
+	sessionUpdates: Array<Record<string, unknown>>;
 } {
 	const insertedEvents: unknown[] = [];
+	const sessionUpdates: Array<Record<string, unknown>> = [];
 	const client = {
 		from(table: string) {
 			if (table === "agent_secrets") {
@@ -71,6 +77,52 @@ function makeSupabase({
 						return {
 							eq() {
 								return Promise.resolve({ data: secrets, error: null });
+							},
+						};
+					},
+				};
+			}
+			if (table === "agent_sessions") {
+				return {
+					select() {
+						const filters: Record<string, unknown> = {};
+						const chain = {
+							eq(column: string, value: unknown) {
+								filters[column] = value;
+								return chain;
+							},
+							maybeSingle() {
+								const row = agentSessions.find((session) =>
+									Object.entries(filters).every(
+										([column, value]) => session[column] === value
+									)
+								);
+								return Promise.resolve({ data: row ?? null, error: null });
+							},
+							in() {
+								return chain;
+							},
+							or() {
+								return chain;
+							},
+							limit() {
+								return Promise.resolve({
+									data: agentSessions,
+									error: null,
+								});
+							},
+						};
+						return chain;
+					},
+					update(values: Record<string, unknown>) {
+						sessionUpdates.push(values);
+						return {
+							eq() {
+								return {
+									eq() {
+										return Promise.resolve({ data: null, error: null });
+									},
+								};
 							},
 						};
 					},
@@ -86,7 +138,7 @@ function makeSupabase({
 		},
 	} as unknown as SupabaseClient;
 
-	return { client, insertedEvents };
+	return { client, insertedEvents, sessionUpdates };
 }
 
 function flattenInsertedEvents({
@@ -159,14 +211,11 @@ describe("buildDaytonaCommand", () => {
 	});
 
 	it("builds a codex stdin command without interpolating the prompt", () => {
-		expect(
-			buildDaytonaCommand({
-				command: CODEX_AGENT_COMMAND,
-				args: { codexPrompt: "Explain QCut's agent path." },
-			})
-		).toMatchObject({
-			command:
-				"set -o pipefail; mkdir -p /tmp/qcut-output; printf '%s' \"$QCUT_CODEX_PROMPT_B64\" | base64 -d | /usr/local/bin/qcut-entrypoint codex exec --skip-git-repo-check --sandbox danger-full-access --json --output-last-message /tmp/qcut-output/codex-last-message.md - > /tmp/qcut-output/codex-events.jsonl",
+		const commandParts = buildDaytonaCommand({
+			command: CODEX_AGENT_COMMAND,
+			args: { codexPrompt: "Explain QCut's agent path." },
+		});
+		expect(commandParts).toMatchObject({
 			archiveCommand:
 				"tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
 			streams: [
@@ -185,6 +234,11 @@ describe("buildDaytonaCommand", () => {
 			stderrPath: "/tmp/qcut-output/.qcut-agent-wrapper-stderr",
 			exitPath: "/tmp/qcut-output/qcut-exit.json",
 		});
+		const command = commandParts.command;
+		expect(command).toContain("export QCUT_CODEX_PROMPT_B64=");
+		expect(command).toContain("export QCUT_BOOTSTRAP_CODEX=1");
+		expect(command).toContain("/usr/local/bin/qcut-entrypoint codex exec");
+		expect(command).not.toContain("Explain QCut's agent path.");
 	});
 });
 
@@ -325,6 +379,12 @@ describe("runOnDaytona", () => {
 				return Promise.resolve(sandbox);
 			}
 
+			get() {
+				return Promise.reject(
+					new Error("get should not run for one-shot jobs")
+				);
+			}
+
 			delete(target: { id: string }) {
 				deleteCalls.push(target.id);
 				return Promise.resolve();
@@ -459,6 +519,12 @@ describe("runOnDaytona", () => {
 				return Promise.resolve(sandbox);
 			}
 
+			get() {
+				return Promise.reject(
+					new Error("get should not run for one-shot jobs")
+				);
+			}
+
 			delete() {
 				return Promise.resolve();
 			}
@@ -487,5 +553,180 @@ describe("runOnDaytona", () => {
 		expect(result.artifactsFallback).toBe(true);
 
 		await rm(outputDir, { recursive: true, force: true });
+	});
+
+	it("reuses a persisted agent session sandbox and keeps it alive after the job", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, insertedEvents, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "active",
+					provider_session_id: "sandbox-persisted",
+					image_tag:
+						"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923",
+					last_active_at: "2026-05-14T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: null,
+				},
+			],
+		});
+		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
+		const getCalls: string[] = [];
+		const deleteCalls: string[] = [];
+
+		const sandbox = {
+			id: "sandbox-persisted",
+			process: {
+				createSession() {
+					return Promise.resolve();
+				},
+				deleteSession() {
+					return Promise.resolve();
+				},
+				executeSessionCommand(
+					_sessionId: string,
+					request: { command: string }
+				) {
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				},
+			},
+			fs: {
+				downloadFile() {
+					return Promise.resolve();
+				},
+			},
+		};
+
+		class FakeDaytonaClient {
+			get(sandboxId: string) {
+				getCalls.push(sandboxId);
+				return Promise.resolve(sandbox);
+			}
+
+			create() {
+				return Promise.reject(
+					new Error("create should not run for an existing session")
+				);
+			}
+
+			delete(target: { id: string }) {
+				deleteCalls.push(target.id);
+				return Promise.resolve();
+			}
+		}
+
+		await runOnDaytona({
+			supabase: client,
+			job: makeJob({ sessionId: "agent-session-1" }),
+			deps: {
+				DaytonaClient: FakeDaytonaClient,
+				makeOutputDir: () => Promise.resolve(outputDir),
+				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
+				extractArchive: () => Promise.resolve(),
+			},
+		});
+
+		expect(getCalls).toEqual(["sandbox-persisted"]);
+		expect(deleteCalls).toEqual([]);
+		expect(sessionUpdates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					provider_session_id: "sandbox-persisted",
+					runner_id: "runner-1",
+				}),
+			])
+		);
+		expect(
+			flattenInsertedEvents({ insertedEvents }).map((event) => event.kind)
+		).toContain("agent_session_ready");
+
+		await rm(outputDir, { recursive: true, force: true });
+	});
+
+	it("cleans up idle Daytona agent sessions", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		const { client, insertedEvents, sessionUpdates } = makeSupabase({
+			agentSessions: [
+				{
+					id: "agent-session-1",
+					user_id: "user-1",
+					status: "active",
+					provider_session_id: "sandbox-persisted",
+					image_tag: "qcut-cli",
+					last_active_at: "2026-05-14T00:00:00.000Z",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					end_reason: null,
+				},
+			],
+		});
+		const deleteCalls: string[] = [];
+		const sandbox = {
+			id: "sandbox-persisted",
+			process: {
+				createSession() {
+					return Promise.resolve();
+				},
+				deleteSession() {
+					return Promise.resolve();
+				},
+				executeSessionCommand() {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				},
+			},
+			fs: {
+				downloadFile() {
+					return Promise.resolve();
+				},
+			},
+		};
+
+		class FakeDaytonaClient {
+			get() {
+				return Promise.resolve(sandbox);
+			}
+
+			create() {
+				return Promise.reject(
+					new Error("create should not run during cleanup")
+				);
+			}
+
+			delete(target: { id: string }) {
+				deleteCalls.push(target.id);
+				return Promise.resolve();
+			}
+		}
+
+		const count = await cleanupDaytonaAgentSessions({
+			supabase: client,
+			runnerId: "runner-cleanup",
+			deps: { DaytonaClient: FakeDaytonaClient },
+		});
+
+		expect(count).toBe(1);
+		expect(deleteCalls).toEqual(["sandbox-persisted"]);
+		expect(sessionUpdates).toEqual([
+			expect.objectContaining({
+				status: "ended",
+				end_reason: "idle_timeout",
+				runner_id: "runner-cleanup",
+			}),
+		]);
+		expect(
+			flattenInsertedEvents({ insertedEvents }).map((event) => event.kind)
+		).toContain("agent_session_ended");
 	});
 });

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -243,6 +243,7 @@ describe("runOnDaytona", () => {
 		const { client, insertedEvents } = makeSupabase();
 		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
 		const sessionCalls: string[] = [];
+		let stdoutReads = 0;
 		const clientConfigs: Array<{ apiKey: string }> = [];
 		const createCalls: unknown[] = [];
 		const deleteCalls: string[] = [];
@@ -265,7 +266,18 @@ describe("runOnDaytona", () => {
 					timeout?: number
 				) {
 					sessionCalls.push(`${sessionId}:${request.command}:${timeout}`);
-					if (request.command.includes("qcut-stdout.txt")) {
+					if (
+						request.command.startsWith("cat ") &&
+						request.command.includes("qcut-stdout.txt")
+					) {
+						stdoutReads += 1;
+						if (stdoutReads === 1) {
+							return Promise.reject(
+								new Error(
+									'DaytonaError: failed to execute command: bad request: failed to convert exit code to int: strconv.Atoi: parsing "": invalid syntax'
+								)
+							);
+						}
 						return Promise.resolve({
 							stdout: '{"kind":"cli_progress","message":"halfway"}\n',
 							stderr: "",
@@ -376,6 +388,7 @@ describe("runOnDaytona", () => {
 			"cli_progress",
 			"daytona_command_finished",
 		]);
+		expect(stdoutReads).toBeGreaterThan(1);
 
 		await rm(outputDir, { recursive: true, force: true });
 	});

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -243,6 +243,7 @@ describe("buildDaytonaCommand", () => {
 		expect(command).toContain("export QCUT_CODEX_PROMPT_B64=");
 		expect(command).toContain("export QCUT_BOOTSTRAP_CODEX=1");
 		expect(command).toContain("/usr/local/bin/qcut-entrypoint codex exec");
+		expect(command).toContain("--dangerously-bypass-approvals-and-sandbox");
 		expect(command).not.toContain("Explain QCut's agent path.");
 	});
 });

--- a/qcut/packages/agent-worker/src/run-on-daytona.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.test.ts
@@ -89,15 +89,54 @@ function makeSupabase({
 	return { client, insertedEvents };
 }
 
+function flattenInsertedEvents({
+	insertedEvents,
+}: {
+	insertedEvents: unknown[];
+}): Array<{ kind?: unknown; payload?: unknown }> {
+	const rows: Array<{ kind?: unknown; payload?: unknown }> = [];
+	for (const entry of insertedEvents) {
+		if (Array.isArray(entry)) {
+			for (const row of entry) {
+				rows.push(row as { kind?: unknown; payload?: unknown });
+			}
+			continue;
+		}
+		rows.push(entry as { kind?: unknown; payload?: unknown });
+	}
+	return rows;
+}
+
 describe("buildDaytonaCommand", () => {
 	it("wraps qcut through the container entrypoint and archives /output", () => {
 		expect(
 			buildDaytonaCommand({
 				command: "qcut system doctor --json --skip-health",
 			})
-		).toEqual({
+		).toMatchObject({
 			command: EXPECTED_QCUT_DOCTOR_DAYTONA_COMMAND,
-			archiveCommand: "tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
+			archiveCommand:
+				"tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
+			streams: [
+				{
+					path: "/tmp/qcut-output/qcut-stdout.txt",
+					kind: "daytona_stdout",
+					source: "qcut-stdout.txt",
+				},
+				{
+					path: "/tmp/qcut-output/qcut-stderr.txt",
+					kind: "daytona_stderr",
+					source: "qcut-stderr.txt",
+				},
+				{
+					path: "/tmp/qcut-output/.qcut-agent-wrapper-stderr",
+					kind: "daytona_stderr",
+					source: ".qcut-agent-wrapper-stderr",
+				},
+			],
+			stdoutPath: "/tmp/qcut-output/qcut-stdout.txt",
+			stderrPath: "/tmp/qcut-output/qcut-stderr.txt",
+			exitPath: "/tmp/qcut-output/qcut-exit.json",
 		});
 	});
 
@@ -106,9 +145,10 @@ describe("buildDaytonaCommand", () => {
 			buildDaytonaCommand({
 				command: "qcut gen image -t icon,logo -m flux_dev --json",
 			})
-		).toEqual({
+		).toMatchObject({
 			command: EXPECTED_QCUT_IMAGE_DAYTONA_COMMAND,
-			archiveCommand: "tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
+			archiveCommand:
+				"tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
 		});
 	});
 
@@ -124,10 +164,26 @@ describe("buildDaytonaCommand", () => {
 				command: CODEX_AGENT_COMMAND,
 				args: { codexPrompt: "Explain QCut's agent path." },
 			})
-		).toEqual({
+		).toMatchObject({
 			command:
 				"set -o pipefail; mkdir -p /tmp/qcut-output; printf '%s' \"$QCUT_CODEX_PROMPT_B64\" | base64 -d | /usr/local/bin/qcut-entrypoint codex exec --skip-git-repo-check --sandbox danger-full-access --json --output-last-message /tmp/qcut-output/codex-last-message.md - > /tmp/qcut-output/codex-events.jsonl",
-			archiveCommand: "tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
+			archiveCommand:
+				"tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .",
+			streams: [
+				{
+					path: "/tmp/qcut-output/codex-events.jsonl",
+					kind: "codex_event",
+					source: "codex-events.jsonl",
+				},
+				{
+					path: "/tmp/qcut-output/.qcut-agent-wrapper-stderr",
+					kind: "daytona_stderr",
+					source: ".qcut-agent-wrapper-stderr",
+				},
+			],
+			stdoutPath: "/tmp/qcut-output/codex-events.jsonl",
+			stderrPath: "/tmp/qcut-output/.qcut-agent-wrapper-stderr",
+			exitPath: "/tmp/qcut-output/qcut-exit.json",
 		});
 	});
 });
@@ -184,7 +240,7 @@ describe("buildDaytonaEnv", () => {
 describe("runOnDaytona", () => {
 	it("creates an ephemeral image sandbox, executes qcut, downloads artifacts, and deletes the sandbox", async () => {
 		process.env.DAYTONA_API_KEY = "daytona-test";
-		const { client } = makeSupabase();
+		const { client, insertedEvents } = makeSupabase();
 		const outputDir = await mkdtemp(join(tmpdir(), "qcut-daytona-test-"));
 		const sessionCalls: string[] = [];
 		const clientConfigs: Array<{ apiKey: string }> = [];
@@ -209,6 +265,29 @@ describe("runOnDaytona", () => {
 					timeout?: number
 				) {
 					sessionCalls.push(`${sessionId}:${request.command}:${timeout}`);
+					if (request.command.includes("qcut-stdout.txt")) {
+						return Promise.resolve({
+							stdout: '{"kind":"cli_progress","message":"halfway"}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (
+						request.command.includes("qcut-stderr.txt") ||
+						request.command.includes(".qcut-agent-wrapper-stderr")
+					) {
+						return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
 					return Promise.resolve({
 						stdout: "ok",
 						stderr: "",
@@ -247,6 +326,7 @@ describe("runOnDaytona", () => {
 				DaytonaClient: FakeDaytonaClient,
 				makeOutputDir: () => Promise.resolve(outputDir),
 				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
 				extractArchive: () => Promise.resolve(),
 			},
 		});
@@ -265,11 +345,13 @@ describe("runOnDaytona", () => {
 				autoStopInterval: 30,
 			},
 		]);
+		expect(
+			sessionCalls.some((call) => call.includes("rm -rf /tmp/qcut-output"))
+		).toBe(true);
+		expect(sessionCalls.some((call) => call.includes("&;"))).toBe(false);
+		expect(sessionCalls.some((call) => call.includes("& pid=$!"))).toBe(true);
 		expect(sessionCalls).toContain(
-			`session-1:${EXPECTED_QCUT_DOCTOR_DAYTONA_COMMAND}:1800`
-		);
-		expect(sessionCalls).toContain(
-			"session-1:tar -C /tmp/qcut-output -cf /tmp/qcut-output.tar .:1800"
+			"session-1:tar --exclude='.qcut-agent-*' -C /tmp/qcut-output -cf /tmp/qcut-output.tar .:1800"
 		);
 		expect(downloaded).toEqual([
 			{
@@ -279,12 +361,21 @@ describe("runOnDaytona", () => {
 		]);
 		expect(deleteCalls).toEqual(["sandbox-1"]);
 		expect(result).toMatchObject({
-			stdout: "ok",
+			stdout: '{"kind":"cli_progress","message":"halfway"}\n',
 			stderr: "",
 			exitCode: 0,
 			outputDir,
 			artifactsFallback: false,
+			eventsStreamed: true,
 		});
+		expect(
+			flattenInsertedEvents({ insertedEvents }).map((event) => event.kind)
+		).toEqual([
+			"daytona_sandbox_ready",
+			"daytona_command_started",
+			"cli_progress",
+			"daytona_command_finished",
+		]);
 
 		await rm(outputDir, { recursive: true, force: true });
 	});
@@ -305,7 +396,33 @@ describe("runOnDaytona", () => {
 				deleteSession() {
 					return Promise.resolve();
 				},
-				executeSessionCommand() {
+				executeSessionCommand(
+					_sessionId: string,
+					request: { command: string }
+				) {
+					if (request.command.includes("qcut-stderr.txt")) {
+						return Promise.resolve({
+							stdout: "stderr text",
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (
+						request.command.includes("qcut-stdout.txt") ||
+						request.command.includes(".qcut-agent-wrapper-stderr")
+					) {
+						return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes(".qcut-agent-done")) {
+						return Promise.resolve({ stdout: "yes", stderr: "", exitCode: 0 });
+					}
+					if (request.command.includes("qcut-exit.json")) {
+						return Promise.resolve({
+							stdout: '{"exitCode":0}\n',
+							stderr: "",
+							exitCode: 0,
+						});
+					}
 					return Promise.resolve({
 						stdout: "",
 						stderr: "stderr text",
@@ -341,6 +458,7 @@ describe("runOnDaytona", () => {
 				DaytonaClient: FakeDaytonaClient,
 				makeOutputDir: () => Promise.resolve(outputDir),
 				makeSessionId: () => "session-1",
+				sleep: () => Promise.resolve(),
 			},
 		});
 
@@ -348,7 +466,11 @@ describe("runOnDaytona", () => {
 			"stderr text"
 		);
 		expect(clientConfigs).toEqual([{ apiKey: "daytona-test" }]);
-		expect(insertedEvents).toHaveLength(1);
+		expect(
+			flattenInsertedEvents({ insertedEvents }).some(
+				(event) => event.kind === "artifact_fallback"
+			)
+		).toBe(true);
 		expect(result.artifactsFallback).toBe(true);
 
 		await rm(outputDir, { recursive: true, force: true });

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -44,6 +44,7 @@ const AGENT_DONE_FILE = ".qcut-agent-done";
 const AGENT_PID_FILE = ".qcut-agent-pid";
 const WRAPPER_STDOUT_FILE = ".qcut-agent-wrapper-stdout";
 const WRAPPER_STDERR_FILE = ".qcut-agent-wrapper-stderr";
+const CODEX_LIVE_STDOUT_FILE = "codex-live-stdout.log";
 const STREAM_POLL_MS = 2000;
 const SESSION_SANDBOX_AUTO_STOP_MINUTES = 120;
 const DEFAULT_AGENT_SESSION_IDLE_MS = 20 * 60 * 1000;
@@ -164,6 +165,10 @@ interface StreamCursor {
 	size: number;
 }
 
+interface StreamState {
+	liveStdoutMessages: Set<string>;
+}
+
 function isDaytonaEmptyExitCodeError({ error }: { error: unknown }): boolean {
 	const message = error instanceof Error ? error.message : String(error);
 	return (
@@ -239,6 +244,11 @@ export function buildDaytonaCommand({
 			command: buildCodexShellCommandForJob({ args }),
 			archiveCommand: ARCHIVE_COMMAND,
 			streams: [
+				{
+					path: outputPath({ filename: CODEX_LIVE_STDOUT_FILE }),
+					kind: "codex_stdout",
+					source: CODEX_LIVE_STDOUT_FILE,
+				},
 				{
 					path: outputPath({ filename: "codex-events.jsonl" }),
 					kind: "codex_event",
@@ -753,6 +763,38 @@ function takeNewCompleteLines({
 	return lines.join("\n");
 }
 
+function filterDuplicateStdoutRows({
+	rows,
+	stream,
+	state,
+}: {
+	rows: ReturnType<typeof parseEventText>;
+	stream: StreamSpec;
+	state: StreamState;
+}): ReturnType<typeof parseEventText> {
+	return rows.filter((row) => {
+		if (row.kind !== "codex_stdout") {
+			return true;
+		}
+		const message =
+			typeof row.payload.message === "string" ? row.payload.message : "";
+		if (message.length === 0) {
+			return true;
+		}
+		if (stream.source === CODEX_LIVE_STDOUT_FILE) {
+			state.liveStdoutMessages.add(message);
+			return true;
+		}
+		if (
+			row.payload.source === "codex-events.jsonl:aggregated_output" &&
+			state.liveStdoutMessages.has(message)
+		) {
+			return false;
+		}
+		return true;
+	});
+}
+
 async function flushStreamEvents({
 	supabase,
 	job,
@@ -760,6 +802,7 @@ async function flushStreamEvents({
 	sessionId,
 	streams,
 	cursors,
+	state,
 	includePartial = false,
 }: {
 	supabase: SupabaseClient;
@@ -768,6 +811,7 @@ async function flushStreamEvents({
 	sessionId: string;
 	streams: StreamSpec[];
 	cursors: Map<string, StreamCursor>;
+	state: StreamState;
 	includePartial?: boolean;
 }): Promise<void> {
 	for (const stream of streams) {
@@ -786,7 +830,10 @@ async function flushStreamEvents({
 			defaultKind: stream.kind,
 			source: stream.source,
 		});
-		await insertAgentEvents({ supabase, rows });
+		await insertAgentEvents({
+			supabase,
+			rows: filterDuplicateStdoutRows({ rows, stream, state }),
+		});
 	}
 }
 
@@ -807,6 +854,7 @@ async function waitForRemoteCommand({
 }): Promise<void> {
 	const startedAt = Date.now();
 	const cursors = new Map<string, StreamCursor>();
+	const state: StreamState = { liveStdoutMessages: new Set() };
 	const donePath = outputPath({ filename: AGENT_DONE_FILE });
 	while (Date.now() - startedAt < TIMEOUT_SECONDS * 1000) {
 		await sleepFn(STREAM_POLL_MS);
@@ -817,6 +865,7 @@ async function waitForRemoteCommand({
 			sessionId,
 			streams,
 			cursors,
+			state,
 		});
 		if (await remoteFileExists({ sandbox, sessionId, path: donePath })) {
 			await flushStreamEvents({
@@ -826,6 +875,7 @@ async function waitForRemoteCommand({
 				sessionId,
 				streams,
 				cursors,
+				state,
 				includePartial: true,
 			});
 			return;

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -428,15 +428,17 @@ async function updateAgentSession({
 async function createDaytonaSandbox({
 	daytona,
 	envVars,
+	imageTag,
 	autoStopInterval,
 }: {
 	daytona: DaytonaClient;
 	envVars: Record<string, string>;
+	imageTag: string;
 	autoStopInterval: number;
 }): Promise<DaytonaSandbox> {
 	return daytona.create(
 		{
-			image: IMAGE_TAG,
+			image: imageTag,
 			envVars,
 			resources: { cpu: 2, memory: 4 },
 			ephemeral: true,
@@ -483,6 +485,7 @@ async function prepareDaytonaSandbox({
 		const sandbox = await createDaytonaSandbox({
 			daytona,
 			envVars,
+			imageTag: IMAGE_TAG,
 			autoStopInterval: 30,
 		});
 		await recordAgentEvent({
@@ -512,6 +515,7 @@ async function prepareDaytonaSandbox({
 		(await createDaytonaSandbox({
 			daytona,
 			envVars,
+			imageTag: agentSession.image_tag || IMAGE_TAG,
 			autoStopInterval: SESSION_SANDBOX_AUTO_STOP_MINUTES,
 		}));
 	await updateAgentSession({

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -34,6 +34,9 @@ const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 const TIMEOUT_SECONDS = 30 * 60;
 const DAYTONA_OUTPUT_DIR = "/tmp/qcut-output";
 const OUTPUT_ARCHIVE = "/tmp/qcut-output.tar";
+const QCUT_STDOUT_FILE = "qcut-stdout.txt";
+const QCUT_STDERR_FILE = "qcut-stderr.txt";
+const QCUT_EXIT_FILE = "qcut-exit.json";
 
 interface AgentSecretRow {
 	key: string;
@@ -117,6 +120,18 @@ function quoteShellArg({ arg }: { arg: string }): string {
 	return `'${arg.replaceAll("'", "'\\''")}'`;
 }
 
+function buildQcutShellCommand({ quotedArgv }: { quotedArgv: string }): string {
+	const qcutCommand = `/usr/local/bin/qcut-entrypoint ${quotedArgv} -o ${DAYTONA_OUTPUT_DIR}`;
+	return [
+		`mkdir -p ${DAYTONA_OUTPUT_DIR}`,
+		"set +e",
+		`${qcutCommand} > ${DAYTONA_OUTPUT_DIR}/${QCUT_STDOUT_FILE} 2> ${DAYTONA_OUTPUT_DIR}/${QCUT_STDERR_FILE}`,
+		"exit_code=$?",
+		`printf '{"exitCode":%s}\\n' "$exit_code" > ${DAYTONA_OUTPUT_DIR}/${QCUT_EXIT_FILE}`,
+		'[ "$exit_code" -eq 0 ]',
+	].join("; ");
+}
+
 export function buildDaytonaCommand({
 	command,
 	args,
@@ -134,10 +149,9 @@ export function buildDaytonaCommand({
 	}
 
 	const quotedArgv = safeArgv.map((arg) => quoteShellArg({ arg })).join(" ");
-	const qcutCommand = `/usr/local/bin/qcut-entrypoint ${quotedArgv} -o ${DAYTONA_OUTPUT_DIR}`;
 
 	return {
-		command: `mkdir -p ${DAYTONA_OUTPUT_DIR} && ${qcutCommand}`,
+		command: buildQcutShellCommand({ quotedArgv }),
 		archiveCommand: `tar -C ${DAYTONA_OUTPUT_DIR} -cf ${OUTPUT_ARCHIVE} .`,
 	};
 }

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -44,10 +44,24 @@ const AGENT_PID_FILE = ".qcut-agent-pid";
 const WRAPPER_STDOUT_FILE = ".qcut-agent-wrapper-stdout";
 const WRAPPER_STDERR_FILE = ".qcut-agent-wrapper-stderr";
 const STREAM_POLL_MS = 2000;
+const SESSION_SANDBOX_AUTO_STOP_MINUTES = 120;
+const DEFAULT_AGENT_SESSION_IDLE_MS = 20 * 60 * 1000;
+const AGENT_SESSION_CLEANUP_LIMIT = 20;
 
 interface AgentSecretRow {
 	key: string;
 	value: string;
+}
+
+interface AgentSessionRow {
+	id: string;
+	user_id: string;
+	status: string;
+	provider_session_id: string | null;
+	image_tag: string;
+	last_active_at: string;
+	expires_at: string;
+	end_reason?: string | null;
 }
 
 interface DaytonaSessionCommandResult {
@@ -92,6 +106,7 @@ interface DaytonaClient {
 		},
 		options: { timeout: number }
 	): Promise<DaytonaSandbox>;
+	get(sandboxId: string): Promise<DaytonaSandbox>;
 	delete(sandbox: DaytonaSandbox, timeout?: number): Promise<void>;
 }
 
@@ -116,6 +131,12 @@ interface RunOnDaytonaParams {
 	deps?: RunOnDaytonaDeps;
 }
 
+interface CleanupDaytonaAgentSessionsParams {
+	supabase: SupabaseClient;
+	runnerId: string;
+	deps?: Pick<RunOnDaytonaDeps, "DaytonaClient">;
+}
+
 interface CommandParts {
 	command: string;
 	archiveCommand: string;
@@ -123,6 +144,12 @@ interface CommandParts {
 	stdoutPath: string;
 	stderrPath: string;
 	exitPath: string;
+}
+
+interface PreparedSandbox {
+	sandbox: DaytonaSandbox;
+	deleteSandboxOnFinish: boolean;
+	agentSessionId: string | null;
 }
 
 interface StreamSpec {
@@ -163,6 +190,15 @@ function buildQcutShellCommand({ quotedArgv }: { quotedArgv: string }): string {
 	].join("; ");
 }
 
+function buildCodexShellCommandForJob({ args }: { args?: unknown }): string {
+	const env = buildCodexPromptEnv({ prompt: getCodexPrompt({ args }) });
+	return [
+		`export QCUT_CODEX_PROMPT_B64=${quoteShellArg({ arg: env.QCUT_CODEX_PROMPT_B64 })}`,
+		"export QCUT_BOOTSTRAP_CODEX=1",
+		buildCodexShellCommand({ outputDir: DAYTONA_OUTPUT_DIR }),
+	].join("; ");
+}
+
 function outputPath({ filename }: { filename: string }): string {
 	return `${DAYTONA_OUTPUT_DIR}/${filename}`;
 }
@@ -199,7 +235,7 @@ export function buildDaytonaCommand({
 	if (isCodexAgentCommand({ command })) {
 		getCodexPrompt({ args });
 		return {
-			command: buildCodexShellCommand({ outputDir: DAYTONA_OUTPUT_DIR }),
+			command: buildCodexShellCommandForJob({ args }),
 			archiveCommand: ARCHIVE_COMMAND,
 			streams: [
 				{
@@ -245,6 +281,13 @@ export function buildDaytonaCommand({
 		stderrPath: outputPath({ filename: QCUT_STDERR_FILE }),
 		exitPath: outputPath({ filename: QCUT_EXIT_FILE }),
 	};
+}
+
+function getJobSessionId({ job }: { job: AgentJob }): string | null {
+	const value = job.sessionId;
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
 }
 
 export function buildDaytonaEnv({
@@ -296,6 +339,13 @@ function sleep({ ms }: { ms: number }): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function getAgentSessionIdleMs(): number {
+	const parsed = Number(process.env.AGENT_SESSION_IDLE_MS);
+	return Number.isFinite(parsed) && parsed > 0
+		? parsed
+		: DEFAULT_AGENT_SESSION_IDLE_MS;
+}
+
 async function recordAgentEvent({
 	supabase,
 	job,
@@ -319,6 +369,279 @@ async function recordAgentEvent({
 			},
 		],
 	});
+}
+
+async function fetchAgentSession({
+	supabase,
+	job,
+	sessionId,
+}: {
+	supabase: SupabaseClient;
+	job: AgentJob;
+	sessionId: string;
+}): Promise<AgentSessionRow> {
+	const { data, error } = await supabase
+		.from("agent_sessions")
+		.select(
+			"id, user_id, status, provider_session_id, image_tag, last_active_at, expires_at, end_reason"
+		)
+		.eq("id", sessionId)
+		.eq("user_id", job.userId)
+		.maybeSingle();
+	if (error) {
+		throw new Error(`agent_sessions fetch failed: ${error.message}`);
+	}
+	if (!data) {
+		throw new Error(`agent session ${sessionId} was not found`);
+	}
+	const row = data as AgentSessionRow;
+	if (row.status !== "active") {
+		throw new Error(`agent session ${sessionId} is ${row.status}`);
+	}
+	if (Date.parse(row.expires_at) <= Date.now()) {
+		throw new Error(`agent session ${sessionId} expired`);
+	}
+	return row;
+}
+
+async function updateAgentSession({
+	supabase,
+	sessionId,
+	userId,
+	values,
+}: {
+	supabase: SupabaseClient;
+	sessionId: string;
+	userId: string;
+	values: Record<string, unknown>;
+}): Promise<void> {
+	const { error } = await supabase
+		.from("agent_sessions")
+		.update(values)
+		.eq("id", sessionId)
+		.eq("user_id", userId);
+	if (error) {
+		throw new Error(`agent_sessions update failed: ${error.message}`);
+	}
+}
+
+async function createDaytonaSandbox({
+	daytona,
+	envVars,
+	autoStopInterval,
+}: {
+	daytona: DaytonaClient;
+	envVars: Record<string, string>;
+	autoStopInterval: number;
+}): Promise<DaytonaSandbox> {
+	return daytona.create(
+		{
+			image: IMAGE_TAG,
+			envVars,
+			resources: { cpu: 2, memory: 4 },
+			ephemeral: true,
+			autoStopInterval,
+		},
+		{ timeout: 120 }
+	);
+}
+
+async function getReusableSandbox({
+	daytona,
+	session,
+}: {
+	daytona: DaytonaClient;
+	session: AgentSessionRow;
+}): Promise<DaytonaSandbox | null> {
+	if (!session.provider_session_id) {
+		return null;
+	}
+	try {
+		return await daytona.get(session.provider_session_id);
+	} catch (error) {
+		console.warn(
+			`[agent-worker] Daytona session ${session.id} sandbox ${session.provider_session_id} is unavailable; creating a replacement:`,
+			error
+		);
+		return null;
+	}
+}
+
+async function prepareDaytonaSandbox({
+	supabase,
+	job,
+	daytona,
+	envVars,
+}: {
+	supabase: SupabaseClient;
+	job: AgentJob;
+	daytona: DaytonaClient;
+	envVars: Record<string, string>;
+}): Promise<PreparedSandbox> {
+	const agentSessionId = getJobSessionId({ job });
+	if (!agentSessionId) {
+		const sandbox = await createDaytonaSandbox({
+			daytona,
+			envVars,
+			autoStopInterval: 30,
+		});
+		await recordAgentEvent({
+			supabase,
+			job,
+			kind: "daytona_sandbox_ready",
+			payload: { sandboxId: sandbox.id, image: IMAGE_TAG },
+		});
+		return {
+			sandbox,
+			deleteSandboxOnFinish: true,
+			agentSessionId: null,
+		};
+	}
+
+	const agentSession = await fetchAgentSession({
+		supabase,
+		job,
+		sessionId: agentSessionId,
+	});
+	const reusableSandbox = await getReusableSandbox({
+		daytona,
+		session: agentSession,
+	});
+	const sandbox =
+		reusableSandbox ??
+		(await createDaytonaSandbox({
+			daytona,
+			envVars,
+			autoStopInterval: SESSION_SANDBOX_AUTO_STOP_MINUTES,
+		}));
+	await updateAgentSession({
+		supabase,
+		sessionId: agentSession.id,
+		userId: job.userId,
+		values: {
+			provider_session_id: sandbox.id,
+			image_tag: IMAGE_TAG,
+			last_active_at: new Date().toISOString(),
+			runner_id: job.runnerId ?? null,
+		},
+	});
+	await recordAgentEvent({
+		supabase,
+		job,
+		kind: "agent_session_ready",
+		payload: {
+			sessionId: agentSession.id,
+			sandboxId: sandbox.id,
+			reused: Boolean(reusableSandbox),
+			image: IMAGE_TAG,
+		},
+	});
+	return {
+		sandbox,
+		deleteSandboxOnFinish: false,
+		agentSessionId: agentSession.id,
+	};
+}
+
+function getSessionEndReason({
+	session,
+	nowMs,
+}: {
+	session: AgentSessionRow;
+	nowMs: number;
+}): "idle_timeout" | "ttl" | "user_kill" {
+	if (session.status === "stopping") {
+		return "user_kill";
+	}
+	if (Date.parse(session.expires_at) <= nowMs) {
+		return "ttl";
+	}
+	return "idle_timeout";
+}
+
+async function endDaytonaAgentSession({
+	supabase,
+	daytona,
+	session,
+	runnerId,
+}: {
+	supabase: SupabaseClient;
+	daytona: DaytonaClient;
+	session: AgentSessionRow;
+	runnerId: string;
+}): Promise<void> {
+	const now = new Date();
+	const endReason = getSessionEndReason({
+		session,
+		nowMs: now.getTime(),
+	});
+	if (session.provider_session_id) {
+		try {
+			const sandbox = await daytona.get(session.provider_session_id);
+			await daytona.delete(sandbox, 60);
+		} catch (error) {
+			console.warn(
+				`[agent-worker] cleanup could not delete Daytona sandbox ${session.provider_session_id}:`,
+				error
+			);
+		}
+	}
+	await supabase
+		.from("agent_sessions")
+		.update({
+			status: "ended",
+			ended_at: now.toISOString(),
+			end_reason: endReason,
+			runner_id: runnerId,
+		})
+		.eq("id", session.id);
+	await supabase.from("agent_events").insert({
+		job_id: null,
+		user_id: session.user_id,
+		kind: "agent_session_ended",
+		payload: {
+			sessionId: session.id,
+			sandboxId: session.provider_session_id,
+			reason: endReason,
+		},
+		created_at: now.toISOString(),
+	});
+}
+
+export async function cleanupDaytonaAgentSessions({
+	supabase,
+	runnerId,
+	deps = {},
+}: CleanupDaytonaAgentSessionsParams): Promise<number> {
+	const apiKey = process.env.DAYTONA_API_KEY;
+	if (!apiKey) {
+		return 0;
+	}
+	const DaytonaClient =
+		deps.DaytonaClient ?? (Daytona as unknown as DaytonaClientCtor);
+	const daytona = new DaytonaClient({ apiKey });
+	const now = new Date();
+	const idleCutoff = new Date(now.getTime() - getAgentSessionIdleMs());
+	const { data, error } = await supabase
+		.from("agent_sessions")
+		.select(
+			"id, user_id, status, provider_session_id, image_tag, last_active_at, expires_at, end_reason"
+		)
+		.in("status", ["active", "stopping"])
+		.or(
+			`status.eq.stopping,expires_at.lt.${now.toISOString()},last_active_at.lt.${idleCutoff.toISOString()}`
+		)
+		.limit(AGENT_SESSION_CLEANUP_LIMIT);
+	if (error) {
+		throw new Error(`agent_sessions cleanup select failed: ${error.message}`);
+	}
+	const sessions = (data ?? []) as AgentSessionRow[];
+	await Promise.all(
+		sessions.map((session) =>
+			endDaytonaAgentSession({ supabase, daytona, session, runnerId })
+		)
+	);
+	return sessions.length;
 }
 
 async function executeShellCommand({
@@ -550,6 +873,7 @@ export async function runOnDaytona({
 	const DaytonaClient =
 		deps.DaytonaClient ?? (Daytona as unknown as DaytonaClientCtor);
 	const daytona = new DaytonaClient({ apiKey });
+	const envVars = buildDaytonaEnv({ secrets: secrets ?? [], job });
 	const outputDir = deps.makeOutputDir
 		? await deps.makeOutputDir()
 		: await mkdtemp(join(tmpdir(), "qcut-daytona-"));
@@ -563,24 +887,19 @@ export async function runOnDaytona({
 	let sandbox: DaytonaSandbox | undefined;
 	let result: DaytonaSessionCommandResult | undefined;
 	let artifactsFallback = false;
+	let deleteSandboxOnFinish = true;
+	let agentSessionId: string | null = null;
 
 	try {
-		sandbox = await daytona.create(
-			{
-				image: IMAGE_TAG,
-				envVars: buildDaytonaEnv({ secrets: secrets ?? [], job }),
-				resources: { cpu: 2, memory: 4 },
-				ephemeral: true,
-				autoStopInterval: 30,
-			},
-			{ timeout: 120 }
-		);
-		await recordAgentEvent({
+		const prepared = await prepareDaytonaSandbox({
 			supabase,
 			job,
-			kind: "daytona_sandbox_ready",
-			payload: { sandboxId: sandbox.id, image: IMAGE_TAG },
+			daytona,
+			envVars,
 		});
+		sandbox = prepared.sandbox;
+		deleteSandboxOnFinish = prepared.deleteSandboxOnFinish;
+		agentSessionId = prepared.agentSessionId;
 
 		await sandbox.process.createSession(sessionId);
 		await recordAgentEvent({
@@ -637,6 +956,14 @@ export async function runOnDaytona({
 			kind: "daytona_command_finished",
 			payload: { exitCode: result.exitCode },
 		});
+		if (agentSessionId) {
+			await updateAgentSession({
+				supabase,
+				sessionId: agentSessionId,
+				userId: job.userId,
+				values: { last_active_at: new Date().toISOString() },
+			});
+		}
 		await executeShellCommand({
 			sandbox,
 			sessionId,
@@ -692,13 +1019,15 @@ export async function runOnDaytona({
 			} catch (err) {
 				console.warn("[agent-worker] daytona session cleanup failed:", err);
 			}
-			try {
-				await daytona.delete(sandbox, 60);
-			} catch (err) {
-				console.error(
-					`[agent-worker] delete sandbox ${sandbox.id} failed:`,
-					err
-				);
+			if (deleteSandboxOnFinish) {
+				try {
+					await daytona.delete(sandbox, 60);
+				} catch (err) {
+					console.error(
+						`[agent-worker] delete sandbox ${sandbox.id} failed:`,
+						err
+					);
+				}
 			}
 		}
 	}

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -136,6 +136,14 @@ interface StreamCursor {
 	size: number;
 }
 
+function isDaytonaEmptyExitCodeError({ error }: { error: unknown }): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		message.includes("failed to convert exit code to int") ||
+		message.includes('strconv.Atoi: parsing ""')
+	);
+}
+
 function quoteShellArg({ arg }: { arg: string }): string {
 	if (/^[A-Za-z0-9_\-./:=,@+]+$/.test(arg)) {
 		return arg;
@@ -318,36 +326,48 @@ async function executeShellCommand({
 	sessionId,
 	command,
 	timeout = 60,
+	allowEmptyExitCodeError = false,
 }: {
 	sandbox: DaytonaSandbox;
 	sessionId: string;
 	command: string;
 	timeout?: number;
+	allowEmptyExitCodeError?: boolean;
 }): Promise<DaytonaSessionCommandResult> {
-	return sandbox.process.executeSessionCommand(
-		sessionId,
-		{
-			command,
-			runAsync: false,
-			suppressInputEcho: true,
-		},
-		timeout
-	);
+	try {
+		return await sandbox.process.executeSessionCommand(
+			sessionId,
+			{
+				command,
+				runAsync: false,
+				suppressInputEcho: true,
+			},
+			timeout
+		);
+	} catch (error) {
+		if (allowEmptyExitCodeError && isDaytonaEmptyExitCodeError({ error })) {
+			return { stdout: "", stderr: "", exitCode: 0 };
+		}
+		throw error;
+	}
 }
 
 async function readRemoteFile({
 	sandbox,
 	sessionId,
 	path,
+	allowEmptyExitCodeError = false,
 }: {
 	sandbox: DaytonaSandbox;
 	sessionId: string;
 	path: string;
+	allowEmptyExitCodeError?: boolean;
 }): Promise<string> {
 	const result = await executeShellCommand({
 		sandbox,
 		sessionId,
 		command: `cat ${quoteShellArg({ arg: path })} 2>/dev/null || true`,
+		allowEmptyExitCodeError,
 	});
 	return result.stdout ?? result.output ?? "";
 }
@@ -365,6 +385,7 @@ async function remoteFileExists({
 		sandbox,
 		sessionId,
 		command: `test -f ${quoteShellArg({ arg: path })} && printf yes || true`,
+		allowEmptyExitCodeError: true,
 	});
 	return (result.stdout ?? result.output ?? "").trim() === "yes";
 }
@@ -428,6 +449,7 @@ async function flushStreamEvents({
 			sandbox,
 			sessionId,
 			path: stream.path,
+			allowEmptyExitCodeError: true,
 		});
 		const newLines = takeNewCompleteLines({ text, cursor, includePartial });
 		const rows = parseEventText({

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -27,6 +27,7 @@ import {
 	tokenizeCommand,
 } from "./run-container.js";
 import type { ContainerResult } from "./run-container.js";
+import { insertAgentEvents, parseEventText } from "./stream-events.js";
 
 const DEFAULT_DAYTONA_IMAGE =
 	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
@@ -34,9 +35,15 @@ const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 const TIMEOUT_SECONDS = 30 * 60;
 const DAYTONA_OUTPUT_DIR = "/tmp/qcut-output";
 const OUTPUT_ARCHIVE = "/tmp/qcut-output.tar";
+const ARCHIVE_COMMAND = `tar --exclude='.qcut-agent-*' -C ${DAYTONA_OUTPUT_DIR} -cf ${OUTPUT_ARCHIVE} .`;
 const QCUT_STDOUT_FILE = "qcut-stdout.txt";
 const QCUT_STDERR_FILE = "qcut-stderr.txt";
 const QCUT_EXIT_FILE = "qcut-exit.json";
+const AGENT_DONE_FILE = ".qcut-agent-done";
+const AGENT_PID_FILE = ".qcut-agent-pid";
+const WRAPPER_STDOUT_FILE = ".qcut-agent-wrapper-stdout";
+const WRAPPER_STDERR_FILE = ".qcut-agent-wrapper-stderr";
+const STREAM_POLL_MS = 2000;
 
 interface AgentSecretRow {
 	key: string;
@@ -96,6 +103,7 @@ interface RunOnDaytonaDeps {
 	DaytonaClient?: DaytonaClientCtor;
 	makeOutputDir?: () => Promise<string>;
 	makeSessionId?: () => string;
+	sleep?: (ms: number) => Promise<void>;
 	extractArchive?: (params: {
 		archivePath: string;
 		outputDir: string;
@@ -111,6 +119,21 @@ interface RunOnDaytonaParams {
 interface CommandParts {
 	command: string;
 	archiveCommand: string;
+	streams: StreamSpec[];
+	stdoutPath: string;
+	stderrPath: string;
+	exitPath: string;
+}
+
+interface StreamSpec {
+	path: string;
+	kind: string;
+	source: string;
+}
+
+interface StreamCursor {
+	partial: string;
+	size: number;
 }
 
 function quoteShellArg({ arg }: { arg: string }): string {
@@ -132,6 +155,31 @@ function buildQcutShellCommand({ quotedArgv }: { quotedArgv: string }): string {
 	].join("; ");
 }
 
+function outputPath({ filename }: { filename: string }): string {
+	return `${DAYTONA_OUTPUT_DIR}/${filename}`;
+}
+
+function buildAsyncStartCommand({ command }: { command: string }): string {
+	const donePath = outputPath({ filename: AGENT_DONE_FILE });
+	const pidPath = outputPath({ filename: AGENT_PID_FILE });
+	const wrapperStdoutPath = outputPath({ filename: WRAPPER_STDOUT_FILE });
+	const wrapperStderrPath = outputPath({ filename: WRAPPER_STDERR_FILE });
+	const wrappedCommand = [
+		"set +e",
+		command,
+		"exit_code=$?",
+		`[ -f ${outputPath({ filename: QCUT_EXIT_FILE })} ] || printf '{"exitCode":%s}\\n' "$exit_code" > ${outputPath({ filename: QCUT_EXIT_FILE })}`,
+		`touch ${donePath}`,
+		'exit "$exit_code"',
+	].join("; ");
+	return [
+		`rm -rf ${DAYTONA_OUTPUT_DIR} ${OUTPUT_ARCHIVE}`,
+		`mkdir -p ${DAYTONA_OUTPUT_DIR}`,
+		`( ${wrappedCommand} ) > ${wrapperStdoutPath} 2> ${wrapperStderrPath} & pid=$!`,
+		`printf '{"pid":%s}\\n' "$pid" > ${pidPath}`,
+	].join("; ");
+}
+
 export function buildDaytonaCommand({
 	command,
 	args,
@@ -144,7 +192,22 @@ export function buildDaytonaCommand({
 		getCodexPrompt({ args });
 		return {
 			command: buildCodexShellCommand({ outputDir: DAYTONA_OUTPUT_DIR }),
-			archiveCommand: `tar -C ${DAYTONA_OUTPUT_DIR} -cf ${OUTPUT_ARCHIVE} .`,
+			archiveCommand: ARCHIVE_COMMAND,
+			streams: [
+				{
+					path: outputPath({ filename: "codex-events.jsonl" }),
+					kind: "codex_event",
+					source: "codex-events.jsonl",
+				},
+				{
+					path: outputPath({ filename: WRAPPER_STDERR_FILE }),
+					kind: "daytona_stderr",
+					source: WRAPPER_STDERR_FILE,
+				},
+			],
+			stdoutPath: outputPath({ filename: "codex-events.jsonl" }),
+			stderrPath: outputPath({ filename: WRAPPER_STDERR_FILE }),
+			exitPath: outputPath({ filename: QCUT_EXIT_FILE }),
 		};
 	}
 
@@ -152,7 +215,27 @@ export function buildDaytonaCommand({
 
 	return {
 		command: buildQcutShellCommand({ quotedArgv }),
-		archiveCommand: `tar -C ${DAYTONA_OUTPUT_DIR} -cf ${OUTPUT_ARCHIVE} .`,
+		archiveCommand: ARCHIVE_COMMAND,
+		streams: [
+			{
+				path: outputPath({ filename: QCUT_STDOUT_FILE }),
+				kind: "daytona_stdout",
+				source: QCUT_STDOUT_FILE,
+			},
+			{
+				path: outputPath({ filename: QCUT_STDERR_FILE }),
+				kind: "daytona_stderr",
+				source: QCUT_STDERR_FILE,
+			},
+			{
+				path: outputPath({ filename: WRAPPER_STDERR_FILE }),
+				kind: "daytona_stderr",
+				source: WRAPPER_STDERR_FILE,
+			},
+		],
+		stdoutPath: outputPath({ filename: QCUT_STDOUT_FILE }),
+		stderrPath: outputPath({ filename: QCUT_STDERR_FILE }),
+		exitPath: outputPath({ filename: QCUT_EXIT_FILE }),
 	};
 }
 
@@ -201,6 +284,222 @@ async function downloadOutputDir({
 	await extract({ archivePath: localArchive, outputDir });
 }
 
+function sleep({ ms }: { ms: number }): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function recordAgentEvent({
+	supabase,
+	job,
+	kind,
+	payload,
+}: {
+	supabase: SupabaseClient;
+	job: AgentJob;
+	kind: string;
+	payload: Record<string, unknown>;
+}): Promise<void> {
+	await insertAgentEvents({
+		supabase,
+		rows: [
+			{
+				job_id: job.id,
+				user_id: job.userId,
+				kind,
+				payload,
+				created_at: new Date().toISOString(),
+			},
+		],
+	});
+}
+
+async function executeShellCommand({
+	sandbox,
+	sessionId,
+	command,
+	timeout = 60,
+}: {
+	sandbox: DaytonaSandbox;
+	sessionId: string;
+	command: string;
+	timeout?: number;
+}): Promise<DaytonaSessionCommandResult> {
+	return sandbox.process.executeSessionCommand(
+		sessionId,
+		{
+			command,
+			runAsync: false,
+			suppressInputEcho: true,
+		},
+		timeout
+	);
+}
+
+async function readRemoteFile({
+	sandbox,
+	sessionId,
+	path,
+}: {
+	sandbox: DaytonaSandbox;
+	sessionId: string;
+	path: string;
+}): Promise<string> {
+	const result = await executeShellCommand({
+		sandbox,
+		sessionId,
+		command: `cat ${quoteShellArg({ arg: path })} 2>/dev/null || true`,
+	});
+	return result.stdout ?? result.output ?? "";
+}
+
+async function remoteFileExists({
+	sandbox,
+	sessionId,
+	path,
+}: {
+	sandbox: DaytonaSandbox;
+	sessionId: string;
+	path: string;
+}): Promise<boolean> {
+	const result = await executeShellCommand({
+		sandbox,
+		sessionId,
+		command: `test -f ${quoteShellArg({ arg: path })} && printf yes || true`,
+	});
+	return (result.stdout ?? result.output ?? "").trim() === "yes";
+}
+
+function takeNewCompleteLines({
+	text,
+	cursor,
+	includePartial = false,
+}: {
+	text: string;
+	cursor: StreamCursor;
+	includePartial?: boolean;
+}): string {
+	if (text.length < cursor.size) {
+		cursor.size = 0;
+		cursor.partial = "";
+	}
+	const chunk = text.slice(cursor.size);
+	cursor.size = text.length;
+	if (chunk.length === 0) {
+		if (!includePartial) return "";
+		const partial = cursor.partial;
+		cursor.partial = "";
+		return partial;
+	}
+	const combined = `${cursor.partial}${chunk}`;
+	if (includePartial) {
+		cursor.partial = "";
+		return combined;
+	}
+	if (!combined.includes("\n")) {
+		cursor.partial = combined;
+		return "";
+	}
+	const lines = combined.split("\n");
+	cursor.partial = lines.pop() ?? "";
+	return lines.join("\n");
+}
+
+async function flushStreamEvents({
+	supabase,
+	job,
+	sandbox,
+	sessionId,
+	streams,
+	cursors,
+	includePartial = false,
+}: {
+	supabase: SupabaseClient;
+	job: AgentJob;
+	sandbox: DaytonaSandbox;
+	sessionId: string;
+	streams: StreamSpec[];
+	cursors: Map<string, StreamCursor>;
+	includePartial?: boolean;
+}): Promise<void> {
+	for (const stream of streams) {
+		const cursor = cursors.get(stream.path) ?? { partial: "", size: 0 };
+		cursors.set(stream.path, cursor);
+		const text = await readRemoteFile({
+			sandbox,
+			sessionId,
+			path: stream.path,
+		});
+		const newLines = takeNewCompleteLines({ text, cursor, includePartial });
+		const rows = parseEventText({
+			text: newLines,
+			job,
+			defaultKind: stream.kind,
+			source: stream.source,
+		});
+		await insertAgentEvents({ supabase, rows });
+	}
+}
+
+async function waitForRemoteCommand({
+	supabase,
+	job,
+	sandbox,
+	sessionId,
+	streams,
+	sleepFn,
+}: {
+	supabase: SupabaseClient;
+	job: AgentJob;
+	sandbox: DaytonaSandbox;
+	sessionId: string;
+	streams: StreamSpec[];
+	sleepFn: (ms: number) => Promise<void>;
+}): Promise<void> {
+	const startedAt = Date.now();
+	const cursors = new Map<string, StreamCursor>();
+	const donePath = outputPath({ filename: AGENT_DONE_FILE });
+	while (Date.now() - startedAt < TIMEOUT_SECONDS * 1000) {
+		await sleepFn(STREAM_POLL_MS);
+		await flushStreamEvents({
+			supabase,
+			job,
+			sandbox,
+			sessionId,
+			streams,
+			cursors,
+		});
+		if (await remoteFileExists({ sandbox, sessionId, path: donePath })) {
+			await flushStreamEvents({
+				supabase,
+				job,
+				sandbox,
+				sessionId,
+				streams,
+				cursors,
+				includePartial: true,
+			});
+			return;
+		}
+	}
+	await recordAgentEvent({
+		supabase,
+		job,
+		kind: "daytona_timeout",
+		payload: { timeoutSeconds: TIMEOUT_SECONDS },
+	});
+	throw new Error(`Daytona command timed out after ${TIMEOUT_SECONDS}s`);
+}
+
+function parseExitCode({ text }: { text: string }): number {
+	try {
+		const parsed = JSON.parse(text);
+		const value = (parsed as { exitCode?: unknown }).exitCode;
+		return typeof value === "number" && Number.isFinite(value) ? value : 1;
+	} catch {
+		return 1;
+	}
+}
+
 export async function runOnDaytona({
 	supabase,
 	job,
@@ -233,10 +532,11 @@ export async function runOnDaytona({
 		? await deps.makeOutputDir()
 		: await mkdtemp(join(tmpdir(), "qcut-daytona-"));
 	const sessionId = deps.makeSessionId?.() ?? `qcut-${randomUUID()}`;
-	const { command, archiveCommand } = buildDaytonaCommand({
-		command: job.command,
-		args: job.args,
-	});
+	const { command, archiveCommand, streams, stdoutPath, stderrPath, exitPath } =
+		buildDaytonaCommand({
+			command: job.command,
+			args: job.args,
+		});
 
 	let sandbox: DaytonaSandbox | undefined;
 	let result: DaytonaSessionCommandResult | undefined;
@@ -253,26 +553,74 @@ export async function runOnDaytona({
 			},
 			{ timeout: 120 }
 		);
+		await recordAgentEvent({
+			supabase,
+			job,
+			kind: "daytona_sandbox_ready",
+			payload: { sandboxId: sandbox.id, image: IMAGE_TAG },
+		});
 
 		await sandbox.process.createSession(sessionId);
-		result = await sandbox.process.executeSessionCommand(
+		await recordAgentEvent({
+			supabase,
+			job,
+			kind: "daytona_command_started",
+			payload: { sessionId },
+		});
+		const startResult = await executeShellCommand({
+			sandbox,
 			sessionId,
-			{
-				command,
-				runAsync: false,
-				suppressInputEcho: true,
-			},
-			TIMEOUT_SECONDS
-		);
-		await sandbox.process.executeSessionCommand(
+			command: buildAsyncStartCommand({ command }),
+			timeout: 120,
+		});
+		if (
+			typeof startResult.exitCode === "number" &&
+			startResult.exitCode !== 0
+		) {
+			await recordAgentEvent({
+				supabase,
+				job,
+				kind: "daytona_command_start_failed",
+				payload: {
+					exitCode: startResult.exitCode,
+					stderr: startResult.stderr ?? "",
+					stdout: startResult.stdout ?? startResult.output ?? "",
+				},
+			});
+			throw new Error(
+				`Daytona command failed to start with exit ${startResult.exitCode}`
+			);
+		}
+		await waitForRemoteCommand({
+			supabase,
+			job,
+			sandbox,
 			sessionId,
-			{
-				command: archiveCommand,
-				runAsync: false,
-				suppressInputEcho: true,
-			},
-			TIMEOUT_SECONDS
-		);
+			streams,
+			sleepFn: deps.sleep ?? ((ms) => sleep({ ms })),
+		});
+		const [stdout, stderr, exitText] = await Promise.all([
+			readRemoteFile({ sandbox, sessionId, path: stdoutPath }),
+			readRemoteFile({ sandbox, sessionId, path: stderrPath }),
+			readRemoteFile({ sandbox, sessionId, path: exitPath }),
+		]);
+		result = {
+			stdout,
+			stderr,
+			exitCode: parseExitCode({ text: exitText }),
+		};
+		await recordAgentEvent({
+			supabase,
+			job,
+			kind: "daytona_command_finished",
+			payload: { exitCode: result.exitCode },
+		});
+		await executeShellCommand({
+			sandbox,
+			sessionId,
+			command: archiveCommand,
+			timeout: TIMEOUT_SECONDS,
+		});
 
 		try {
 			await downloadOutputDir({
@@ -312,6 +660,7 @@ export async function runOnDaytona({
 			stderr: result.stderr ?? "",
 			exitCode: result.exitCode ?? 1,
 			outputDir,
+			eventsStreamed: true,
 			artifactsFallback,
 		};
 	} finally {

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -29,7 +29,7 @@ import {
 import type { ContainerResult } from "./run-container.js";
 
 const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:2b9b8c7aa80bc2e5db874f04ccca302bbce0693a7d90274fe2b8645049fdbb7b";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
 const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 const TIMEOUT_SECONDS = 30 * 60;
 const DAYTONA_OUTPUT_DIR = "/tmp/qcut-output";

--- a/qcut/packages/agent-worker/src/run-on-daytona.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ts
@@ -33,6 +33,7 @@ const DEFAULT_DAYTONA_IMAGE =
 	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
 const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 const TIMEOUT_SECONDS = 30 * 60;
+const DAYTONA_CREATE_TIMEOUT_SECONDS = 300;
 const DAYTONA_OUTPUT_DIR = "/tmp/qcut-output";
 const OUTPUT_ARCHIVE = "/tmp/qcut-output.tar";
 const ARCHIVE_COMMAND = `tar --exclude='.qcut-agent-*' -C ${DAYTONA_OUTPUT_DIR} -cf ${OUTPUT_ARCHIVE} .`;
@@ -444,7 +445,7 @@ async function createDaytonaSandbox({
 			ephemeral: true,
 			autoStopInterval,
 		},
-		{ timeout: 120 }
+		{ timeout: DAYTONA_CREATE_TIMEOUT_SECONDS }
 	);
 }
 

--- a/qcut/packages/agent-worker/src/stream-events.test.ts
+++ b/qcut/packages/agent-worker/src/stream-events.test.ts
@@ -6,6 +6,7 @@ function fakeJob(): AgentJob {
 	return {
 		id: "j-1",
 		userId: "user-abc",
+		sessionId: null,
 		status: "running",
 		command: "qcut system doctor --json --skip-health",
 		args: {},

--- a/qcut/packages/agent-worker/src/stream-events.test.ts
+++ b/qcut/packages/agent-worker/src/stream-events.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentJob } from "@qcut/db";
-import { parseStderr } from "./stream-events";
+import { parseEventText, parseStderr } from "./stream-events";
 
 function fakeJob(): AgentJob {
 	return {
@@ -68,5 +68,31 @@ describe("parseStderr", () => {
 	it("returns empty array for empty input", () => {
 		expect(parseStderr("", fakeJob())).toEqual([]);
 		expect(parseStderr("\n\n\n", fakeJob())).toEqual([]);
+	});
+
+	it("uses caller default kind when JSON has no kind", () => {
+		const rows = parseEventText({
+			text: '{"type":"exec_command","status":"started"}',
+			job: fakeJob(),
+			defaultKind: "codex_event",
+		});
+		expect(rows[0]?.kind).toBe("codex_event");
+		expect(rows[0]?.payload).toMatchObject({
+			type: "exec_command",
+			status: "started",
+		});
+	});
+
+	it("adds source metadata when payload does not provide it", () => {
+		const rows = parseEventText({
+			text: "download started",
+			job: fakeJob(),
+			defaultKind: "daytona_stdout",
+			source: "qcut-stdout.txt",
+		});
+		expect(rows[0]?.payload).toEqual({
+			message: "download started",
+			source: "qcut-stdout.txt",
+		});
 	});
 });

--- a/qcut/packages/agent-worker/src/stream-events.test.ts
+++ b/qcut/packages/agent-worker/src/stream-events.test.ts
@@ -96,4 +96,37 @@ describe("parseStderr", () => {
 			source: "qcut-stdout.txt",
 		});
 	});
+
+	it("splits Codex command aggregated output into stdout line events", () => {
+		const rows = parseEventText({
+			text: JSON.stringify({
+				item: {
+					id: "item_0",
+					type: "command_execution",
+					status: "completed",
+					command: "/bin/bash -lc 'echo hello'",
+					aggregated_output: "line one\nline two\n",
+				},
+				type: "item.completed",
+			}),
+			job: fakeJob(),
+			defaultKind: "codex_event",
+			source: "codex-events.jsonl",
+		});
+		expect(rows.map((row) => row.kind)).toEqual([
+			"codex_event",
+			"codex_stdout",
+			"codex_stdout",
+		]);
+		expect(rows[1]?.payload).toMatchObject({
+			message: "line one",
+			source: "codex-events.jsonl:aggregated_output",
+			itemId: "item_0",
+			command: "/bin/bash -lc 'echo hello'",
+		});
+		expect(rows[2]?.payload).toMatchObject({
+			message: "line two",
+			source: "codex-events.jsonl:aggregated_output",
+		});
+	});
 });

--- a/qcut/packages/agent-worker/src/stream-events.ts
+++ b/qcut/packages/agent-worker/src/stream-events.ts
@@ -14,7 +14,7 @@ import { mask } from "./mask.js";
 
 const BATCH = 500;
 
-interface EventRow {
+export interface EventRow {
 	job_id: string;
 	user_id: string;
 	kind: string;
@@ -22,9 +22,19 @@ interface EventRow {
 	created_at: string;
 }
 
-export function parseStderr(stderr: string, job: AgentJob): EventRow[] {
+export function parseEventText({
+	text,
+	job,
+	defaultKind = "cli_stderr",
+	source,
+}: {
+	text: string;
+	job: AgentJob;
+	defaultKind?: string;
+	source?: string;
+}): EventRow[] {
 	const rows: EventRow[] = [];
-	for (const raw of stderr.split("\n")) {
+	for (const raw of text.split("\n")) {
 		if (!raw.trim()) continue;
 		const masked = mask(raw);
 		let payload: Record<string, unknown>;
@@ -37,10 +47,11 @@ export function parseStderr(stderr: string, job: AgentJob): EventRow[] {
 		} catch {
 			payload = { message: masked };
 		}
+		if (source && typeof payload.source !== "string") {
+			payload = { ...payload, source };
+		}
 		const kind =
-			typeof payload.kind === "string"
-				? (payload.kind as string)
-				: "cli_stderr";
+			typeof payload.kind === "string" ? (payload.kind as string) : defaultKind;
 		rows.push({
 			job_id: job.id,
 			user_id: job.userId,
@@ -52,12 +63,17 @@ export function parseStderr(stderr: string, job: AgentJob): EventRow[] {
 	return rows;
 }
 
-export async function streamEvents(
-	supabase: SupabaseClient,
-	job: AgentJob,
-	stderr: string
-): Promise<void> {
-	const rows = parseStderr(stderr, job);
+export function parseStderr(stderr: string, job: AgentJob): EventRow[] {
+	return parseEventText({ text: stderr, job });
+}
+
+export async function insertAgentEvents({
+	supabase,
+	rows,
+}: {
+	supabase: SupabaseClient;
+	rows: EventRow[];
+}): Promise<void> {
 	if (rows.length === 0) return;
 	for (let i = 0; i < rows.length; i += BATCH) {
 		const slice = rows.slice(i, i + BATCH);
@@ -72,4 +88,13 @@ export async function streamEvents(
 			return;
 		}
 	}
+}
+
+export async function streamEvents(
+	supabase: SupabaseClient,
+	job: AgentJob,
+	stderr: string
+): Promise<void> {
+	const rows = parseStderr(stderr, job);
+	await insertAgentEvents({ supabase, rows });
 }

--- a/qcut/packages/agent-worker/src/stream-events.ts
+++ b/qcut/packages/agent-worker/src/stream-events.ts
@@ -22,6 +22,75 @@ export interface EventRow {
 	created_at: string;
 }
 
+function buildEventRow({
+	job,
+	kind,
+	payload,
+	createdAt,
+}: {
+	job: AgentJob;
+	kind: string;
+	payload: Record<string, unknown>;
+	createdAt: string;
+}): EventRow {
+	return {
+		job_id: job.id,
+		user_id: job.userId,
+		kind,
+		payload,
+		created_at: createdAt,
+	};
+}
+
+function buildCodexStdoutRows({
+	payload,
+	job,
+	createdAt,
+}: {
+	payload: Record<string, unknown>;
+	job: AgentJob;
+	createdAt: string;
+}): EventRow[] {
+	if (payload.source !== "codex-events.jsonl") {
+		return [];
+	}
+	const item =
+		payload.item && typeof payload.item === "object"
+			? (payload.item as Record<string, unknown>)
+			: null;
+	if (
+		!item ||
+		item.type !== "command_execution" ||
+		typeof item.aggregated_output !== "string" ||
+		item.aggregated_output.trim().length === 0
+	) {
+		return [];
+	}
+	const commandContext: Record<string, unknown> = {};
+	if (typeof item.id === "string") {
+		commandContext.itemId = item.id;
+	}
+	if (typeof item.command === "string") {
+		commandContext.command = mask(item.command);
+	}
+	return item.aggregated_output
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.filter((line) => line.trim().length > 0)
+		.map((line) =>
+			buildEventRow({
+				job,
+				kind: "codex_stdout",
+				createdAt,
+				payload: {
+					message: mask(line),
+					source: "codex-events.jsonl:aggregated_output",
+					...commandContext,
+				},
+			})
+		);
+}
+
 export function parseEventText({
 	text,
 	job,
@@ -36,6 +105,7 @@ export function parseEventText({
 	const rows: EventRow[] = [];
 	for (const raw of text.split("\n")) {
 		if (!raw.trim()) continue;
+		const createdAt = new Date().toISOString();
 		const masked = mask(raw);
 		let payload: Record<string, unknown>;
 		try {
@@ -52,13 +122,21 @@ export function parseEventText({
 		}
 		const kind =
 			typeof payload.kind === "string" ? (payload.kind as string) : defaultKind;
-		rows.push({
-			job_id: job.id,
-			user_id: job.userId,
-			kind,
-			payload,
-			created_at: new Date().toISOString(),
-		});
+		rows.push(
+			buildEventRow({
+				job,
+				kind,
+				payload,
+				createdAt,
+			})
+		);
+		rows.push(
+			...buildCodexStdoutRows({
+				payload,
+				job,
+				createdAt,
+			})
+		);
 	}
 	return rows;
 }

--- a/qcut/packages/db/migrations/0006_agent_sessions.sql
+++ b/qcut/packages/db/migrations/0006_agent_sessions.sql
@@ -1,7 +1,7 @@
 -- Persistent headless Daytona sessions for website Codex chat. Jobs can
 -- attach to a session so follow-up prompts reuse the same sandbox until
 -- TTL or idle cleanup ends it.
-CREATE TABLE "agent_sessions" (
+CREATE TABLE IF NOT EXISTS "agent_sessions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
 	"status" text NOT NULL,
@@ -18,23 +18,39 @@ CREATE TABLE "agent_sessions" (
 --> statement-breakpoint
 ALTER TABLE "agent_sessions" ENABLE ROW LEVEL SECURITY;
 --> statement-breakpoint
-ALTER TABLE "agent_sessions"
-	ADD CONSTRAINT "agent_sessions_user_id_users_id_fk"
-	FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
-	ON DELETE cascade ON UPDATE no action;
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint
+		WHERE conname = 'agent_sessions_user_id_users_id_fk'
+	) THEN
+		ALTER TABLE "agent_sessions"
+			ADD CONSTRAINT "agent_sessions_user_id_users_id_fk"
+			FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+			ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "agent_jobs" ADD COLUMN "session_id" text;
+ALTER TABLE "agent_jobs" ADD COLUMN IF NOT EXISTS "session_id" text;
 --> statement-breakpoint
-ALTER TABLE "agent_jobs"
-	ADD CONSTRAINT "agent_jobs_session_id_agent_sessions_id_fk"
-	FOREIGN KEY ("session_id") REFERENCES "public"."agent_sessions"("id")
-	ON DELETE set null ON UPDATE no action;
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint
+		WHERE conname = 'agent_jobs_session_id_agent_sessions_id_fk'
+	) THEN
+		ALTER TABLE "agent_jobs"
+			ADD CONSTRAINT "agent_jobs_session_id_agent_sessions_id_fk"
+			FOREIGN KEY ("session_id") REFERENCES "public"."agent_sessions"("id")
+			ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-CREATE INDEX "agent_sessions_user_status_last_active_idx"
+CREATE INDEX IF NOT EXISTS "agent_sessions_user_status_last_active_idx"
 	ON "agent_sessions" USING btree ("user_id","status","last_active_at");
 --> statement-breakpoint
-CREATE INDEX "agent_sessions_expires_active_idx"
+CREATE INDEX IF NOT EXISTS "agent_sessions_expires_active_idx"
 	ON "agent_sessions" USING btree ("expires_at");
 --> statement-breakpoint
-CREATE INDEX "agent_jobs_session_created_idx"
+CREATE INDEX IF NOT EXISTS "agent_jobs_session_created_idx"
 	ON "agent_jobs" USING btree ("session_id","created_at");

--- a/qcut/packages/db/migrations/0006_agent_sessions.sql
+++ b/qcut/packages/db/migrations/0006_agent_sessions.sql
@@ -1,0 +1,40 @@
+-- Persistent headless Daytona sessions for website Codex chat. Jobs can
+-- attach to a session so follow-up prompts reuse the same sandbox until
+-- TTL or idle cleanup ends it.
+CREATE TABLE "agent_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"status" text NOT NULL,
+	"provider" text DEFAULT 'daytona' NOT NULL,
+	"provider_session_id" text,
+	"image_tag" text NOT NULL,
+	"started_at" timestamp NOT NULL,
+	"last_active_at" timestamp NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"ended_at" timestamp,
+	"end_reason" text,
+	"runner_id" text
+);
+--> statement-breakpoint
+ALTER TABLE "agent_sessions" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "agent_sessions"
+	ADD CONSTRAINT "agent_sessions_user_id_users_id_fk"
+	FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+	ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "agent_jobs" ADD COLUMN "session_id" text;
+--> statement-breakpoint
+ALTER TABLE "agent_jobs"
+	ADD CONSTRAINT "agent_jobs_session_id_agent_sessions_id_fk"
+	FOREIGN KEY ("session_id") REFERENCES "public"."agent_sessions"("id")
+	ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "agent_sessions_user_status_last_active_idx"
+	ON "agent_sessions" USING btree ("user_id","status","last_active_at");
+--> statement-breakpoint
+CREATE INDEX "agent_sessions_expires_active_idx"
+	ON "agent_sessions" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE INDEX "agent_jobs_session_created_idx"
+	ON "agent_jobs" USING btree ("session_id","created_at");

--- a/qcut/packages/db/migrations/meta/_journal.json
+++ b/qcut/packages/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1778791283000,
 			"tag": "0005_agent_artifacts_bigint_and_queue_index",
 			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1778900577000,
+			"tag": "0006_agent_sessions",
+			"breakpoints": true
 		}
 	]
 }

--- a/qcut/packages/db/src/schema.ts
+++ b/qcut/packages/db/src/schema.ts
@@ -244,6 +244,47 @@ export const agentSecrets = pgTable(
 	})
 ).enableRLS();
 
+/** Persistent headless Daytona sandbox sessions for website Codex chat.
+ * Jobs may attach to one of these so follow-up prompts reuse the same
+ * filesystem/tool cache until TTL or idle cleanup ends the sandbox. */
+export const agentSessions = pgTable(
+	"agent_sessions",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		status: text("status", {
+			enum: ["active", "stopping", "ended", "error"],
+		}).notNull(),
+		provider: text("provider", { enum: ["daytona"] })
+			.notNull()
+			.default("daytona"),
+		providerSessionId: text("provider_session_id"),
+		imageTag: text("image_tag").notNull(),
+		startedAt: timestamp("started_at")
+			.$defaultFn(() => /* @__PURE__ */ new Date())
+			.notNull(),
+		lastActiveAt: timestamp("last_active_at")
+			.$defaultFn(() => /* @__PURE__ */ new Date())
+			.notNull(),
+		expiresAt: timestamp("expires_at").notNull(),
+		endedAt: timestamp("ended_at"),
+		endReason: text("end_reason", {
+			enum: ["idle_timeout", "ttl", "error", "user_kill"],
+		}),
+		runnerId: text("runner_id"),
+	},
+	(t) => ({
+		userStatusActive: index("agent_sessions_user_status_last_active_idx").on(
+			t.userId,
+			t.status,
+			t.lastActiveAt
+		),
+		expiresActive: index("agent_sessions_expires_active_idx").on(t.expiresAt),
+	})
+).enableRLS();
+
 /** Queued / running / terminal headless jobs. Worker claims via a
  * `claim_one_agent_job` Postgres function (defined in the generated
  * migration alongside this table). */
@@ -254,6 +295,9 @@ export const agentJobs = pgTable(
 		userId: text("user_id")
 			.notNull()
 			.references(() => users.id, { onDelete: "cascade" }),
+		sessionId: text("session_id").references(() => agentSessions.id, {
+			onDelete: "set null",
+		}),
 		status: text("status", {
 			enum: ["queued", "running", "succeeded", "failed", "cancelled"],
 		}).notNull(),
@@ -281,6 +325,10 @@ export const agentJobs = pgTable(
 		queueCreated: index("agent_jobs_queued_created_idx")
 			.on(t.createdAt)
 			.where(sql`${t.status} = 'queued'`),
+		sessionCreated: index("agent_jobs_session_created_idx").on(
+			t.sessionId,
+			t.createdAt
+		),
 	})
 ).enableRLS();
 
@@ -388,6 +436,11 @@ export const sandboxSessions = pgTable(
 
 export type AgentSecret = typeof agentSecrets.$inferSelect;
 export type NewAgentSecret = typeof agentSecrets.$inferInsert;
+
+export type AgentSession = typeof agentSessions.$inferSelect;
+export type NewAgentSession = typeof agentSessions.$inferInsert;
+export type AgentSessionStatus = AgentSession["status"];
+export type AgentSessionEndReason = NonNullable<AgentSession["endReason"]>;
 
 export type AgentJob = typeof agentJobs.$inferSelect;
 export type NewAgentJob = typeof agentJobs.$inferInsert;

--- a/qcut/packages/db/supabase/migrations/20260516000000_agent_sessions.sql
+++ b/qcut/packages/db/supabase/migrations/20260516000000_agent_sessions.sql
@@ -1,0 +1,56 @@
+-- Persistent headless Daytona sessions for website Codex chat. Jobs can
+-- attach to a session so follow-up prompts reuse the same sandbox until
+-- TTL or idle cleanup ends it.
+CREATE TABLE IF NOT EXISTS "agent_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"status" text NOT NULL,
+	"provider" text DEFAULT 'daytona' NOT NULL,
+	"provider_session_id" text,
+	"image_tag" text NOT NULL,
+	"started_at" timestamp NOT NULL,
+	"last_active_at" timestamp NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"ended_at" timestamp,
+	"end_reason" text,
+	"runner_id" text
+);
+--> statement-breakpoint
+ALTER TABLE "agent_sessions" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint
+		WHERE conname = 'agent_sessions_user_id_users_id_fk'
+	) THEN
+		ALTER TABLE "agent_sessions"
+			ADD CONSTRAINT "agent_sessions_user_id_users_id_fk"
+			FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+			ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "agent_jobs" ADD COLUMN IF NOT EXISTS "session_id" text;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint
+		WHERE conname = 'agent_jobs_session_id_agent_sessions_id_fk'
+	) THEN
+		ALTER TABLE "agent_jobs"
+			ADD CONSTRAINT "agent_jobs_session_id_agent_sessions_id_fk"
+			FOREIGN KEY ("session_id") REFERENCES "public"."agent_sessions"("id")
+			ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sessions_user_status_last_active_idx"
+	ON "agent_sessions" USING btree ("user_id","status","last_active_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sessions_expires_active_idx"
+	ON "agent_sessions" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_jobs_session_created_idx"
+	ON "agent_jobs" USING btree ("session_id","created_at");

--- a/qcut/packages/license-server/package.json
+++ b/qcut/packages/license-server/package.json
@@ -10,10 +10,11 @@
 		"test:watch": "bunx vitest --config vitest.config.ts"
 	},
 	"dependencies": {
+		"@daytona/sdk": "^0.175.0",
+		"@noble/hashes": "^1.8.0",
 		"@qcut/auth": "workspace:*",
 		"@qcut/db": "workspace:*",
 		"@supabase/supabase-js": "^2.49.0",
-		"@noble/hashes": "^1.8.0",
 		"better-auth": "1.1.6",
 		"drizzle-orm": "^0.45.1",
 		"e2b": "^1.0.0",

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -298,6 +298,24 @@ describe("POST /api/agent/sessions/:sessionId/end", () => {
 			})
 		);
 	});
+
+	it("returns 404 when ending a session owned by another user", async () => {
+		mockSelectRowsOnce({ rows: [] });
+		const { set } = mockUpdateChain();
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/other-user-session/end",
+			{
+				method: "POST",
+				headers: jsonHeaders(),
+				body: JSON.stringify({}),
+			}
+		);
+
+		expect(res.status).toBe(404);
+		expect(await res.json()).toEqual({ error: "agent_session_not_found" });
+		expect(set).not.toHaveBeenCalled();
+	});
 });
 
 describe("GET /api/agent/jobs/:jobId/artifacts/:artifactId/text", () => {
@@ -482,6 +500,25 @@ describe("POST /api/agent/jobs", () => {
 			body: JSON.stringify({
 				command: CODEX_AGENT_COMMAND,
 				sessionId: "missing-session",
+				args: { codexPrompt: "Continue the chat." },
+			}),
+		});
+
+		expect(res.status).toBe(404);
+		expect(await res.json()).toEqual({ error: "agent_session_not_found" });
+		expect(values).not.toHaveBeenCalled();
+	});
+
+	it("rejects a job attached to a session owned by another user", async () => {
+		mockSelectRowsOnce({ rows: [] });
+		const { values } = mockInsertChain();
+
+		const res = await buildApp().request("/api/agent/jobs", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				command: CODEX_AGENT_COMMAND,
+				sessionId: "other-user-session",
 				args: { codexPrompt: "Continue the chat." },
 			}),
 		});

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -13,12 +13,25 @@ vi.mock("../db/supabase", () => ({
 	getSupabase: vi.fn(),
 }));
 
+const daytonaMocks = vi.hoisted(() => ({
+	Daytona: vi.fn(),
+	create: vi.fn(),
+	get: vi.fn(),
+	executeCommand: vi.fn(),
+	downloadFile: vi.fn(),
+}));
+
+vi.mock("@daytona/sdk", () => ({
+	Daytona: daytonaMocks.Daytona,
+}));
+
 const { db } = await import("../db/drizzle");
 const { getSupabase } = await import("../db/supabase");
 const {
 	CODEX_AGENT_COMMAND,
 	agentRoutes,
 	getDefaultAgentUserId,
+	parseTerminalArtifactList,
 	validateAgentJobBody,
 	validateCommand,
 } = await import("./agent");
@@ -134,6 +147,12 @@ function mockOwnedJobAndArtifact({
 beforeEach(() => {
 	process.env.MOCK_MODE = "true";
 	vi.clearAllMocks();
+	daytonaMocks.Daytona.mockImplementation(function DaytonaMock() {
+		return {
+			create: daytonaMocks.create,
+			get: daytonaMocks.get,
+		};
+	});
 });
 
 afterEach(() => {
@@ -315,6 +334,94 @@ describe("POST /api/agent/sessions/:sessionId/end", () => {
 		expect(res.status).toBe(404);
 		expect(await res.json()).toEqual({ error: "agent_session_not_found" });
 		expect(set).not.toHaveBeenCalled();
+	});
+});
+
+describe("agent terminal artifacts", () => {
+	it("parses only direct safe files from Daytona find output", () => {
+		expect(
+			parseTerminalArtifactList({
+				stdout: [
+					"result.png\t120",
+					"clip.mp4\t4096",
+					"../secret.txt\t10",
+					"nested/file.txt\t20",
+					"bad.txt\tnot-a-number",
+				].join("\n"),
+			})
+		).toEqual([
+			{ filename: "result.png", bytes: 120 },
+			{ filename: "clip.mp4", bytes: 4096 },
+			{ filename: "bad.txt", bytes: 0 },
+		]);
+	});
+
+	it("lists files from the active Daytona terminal sandbox", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		mockSelectRowsOnce({
+			rows: [makeAgentSession({ providerSessionId: "sandbox-1" })],
+		});
+		daytonaMocks.get.mockResolvedValue({
+			process: {
+				executeCommand: daytonaMocks.executeCommand.mockResolvedValue({
+					exitCode: 0,
+					result: "result.png\t120\nclip.mp4\t4096\n",
+				}),
+			},
+		});
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/agent-session-1/artifacts"
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.artifacts).toEqual([
+			expect.objectContaining({
+				id: "result.png",
+				sessionId: "agent-session-1",
+				kind: "image",
+				bytes: 120,
+			}),
+			expect.objectContaining({
+				id: "clip.mp4",
+				sessionId: "agent-session-1",
+				kind: "video",
+				bytes: 4096,
+			}),
+		]);
+		expect(daytonaMocks.get).toHaveBeenCalledWith("sandbox-1");
+	});
+
+	it("downloads a file from the active Daytona terminal sandbox", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		mockSelectRowsOnce({
+			rows: [makeAgentSession({ providerSessionId: "sandbox-1" })],
+		});
+		daytonaMocks.get.mockResolvedValue({
+			fs: {
+				downloadFile: daytonaMocks.downloadFile.mockResolvedValue(
+					Buffer.from([1, 2, 3])
+				),
+			},
+		});
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/agent-session-1/artifacts/result.png/download"
+		);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("image/png");
+		expect(res.headers.get("Content-Disposition")).toBe(
+			'attachment; filename="result.png"'
+		);
+		expect(new Uint8Array(await res.arrayBuffer())).toEqual(
+			new Uint8Array([1, 2, 3])
+		);
+		expect(daytonaMocks.downloadFile).toHaveBeenCalledWith(
+			"/tmp/qcut-output/result.png",
+			600
+		);
 	});
 });
 

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -18,6 +18,7 @@ const daytonaMocks = vi.hoisted(() => ({
 	create: vi.fn(),
 	get: vi.fn(),
 	executeCommand: vi.fn(),
+	listFiles: vi.fn(),
 	downloadFile: vi.fn(),
 	downloadFiles: vi.fn(),
 }));
@@ -31,7 +32,9 @@ const { getSupabase } = await import("../db/supabase");
 const {
 	CODEX_AGENT_COMMAND,
 	agentRoutes,
+	buildTerminalArtifactListCommand,
 	getDefaultAgentUserId,
+	parseTerminalArtifactFiles,
 	parseTerminalArtifactList,
 	validateAgentJobBody,
 	validateCommand,
@@ -360,6 +363,14 @@ describe("POST /api/agent/sessions/:sessionId/end", () => {
 });
 
 describe("agent terminal artifacts", () => {
+	it("builds a shell artifact list fallback command for Daytona process namespace", () => {
+		const command = buildTerminalArtifactListCommand();
+
+		expect(command).toContain("sh -lc");
+		expect(command).toContain("for file in /tmp/qcut-output/*");
+		expect(command).toContain("wc -c");
+	});
+
 	it("parses only direct safe files from Daytona find output", () => {
 		expect(
 			parseTerminalArtifactList({
@@ -378,16 +389,75 @@ describe("agent terminal artifacts", () => {
 		]);
 	});
 
+	it("parses only direct safe files from Daytona file details", () => {
+		expect(
+			parseTerminalArtifactFiles({
+				files: [
+					{ name: "result.png", size: 120, isDir: false },
+					{ name: "clip.mp4", size: 4096, isDir: false },
+					{ name: "nested", size: 0, isDir: true },
+					{ name: "../secret.txt", size: 10, isDir: false },
+					{ name: "bad.txt", size: Number.NaN, isDir: false },
+				],
+			})
+		).toEqual([
+			{ filename: "bad.txt", bytes: 0 },
+			{ filename: "clip.mp4", bytes: 4096 },
+			{ filename: "result.png", bytes: 120 },
+		]);
+	});
+
 	it("lists files from the active Daytona terminal sandbox", async () => {
 		process.env.DAYTONA_API_KEY = "daytona-test";
 		mockSelectRowsOnce({
 			rows: [makeAgentSession({ providerSessionId: "sandbox-1" })],
 		});
 		daytonaMocks.get.mockResolvedValue({
+			fs: {
+				listFiles: daytonaMocks.listFiles.mockResolvedValue([
+					{ name: "result.png", size: 120, isDir: false },
+					{ name: "clip.mp4", size: 4096, isDir: false },
+				]),
+			},
+		});
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/agent-session-1/artifacts"
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.artifacts).toEqual([
+			expect.objectContaining({
+				id: "clip.mp4",
+				sessionId: "agent-session-1",
+				kind: "video",
+				bytes: 4096,
+			}),
+			expect.objectContaining({
+				id: "result.png",
+				sessionId: "agent-session-1",
+				kind: "image",
+				bytes: 120,
+			}),
+		]);
+		expect(daytonaMocks.get).toHaveBeenCalledWith("sandbox-1");
+		expect(daytonaMocks.listFiles).toHaveBeenCalledWith("/tmp/qcut-output");
+	});
+
+	it("falls back to shell listing when Daytona FS listing is empty", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		mockSelectRowsOnce({
+			rows: [makeAgentSession({ providerSessionId: "sandbox-1" })],
+		});
+		daytonaMocks.get.mockResolvedValue({
+			fs: {
+				listFiles: daytonaMocks.listFiles.mockResolvedValue([]),
+			},
 			process: {
 				executeCommand: daytonaMocks.executeCommand.mockResolvedValue({
 					exitCode: 0,
-					result: "result.png\t120\nclip.mp4\t4096\n",
+					result: "result.png\t120\n",
 				}),
 			},
 		});
@@ -401,18 +471,15 @@ describe("agent terminal artifacts", () => {
 		expect(body.artifacts).toEqual([
 			expect.objectContaining({
 				id: "result.png",
-				sessionId: "agent-session-1",
-				kind: "image",
 				bytes: 120,
 			}),
-			expect.objectContaining({
-				id: "clip.mp4",
-				sessionId: "agent-session-1",
-				kind: "video",
-				bytes: 4096,
-			}),
 		]);
-		expect(daytonaMocks.get).toHaveBeenCalledWith("sandbox-1");
+		expect(daytonaMocks.executeCommand).toHaveBeenCalledWith(
+			expect.stringContaining("sh -lc"),
+			"/home/qcut/qcut",
+			undefined,
+			30
+		);
 	});
 
 	it("downloads a file from the active Daytona terminal sandbox", async () => {

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -318,6 +318,28 @@ describe("POST /api/agent/jobs", () => {
 		);
 	});
 
+	it("records the submitted job source when provided", async () => {
+		const { values } = mockInsertChain();
+
+		const res = await buildApp().request("/api/agent/jobs", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				command: "qcut system doctor --json --skip-health",
+				args: { source: "codex_cli_e2e_probe" },
+			}),
+		});
+
+		expect(res.status).toBe(201);
+		expect(values).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				kind: "job_submitted",
+				payload: { source: "codex_cli_e2e_probe" },
+			})
+		);
+	});
+
 	it("rejects unsafe commands before inserting rows", async () => {
 		const { values } = mockInsertChain();
 

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -5,6 +5,7 @@ vi.mock("../db/drizzle", () => ({
 	db: {
 		insert: vi.fn(),
 		select: vi.fn(),
+		update: vi.fn(),
 	},
 }));
 
@@ -51,11 +52,37 @@ function mockInsertChain() {
 	return { values };
 }
 
+function mockUpdateChain() {
+	const where = vi.fn().mockResolvedValue(undefined);
+	const set = vi.fn().mockReturnValue({ where });
+	vi.mocked(db.update).mockReturnValue({ set } as never);
+	return { set, where };
+}
+
 function mockSelectRowsOnce({ rows }: { rows: unknown[] }): void {
 	const limit = vi.fn().mockResolvedValue(rows);
-	const where = vi.fn().mockReturnValue({ limit });
+	const orderBy = vi.fn().mockReturnValue({ limit });
+	const where = vi.fn().mockReturnValue({ limit, orderBy });
 	const from = vi.fn().mockReturnValue({ where });
 	vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+}
+
+function makeAgentSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "agent-session-1",
+		userId: "mock-user-001",
+		status: "active",
+		provider: "daytona",
+		providerSessionId: null,
+		imageTag: "qcut-cli:test",
+		startedAt: new Date("2026-05-15T00:00:00.000Z"),
+		lastActiveAt: new Date("2026-05-15T00:00:00.000Z"),
+		expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+		endedAt: null,
+		endReason: null,
+		runnerId: null,
+		...overrides,
+	};
 }
 
 function mockArtifactDownload({ text }: { text: string }): void {
@@ -207,6 +234,72 @@ describe("agent default user auth", () => {
 	});
 });
 
+describe("POST /api/agent/sessions", () => {
+	it("creates an active Daytona session when none can be reused", async () => {
+		mockSelectRowsOnce({ rows: [] });
+		const { values } = mockInsertChain();
+
+		const res = await buildApp().request("/api/agent/sessions", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.session.status).toBe("active");
+		expect(body.session.provider).toBe("daytona");
+		expect(values).toHaveBeenCalledWith(
+			expect.objectContaining({
+				userId: "mock-user-001",
+				status: "active",
+				provider: "daytona",
+			})
+		);
+	});
+
+	it("reuses the newest active session", async () => {
+		mockSelectRowsOnce({ rows: [makeAgentSession()] });
+
+		const res = await buildApp().request("/api/agent/sessions", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.session.id).toBe("agent-session-1");
+		expect(db.insert).not.toHaveBeenCalled();
+	});
+});
+
+describe("POST /api/agent/sessions/:sessionId/end", () => {
+	it("marks the owned session as stopping for worker cleanup", async () => {
+		mockSelectRowsOnce({ rows: [makeAgentSession()] });
+		const { set } = mockUpdateChain();
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/agent-session-1/end",
+			{
+				method: "POST",
+				headers: jsonHeaders(),
+				body: JSON.stringify({}),
+			}
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.session.status).toBe("stopping");
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "stopping",
+				endReason: "user_kill",
+			})
+		);
+	});
+});
+
 describe("GET /api/agent/jobs/:jobId/artifacts/:artifactId/text", () => {
 	it("returns text artifacts owned by the authenticated user", async () => {
 		mockOwnedJobAndArtifact({
@@ -338,6 +431,64 @@ describe("POST /api/agent/jobs", () => {
 				payload: { source: "codex_cli_e2e_probe" },
 			})
 		);
+	});
+
+	it("creates a queued job attached to an active session", async () => {
+		mockSelectRowsOnce({ rows: [makeAgentSession()] });
+		const { values } = mockInsertChain();
+		const { set } = mockUpdateChain();
+
+		const res = await buildApp().request("/api/agent/jobs", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				command: CODEX_AGENT_COMMAND,
+				sessionId: "agent-session-1",
+				args: { codexPrompt: "Continue the chat." },
+			}),
+		});
+
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.job.sessionId).toBe("agent-session-1");
+		expect(values).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				sessionId: "agent-session-1",
+				command: CODEX_AGENT_COMMAND,
+			})
+		);
+		expect(values).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				payload: {
+					source: "website_chat_agent",
+					sessionId: "agent-session-1",
+				},
+			})
+		);
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({ lastActiveAt: expect.any(Date) })
+		);
+	});
+
+	it("rejects a job attached to a missing session", async () => {
+		mockSelectRowsOnce({ rows: [] });
+		const { values } = mockInsertChain();
+
+		const res = await buildApp().request("/api/agent/jobs", {
+			method: "POST",
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				command: CODEX_AGENT_COMMAND,
+				sessionId: "missing-session",
+				args: { codexPrompt: "Continue the chat." },
+			}),
+		});
+
+		expect(res.status).toBe(404);
+		expect(await res.json()).toEqual({ error: "agent_session_not_found" });
+		expect(values).not.toHaveBeenCalled();
 	});
 
 	it("rejects unsafe commands before inserting rows", async () => {

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -19,6 +19,7 @@ const daytonaMocks = vi.hoisted(() => ({
 	get: vi.fn(),
 	executeCommand: vi.fn(),
 	downloadFile: vi.fn(),
+	downloadFiles: vi.fn(),
 }));
 
 vi.mock("@daytona/sdk", () => ({
@@ -107,6 +108,27 @@ function mockArtifactDownload({ text }: { text: string }): void {
 	vi.mocked(getSupabase).mockReturnValue({
 		storage: { from },
 	} as never);
+}
+
+function buildMultipartDownload({
+	boundary,
+	filename,
+	bytes,
+}: {
+	boundary: string;
+	filename: string;
+	bytes: Uint8Array;
+}): Uint8Array {
+	const encoder = new TextEncoder();
+	const prefix = encoder.encode(
+		`--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`
+	);
+	const suffix = encoder.encode(`\r\n--${boundary}--\r\n`);
+	const output = new Uint8Array(prefix.length + bytes.length + suffix.length);
+	output.set(prefix, 0);
+	output.set(bytes, prefix.length);
+	output.set(suffix, prefix.length + bytes.length);
+	return output;
 }
 
 function mockOwnedJobAndArtifact({
@@ -398,11 +420,21 @@ describe("agent terminal artifacts", () => {
 		mockSelectRowsOnce({
 			rows: [makeAgentSession({ providerSessionId: "sandbox-1" })],
 		});
+		const boundary = "qcut-test-boundary";
 		daytonaMocks.get.mockResolvedValue({
 			fs: {
-				downloadFile: daytonaMocks.downloadFile.mockResolvedValue(
-					Buffer.from([1, 2, 3])
-				),
+				apiClient: {
+					downloadFiles: daytonaMocks.downloadFiles.mockResolvedValue({
+						data: buildMultipartDownload({
+							boundary,
+							filename: "/tmp/qcut-output/result.png",
+							bytes: new Uint8Array([1, 2, 3]),
+						}),
+						headers: {
+							"content-type": `multipart/form-data; boundary=${boundary}`,
+						},
+					}),
+				},
 			},
 		});
 
@@ -418,10 +450,11 @@ describe("agent terminal artifacts", () => {
 		expect(new Uint8Array(await res.arrayBuffer())).toEqual(
 			new Uint8Array([1, 2, 3])
 		);
-		expect(daytonaMocks.downloadFile).toHaveBeenCalledWith(
-			"/tmp/qcut-output/result.png",
-			600
+		expect(daytonaMocks.downloadFiles).toHaveBeenCalledWith(
+			{ paths: ["/tmp/qcut-output/result.png"] },
+			{ responseType: "arraybuffer", timeout: 600_000 }
 		);
+		expect(daytonaMocks.downloadFile).not.toHaveBeenCalled();
 	});
 });
 

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -1,10 +1,13 @@
 import { Hono, type Context, type Next } from "hono";
 import { and, desc, eq, gt } from "drizzle-orm";
+import { Daytona } from "@daytona/sdk";
+import { SignJWT } from "jose";
 import {
 	agentArtifacts,
 	agentEvents,
 	agentJobs,
 	agentSessions,
+	agentSecrets,
 } from "@qcut/db/schema";
 import { db } from "../db/drizzle";
 import { getSupabase } from "../db/supabase";
@@ -16,7 +19,11 @@ const MAX_COMMAND_LENGTH = 2000;
 const MAX_CODEX_PROMPT_LENGTH = 12_000;
 const MAX_AGENT_SOURCE_LENGTH = 120;
 const MAX_TEXT_ARTIFACT_BYTES = 256_000;
+const MAX_TERMINAL_ARTIFACTS = 80;
 const AGENT_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+const AGENT_SESSION_SANDBOX_AUTO_STOP_MINUTES = 120;
+const DAYTONA_CREATE_TIMEOUT_SECONDS = 300;
+const TERMINAL_OUTPUT_DIR = "/tmp/qcut-output";
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9_\-./:=,@+]+$/;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
 const DEFAULT_DAYTONA_IMAGE =
@@ -92,6 +99,57 @@ agentRoutes.post("/sessions/:sessionId/end", async (c) => {
 		);
 	}
 });
+
+agentRoutes.post("/sessions/:sessionId/pty-token", async (c) => {
+	try {
+		return await createAgentPtyToken(c);
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? `Failed to create agent terminal: ${error.message}`
+						: "Failed to create agent terminal",
+			},
+			500
+		);
+	}
+});
+
+agentRoutes.get("/sessions/:sessionId/artifacts", async (c) => {
+	try {
+		return await listAgentSessionArtifacts(c);
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? `Failed to list session artifacts: ${error.message}`
+						: "Failed to list session artifacts",
+			},
+			500
+		);
+	}
+});
+
+agentRoutes.get(
+	"/sessions/:sessionId/artifacts/:filename/download",
+	async (c) => {
+		try {
+			return await downloadAgentSessionArtifact(c);
+		} catch (error) {
+			return c.json(
+				{
+					error:
+						error instanceof Error
+							? `Failed to download session artifact: ${error.message}`
+							: "Failed to download session artifact",
+				},
+				500
+			);
+		}
+	}
+);
 
 function getDefaultAgentUserId(): string {
 	const value = process.env.QCUT_AGENT_DEFAULT_USER_ID;
@@ -437,6 +495,253 @@ async function endAgentSession(c: Context) {
 	});
 }
 
+type DaytonaClient = InstanceType<typeof Daytona>;
+type DaytonaSandbox = Awaited<ReturnType<DaytonaClient["create"]>>;
+
+async function createAgentPtyToken(c: Context) {
+	const userId = c.get("userId") as string;
+	const sessionId = normalizeOptionalId({ value: c.req.param("sessionId") });
+	if (!sessionId) {
+		return c.json({ error: "agent_session_id_required" }, 400);
+	}
+
+	const relaySecret = getRelaySigningSecret();
+	if (!relaySecret) {
+		return c.json({ error: "agent_terminal_misconfigured: relay_secret" }, 500);
+	}
+
+	const apiKey = getDaytonaApiKey();
+	if (!apiKey) {
+		return c.json({ error: "agent_terminal_misconfigured: daytona" }, 500);
+	}
+
+	const session = await getActiveOwnedAgentSession({
+		sessionId,
+		userId,
+		now: new Date(),
+	});
+	if (!session) {
+		return c.json({ error: "agent_session_not_found" }, 404);
+	}
+
+	const daytona = new Daytona({ apiKey });
+	const sandbox = await getOrCreateAgentTerminalSandbox({
+		daytona,
+		session,
+		userId,
+	});
+	const now = new Date();
+	await db
+		.update(agentSessions)
+		.set({
+			providerSessionId: sandbox.id,
+			imageTag: getAgentImageTag(),
+			lastActiveAt: now,
+		})
+		.where(
+			and(eq(agentSessions.id, session.id), eq(agentSessions.userId, userId))
+		);
+	await db.insert(agentEvents).values({
+		jobId: null,
+		userId,
+		kind: "agent_terminal_ready",
+		payload: {
+			sessionId: session.id,
+			sandboxId: sandbox.id,
+			provider: "daytona",
+		},
+		createdAt: now,
+	});
+
+	const wsToken = await new SignJWT({
+		session_id: session.id,
+		session_kind: "agent",
+	})
+		.setProtectedHeader({ alg: "HS256" })
+		.setExpirationTime("5m")
+		.sign(new TextEncoder().encode(relaySecret));
+	const expiresAt = serializeDate({ value: session.expiresAt });
+
+	return c.json({
+		session: serializeAgentSession({
+			...session,
+			providerSessionId: sandbox.id,
+			imageTag: getAgentImageTag(),
+			lastActiveAt: now,
+		}),
+		ws_url: `wss://${getRelayHost()}/pty?token=${wsToken}`,
+		expires_at: expiresAt,
+	});
+}
+
+async function listAgentSessionArtifacts(c: Context) {
+	const userId = c.get("userId") as string;
+	const session = await getRequestAgentSession({ c, userId });
+	if (!session) {
+		return c.json({ error: "agent_session_not_found" }, 404);
+	}
+	if (!session.providerSessionId) {
+		return c.json({ artifacts: [] });
+	}
+
+	const sandbox = await getDaytonaSandboxForSession({ session });
+	const result = await sandbox.process.executeCommand(
+		`find ${TERMINAL_OUTPUT_DIR} -maxdepth 1 -type f -printf '%f\\t%s\\n' 2>/dev/null | sort`,
+		"/home/qcut/qcut",
+		undefined,
+		30
+	);
+	const stdout = typeof result.result === "string" ? result.result : "";
+	const artifacts = parseTerminalArtifactList({ stdout })
+		.slice(0, MAX_TERMINAL_ARTIFACTS)
+		.map((artifact) =>
+			serializeTerminalArtifact({
+				sessionId: session.id,
+				artifact,
+			})
+		);
+
+	return c.json({ artifacts });
+}
+
+async function downloadAgentSessionArtifact(c: Context) {
+	const userId = c.get("userId") as string;
+	const session = await getRequestAgentSession({ c, userId });
+	if (!session) {
+		return c.json({ error: "agent_session_not_found" }, 404);
+	}
+	if (!session.providerSessionId) {
+		return c.json({ error: "agent_session_sandbox_not_ready" }, 409);
+	}
+
+	const filename = normalizeTerminalArtifactFilename({
+		value: c.req.param("filename"),
+	});
+	if (!filename) {
+		return c.json({ error: "artifact_filename_invalid" }, 400);
+	}
+
+	const sandbox = await getDaytonaSandboxForSession({ session });
+	const buffer = await sandbox.fs.downloadFile(
+		`${TERMINAL_OUTPUT_DIR}/${filename}`,
+		10 * 60
+	);
+	const headers: Record<string, string> = {
+		"Content-Disposition": `attachment; filename="${escapeContentDispositionFilename({ filename })}"`,
+		"Content-Type": getContentTypeByFilename({ filename }),
+	};
+	if (typeof buffer.byteLength === "number") {
+		headers["Content-Length"] = String(buffer.byteLength);
+	}
+
+	return c.body(buffer, 200, headers);
+}
+
+async function getRequestAgentSession({
+	c,
+	userId,
+}: {
+	c: Context;
+	userId: string;
+}): Promise<typeof agentSessions.$inferSelect | null> {
+	const sessionId = normalizeOptionalId({ value: c.req.param("sessionId") });
+	if (!sessionId) {
+		return null;
+	}
+	return getActiveOwnedAgentSession({
+		sessionId,
+		userId,
+		now: new Date(),
+	});
+}
+
+async function getDaytonaSandboxForSession({
+	session,
+}: {
+	session: typeof agentSessions.$inferSelect;
+}): Promise<DaytonaSandbox> {
+	if (!session.providerSessionId) {
+		throw new Error("agent_session_sandbox_not_ready");
+	}
+	const apiKey = getDaytonaApiKey();
+	if (!apiKey) {
+		throw new Error("agent_terminal_misconfigured: daytona");
+	}
+	const daytona = new Daytona({ apiKey });
+	return daytona.get(session.providerSessionId);
+}
+
+async function getOrCreateAgentTerminalSandbox({
+	daytona,
+	session,
+	userId,
+}: {
+	daytona: DaytonaClient;
+	session: typeof agentSessions.$inferSelect;
+	userId: string;
+}): Promise<DaytonaSandbox> {
+	if (session.providerSessionId) {
+		try {
+			return await daytona.get(session.providerSessionId);
+		} catch (error) {
+			await db.insert(agentEvents).values({
+				jobId: null,
+				userId,
+				kind: "agent_terminal_sandbox_replaced",
+				payload: {
+					sessionId: session.id,
+					sandboxId: session.providerSessionId,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				createdAt: new Date(),
+			});
+		}
+	}
+
+	const envVars = await buildAgentTerminalEnv({ userId });
+	return daytona.create(
+		{
+			image: getAgentImageTag(),
+			envVars,
+			resources: { cpu: 2, memory: 4 },
+			ephemeral: true,
+			autoStopInterval: AGENT_SESSION_SANDBOX_AUTO_STOP_MINUTES,
+		},
+		{ timeout: DAYTONA_CREATE_TIMEOUT_SECONDS }
+	);
+}
+
+async function buildAgentTerminalEnv({
+	userId,
+}: {
+	userId: string;
+}): Promise<Record<string, string>> {
+	const secrets = await db
+		.select({ key: agentSecrets.key, value: agentSecrets.value })
+		.from(agentSecrets)
+		.where(eq(agentSecrets.userId, userId));
+	const envVars: Record<string, string> = { QCUT_SESSION_ROLE: "agent" };
+	for (const secret of secrets) envVars[secret.key] = secret.value;
+	return envVars;
+}
+
+function getDaytonaApiKey(): string {
+	const value = process.env.DAYTONA_API_KEY;
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function getRelaySigningSecret(): string {
+	const value = process.env.RELAY_SIGNING_SECRET;
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function getRelayHost(): string {
+	const value = process.env.RELAY_HOST;
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: "qcut-relay.zdhpeter.workers.dev";
+}
+
 async function getActiveOwnedAgentSession({
 	sessionId,
 	userId,
@@ -492,6 +797,29 @@ function normalizeOptionalId({ value }: { value: unknown }): string | null {
 	return trimmed.length === 0 ? null : trimmed;
 }
 
+function normalizeTerminalArtifactFilename({
+	value,
+}: {
+	value: unknown;
+}): string | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+	const trimmed = value.trim();
+	if (
+		trimmed.length === 0 ||
+		trimmed.length > 255 ||
+		trimmed === "." ||
+		trimmed === ".." ||
+		trimmed.includes("/") ||
+		trimmed.includes("\\") ||
+		trimmed.includes("\0")
+	) {
+		return null;
+	}
+	return trimmed;
+}
+
 async function parseCreateAgentJobBody({
 	c,
 }: {
@@ -503,6 +831,33 @@ async function parseCreateAgentJobBody({
 	} catch {
 		return {};
 	}
+}
+
+function parseTerminalArtifactList({
+	stdout,
+}: {
+	stdout: string;
+}): Array<{ filename: string; bytes: number }> {
+	return stdout
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.filter((line) => line.length > 0)
+		.flatMap((line) => {
+			const [filename, rawBytes] = line.split("\t");
+			const safeFilename = normalizeTerminalArtifactFilename({
+				value: filename,
+			});
+			if (!safeFilename) {
+				return [];
+			}
+			const bytes = Number(rawBytes);
+			return [
+				{
+					filename: safeFilename,
+					bytes: Number.isFinite(bytes) && bytes >= 0 ? bytes : 0,
+				},
+			];
+		});
 }
 
 function validateCommand({ command }: { command: string }): string {
@@ -614,6 +969,18 @@ function getArtifactContentType({
 	return "application/octet-stream";
 }
 
+function getContentTypeByFilename({ filename }: { filename: string }): string {
+	const normalized = filename.toLowerCase();
+	const dot = normalized.lastIndexOf(".");
+	if (dot >= 0) {
+		return (
+			CONTENT_TYPE_BY_EXTENSION[normalized.slice(dot)] ||
+			"application/octet-stream"
+		);
+	}
+	return "application/octet-stream";
+}
+
 function serializeAgentJob(job: typeof agentJobs.$inferSelect) {
 	return {
 		id: job.id,
@@ -672,10 +1039,53 @@ function serializeAgentArtifact(artifact: typeof agentArtifacts.$inferSelect) {
 	};
 }
 
+function serializeTerminalArtifact({
+	sessionId,
+	artifact,
+}: {
+	sessionId: string;
+	artifact: { filename: string; bytes: number };
+}) {
+	return {
+		id: artifact.filename,
+		sessionId,
+		jobId: null,
+		userId: null,
+		kind: classifyArtifactKind({ filename: artifact.filename }),
+		storagePath: `${TERMINAL_OUTPUT_DIR}/${artifact.filename}`,
+		bytes: artifact.bytes,
+		meta: { filename: artifact.filename, source: "terminal" },
+		createdAt: null,
+	};
+}
+
+function classifyArtifactKind({
+	filename,
+}: {
+	filename: string;
+}): "image" | "video" | "audio" | "json" | "log" {
+	const dot = filename.lastIndexOf(".");
+	const ext = dot >= 0 ? filename.toLowerCase().slice(dot) : "";
+	if ([".gif", ".jpeg", ".jpg", ".png", ".webp"].includes(ext)) {
+		return "image";
+	}
+	if ([".mov", ".mp4", ".webm"].includes(ext)) {
+		return "video";
+	}
+	if ([".m4a", ".mp3", ".ogg", ".wav"].includes(ext)) {
+		return "audio";
+	}
+	if (ext === ".json") {
+		return "json";
+	}
+	return "log";
+}
+
 export {
 	CODEX_AGENT_COMMAND,
 	agentRoutes,
 	getDefaultAgentUserId,
+	parseTerminalArtifactList,
 	validateAgentJobBody,
 	validateCommand,
 };

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -1,6 +1,11 @@
 import { Hono, type Context, type Next } from "hono";
-import { and, desc, eq } from "drizzle-orm";
-import { agentArtifacts, agentEvents, agentJobs } from "@qcut/db/schema";
+import { and, desc, eq, gt } from "drizzle-orm";
+import {
+	agentArtifacts,
+	agentEvents,
+	agentJobs,
+	agentSessions,
+} from "@qcut/db/schema";
 import { db } from "../db/drizzle";
 import { getSupabase } from "../db/supabase";
 import { authMiddleware } from "../middleware/auth";
@@ -11,8 +16,11 @@ const MAX_COMMAND_LENGTH = 2000;
 const MAX_CODEX_PROMPT_LENGTH = 12_000;
 const MAX_AGENT_SOURCE_LENGTH = 120;
 const MAX_TEXT_ARTIFACT_BYTES = 256_000;
+const AGENT_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9_\-./:=,@+]+$/;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
+const DEFAULT_DAYTONA_IMAGE =
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
 const TEXT_ARTIFACT_KINDS = new Set(["json", "log"]);
 const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
 	".gif": "image/gif",
@@ -37,6 +45,7 @@ const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
 interface CreateAgentJobBody {
 	command?: string;
 	args?: Record<string, unknown>;
+	sessionId?: string;
 }
 
 agentRoutes.use("/*", agentAuthMiddleware);
@@ -51,6 +60,38 @@ async function agentAuthMiddleware(c: Context, next: Next) {
 	}
 	return authMiddleware(c, next);
 }
+
+agentRoutes.post("/sessions", async (c) => {
+	try {
+		return await createOrReuseAgentSession(c);
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? `Failed to create agent session: ${error.message}`
+						: "Failed to create agent session",
+			},
+			500
+		);
+	}
+});
+
+agentRoutes.post("/sessions/:sessionId/end", async (c) => {
+	try {
+		return await endAgentSession(c);
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? `Failed to end agent session: ${error.message}`
+						: "Failed to end agent session",
+			},
+			500
+		);
+	}
+});
 
 function getDefaultAgentUserId(): string {
 	const value = process.env.QCUT_AGENT_DEFAULT_USER_ID;
@@ -241,12 +282,26 @@ async function createAgentJob(c: Context) {
 		return c.json({ error: validationError }, 400);
 	}
 
+	const sessionId = normalizeOptionalId({ value: body.sessionId });
+	const session =
+		sessionId === null
+			? null
+			: await getActiveOwnedAgentSession({
+					sessionId,
+					userId,
+					now: new Date(),
+				});
+	if (sessionId && !session) {
+		return c.json({ error: "agent_session_not_found" }, 404);
+	}
+
 	const jobId = crypto.randomUUID();
 	const createdAt = new Date();
 
 	await db.insert(agentJobs).values({
 		id: jobId,
 		userId,
+		sessionId: session?.id ?? null,
 		status: "queued",
 		command,
 		args: body.args ?? {},
@@ -256,15 +311,27 @@ async function createAgentJob(c: Context) {
 		jobId,
 		userId,
 		kind: "job_submitted",
-		payload: { source: getAgentJobSource({ args: body.args }) },
+		payload: {
+			source: getAgentJobSource({ args: body.args }),
+			...(session ? { sessionId: session.id } : {}),
+		},
 		createdAt,
 	});
+	if (session) {
+		await db
+			.update(agentSessions)
+			.set({ lastActiveAt: createdAt })
+			.where(
+				and(eq(agentSessions.id, session.id), eq(agentSessions.userId, userId))
+			);
+	}
 
 	return c.json(
 		{
 			job: {
 				id: jobId,
 				userId,
+				sessionId: session?.id ?? null,
 				status: "queued",
 				command,
 				args: body.args ?? {},
@@ -273,6 +340,125 @@ async function createAgentJob(c: Context) {
 		},
 		201
 	);
+}
+
+async function createOrReuseAgentSession(c: Context) {
+	const userId = c.get("userId") as string;
+	const now = new Date();
+	const [session] = await db
+		.select()
+		.from(agentSessions)
+		.where(
+			and(
+				eq(agentSessions.userId, userId),
+				eq(agentSessions.status, "active"),
+				gt(agentSessions.expiresAt, now)
+			)
+		)
+		.orderBy(desc(agentSessions.lastActiveAt))
+		.limit(1);
+	if (session) {
+		return c.json({ session: serializeAgentSession(session) });
+	}
+
+	const sessionId = crypto.randomUUID();
+	const imageTag = getAgentImageTag();
+	const expiresAt = new Date(now.getTime() + AGENT_SESSION_TTL_MS);
+	await db.insert(agentSessions).values({
+		id: sessionId,
+		userId,
+		status: "active",
+		provider: "daytona",
+		providerSessionId: null,
+		imageTag,
+		startedAt: now,
+		lastActiveAt: now,
+		expiresAt,
+	});
+
+	return c.json(
+		{
+			session: {
+				id: sessionId,
+				userId,
+				status: "active",
+				provider: "daytona",
+				providerSessionId: null,
+				imageTag,
+				startedAt: now.toISOString(),
+				lastActiveAt: now.toISOString(),
+				expiresAt: expiresAt.toISOString(),
+				endedAt: null,
+				endReason: null,
+				runnerId: null,
+			},
+		},
+		201
+	);
+}
+
+async function endAgentSession(c: Context) {
+	const userId = c.get("userId") as string;
+	const sessionId = normalizeOptionalId({ value: c.req.param("sessionId") });
+	if (!sessionId) {
+		return c.json({ error: "agent_session_id_required" }, 400);
+	}
+
+	const [session] = await db
+		.select()
+		.from(agentSessions)
+		.where(
+			and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId))
+		)
+		.limit(1);
+	if (!session) {
+		return c.json({ error: "agent_session_not_found" }, 404);
+	}
+
+	const now = new Date();
+	await db
+		.update(agentSessions)
+		.set({
+			status: "stopping",
+			endReason: "user_kill",
+			lastActiveAt: now,
+		})
+		.where(
+			and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId))
+		);
+
+	return c.json({
+		session: serializeAgentSession({
+			...session,
+			status: "stopping",
+			endReason: "user_kill",
+			lastActiveAt: now,
+		}),
+	});
+}
+
+async function getActiveOwnedAgentSession({
+	sessionId,
+	userId,
+	now,
+}: {
+	sessionId: string;
+	userId: string;
+	now: Date;
+}): Promise<typeof agentSessions.$inferSelect | null> {
+	const [session] = await db
+		.select()
+		.from(agentSessions)
+		.where(
+			and(
+				eq(agentSessions.id, sessionId),
+				eq(agentSessions.userId, userId),
+				eq(agentSessions.status, "active"),
+				gt(agentSessions.expiresAt, now)
+			)
+		)
+		.limit(1);
+	return session || null;
 }
 
 function getAgentJobSource({
@@ -289,6 +475,21 @@ function getAgentJobSource({
 		return "website_chat_agent";
 	}
 	return trimmed.slice(0, MAX_AGENT_SOURCE_LENGTH);
+}
+
+function getAgentImageTag(): string {
+	const value = process.env.QCUT_IMAGE_TAG;
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: DEFAULT_DAYTONA_IMAGE;
+}
+
+function normalizeOptionalId({ value }: { value: unknown }): string | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+	const trimmed = value.trim();
+	return trimmed.length === 0 ? null : trimmed;
 }
 
 async function parseCreateAgentJobBody({
@@ -417,6 +618,7 @@ function serializeAgentJob(job: typeof agentJobs.$inferSelect) {
 	return {
 		id: job.id,
 		userId: job.userId,
+		sessionId: job.sessionId,
 		status: job.status,
 		command: job.command,
 		args: job.args,
@@ -426,6 +628,23 @@ function serializeAgentJob(job: typeof agentJobs.$inferSelect) {
 		exitCode: job.exitCode,
 		error: job.error,
 		runnerId: job.runnerId,
+	};
+}
+
+function serializeAgentSession(session: typeof agentSessions.$inferSelect) {
+	return {
+		id: session.id,
+		userId: session.userId,
+		status: session.status,
+		provider: session.provider,
+		providerSessionId: session.providerSessionId,
+		imageTag: session.imageTag,
+		startedAt: serializeDate({ value: session.startedAt }),
+		lastActiveAt: serializeDate({ value: session.lastActiveAt }),
+		expiresAt: serializeDate({ value: session.expiresAt }),
+		endedAt: serializeDate({ value: session.endedAt }),
+		endReason: session.endReason,
+		runnerId: session.runnerId,
 	};
 }
 

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -585,14 +585,18 @@ async function listAgentSessionArtifacts(c: Context) {
 	}
 
 	const sandbox = await getDaytonaSandboxForSession({ session });
-	const result = await sandbox.process.executeCommand(
-		`find ${TERMINAL_OUTPUT_DIR} -maxdepth 1 -type f -printf '%f\\t%s\\n' 2>/dev/null | sort`,
-		"/home/qcut/qcut",
-		undefined,
-		30
-	);
-	const stdout = typeof result.result === "string" ? result.result : "";
-	const artifacts = parseTerminalArtifactList({ stdout })
+	let files: Array<{ isDir?: boolean; name?: string; size?: number }>;
+	try {
+		files = await sandbox.fs.listFiles(TERMINAL_OUTPUT_DIR);
+	} catch {
+		files = [];
+	}
+	const fileArtifacts = parseTerminalArtifactFiles({ files });
+	const terminalArtifacts =
+		fileArtifacts.length > 0
+			? fileArtifacts
+			: await listTerminalArtifactsViaShell({ sandbox });
+	const artifacts = terminalArtifacts
 		.slice(0, MAX_TERMINAL_ARTIFACTS)
 		.map((artifact) =>
 			serializeTerminalArtifact({
@@ -860,6 +864,64 @@ function parseTerminalArtifactList({
 		});
 }
 
+function parseTerminalArtifactFiles({
+	files,
+}: {
+	files: Array<{ isDir?: boolean; name?: string; size?: number }>;
+}): Array<{ filename: string; bytes: number }> {
+	return files
+		.filter((file) => !file.isDir)
+		.flatMap((file) => {
+			const safeFilename = normalizeTerminalArtifactFilename({
+				value: file.name,
+			});
+			if (!safeFilename) {
+				return [];
+			}
+			const bytes = Number(file.size);
+			return [
+				{
+					filename: safeFilename,
+					bytes: Number.isFinite(bytes) && bytes >= 0 ? bytes : 0,
+				},
+			];
+		})
+		.sort((left, right) => left.filename.localeCompare(right.filename));
+}
+
+async function listTerminalArtifactsViaShell({
+	sandbox,
+}: {
+	sandbox: DaytonaSandbox;
+}): Promise<Array<{ filename: string; bytes: number }>> {
+	const result = await sandbox.process.executeCommand(
+		buildTerminalArtifactListCommand(),
+		"/home/qcut/qcut",
+		undefined,
+		30
+	);
+	const stdout = typeof result.result === "string" ? result.result : "";
+	return parseTerminalArtifactList({ stdout });
+}
+
+function buildTerminalArtifactListCommand(): string {
+	const script = [
+		`if [ -d ${TERMINAL_OUTPUT_DIR} ]; then`,
+		`for file in ${TERMINAL_OUTPUT_DIR}/*; do`,
+		'[ -f "$file" ] || continue',
+		'filename=${file##*/}',
+		'bytes=$(wc -c < "$file" | tr -d " ")',
+		'printf "%s\\t%s\\n" "$filename" "$bytes"',
+		"done | sort",
+		"fi",
+	].join("\n");
+	return `sh -lc ${shellSingleQuote({ value: script })}`;
+}
+
+function shellSingleQuote({ value }: { value: string }): string {
+	return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
 function validateCommand({ command }: { command: string }): string {
 	if (command.length === 0) {
 		return "command_required";
@@ -1084,7 +1146,9 @@ function classifyArtifactKind({
 export {
 	CODEX_AGENT_COMMAND,
 	agentRoutes,
+	buildTerminalArtifactListCommand,
 	getDefaultAgentUserId,
+	parseTerminalArtifactFiles,
 	parseTerminalArtifactList,
 	validateAgentJobBody,
 	validateCommand,

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -12,6 +12,7 @@ import {
 import { db } from "../db/drizzle";
 import { getSupabase } from "../db/supabase";
 import { authMiddleware } from "../middleware/auth";
+import { downloadDaytonaFileBytes } from "../services/daytona-download";
 
 const agentRoutes = new Hono();
 
@@ -48,7 +49,6 @@ const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
 	".webm": "video/webm",
 	".webp": "image/webp",
 };
-
 interface CreateAgentJobBody {
 	command?: string;
 	args?: Record<string, unknown>;
@@ -622,19 +622,19 @@ async function downloadAgentSessionArtifact(c: Context) {
 	}
 
 	const sandbox = await getDaytonaSandboxForSession({ session });
-	const buffer = await sandbox.fs.downloadFile(
-		`${TERMINAL_OUTPUT_DIR}/${filename}`,
-		10 * 60
-	);
+	const remotePath = `${TERMINAL_OUTPUT_DIR}/${filename}`;
+	const fileBytes = await downloadDaytonaFileBytes({
+		sandbox,
+		remotePath,
+		timeoutSeconds: 10 * 60,
+	});
 	const headers: Record<string, string> = {
 		"Content-Disposition": `attachment; filename="${escapeContentDispositionFilename({ filename })}"`,
 		"Content-Type": getContentTypeByFilename({ filename }),
+		"Content-Length": String(fileBytes.byteLength),
 	};
-	if (typeof buffer.byteLength === "number") {
-		headers["Content-Length"] = String(buffer.byteLength);
-	}
 
-	return c.body(buffer, 200, headers);
+	return c.body(fileBytes, 200, headers);
 }
 
 async function getRequestAgentSession({

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -9,6 +9,7 @@ const agentRoutes = new Hono();
 
 const MAX_COMMAND_LENGTH = 2000;
 const MAX_CODEX_PROMPT_LENGTH = 12_000;
+const MAX_AGENT_SOURCE_LENGTH = 120;
 const MAX_TEXT_ARTIFACT_BYTES = 256_000;
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9_\-./:=,@+]+$/;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
@@ -255,7 +256,7 @@ async function createAgentJob(c: Context) {
 		jobId,
 		userId,
 		kind: "job_submitted",
-		payload: { source: "website_chat_agent" },
+		payload: { source: getAgentJobSource({ args: body.args }) },
 		createdAt,
 	});
 
@@ -272,6 +273,22 @@ async function createAgentJob(c: Context) {
 		},
 		201
 	);
+}
+
+function getAgentJobSource({
+	args,
+}: {
+	args?: Record<string, unknown>;
+}): string {
+	const source = args?.source;
+	if (typeof source !== "string") {
+		return "website_chat_agent";
+	}
+	const trimmed = source.trim();
+	if (trimmed.length === 0) {
+		return "website_chat_agent";
+	}
+	return trimmed.slice(0, MAX_AGENT_SOURCE_LENGTH);
 }
 
 async function parseCreateAgentJobBody({

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -909,7 +909,7 @@ function buildTerminalArtifactListCommand(): string {
 		`if [ -d ${TERMINAL_OUTPUT_DIR} ]; then`,
 		`for file in ${TERMINAL_OUTPUT_DIR}/*; do`,
 		'[ -f "$file" ] || continue',
-		'filename=${file##*/}',
+		"filename=${file##*/}",
 		'bytes=$(wc -c < "$file" | tr -d " ")',
 		'printf "%s\\t%s\\n" "$filename" "$bytes"',
 		"done | sort",

--- a/qcut/packages/license-server/src/services/daytona-download.test.ts
+++ b/qcut/packages/license-server/src/services/daytona-download.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { downloadDaytonaFileBytes } from "./daytona-download";
+
+function buildMultipartPart({
+	boundary,
+	name,
+	filename,
+	bytes,
+}: {
+	boundary: string;
+	name: string;
+	filename: string;
+	bytes: Uint8Array;
+}): Uint8Array {
+	const encoder = new TextEncoder();
+	const prefix = encoder.encode(
+		`--${boundary}\r\nContent-Disposition: form-data; name="${name}"; filename="${filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`
+	);
+	const suffix = encoder.encode(`\r\n--${boundary}--\r\n`);
+	const output = new Uint8Array(prefix.length + bytes.length + suffix.length);
+	output.set(prefix, 0);
+	output.set(bytes, prefix.length);
+	output.set(suffix, prefix.length + bytes.length);
+	return output;
+}
+
+function mockSandbox({
+	data,
+	contentType,
+}: {
+	data: unknown;
+	contentType: string;
+}) {
+	const downloadFiles = vi.fn().mockResolvedValue({
+		data,
+		headers: { "content-type": contentType },
+	});
+	return {
+		sandbox: { fs: { apiClient: { downloadFiles } } },
+		downloadFiles,
+	};
+}
+
+describe("downloadDaytonaFileBytes", () => {
+	it("extracts the requested file from Daytona multipart bytes", async () => {
+		const boundary = "qcut-boundary";
+		const remotePath = "/tmp/qcut-output/result.png";
+		const { sandbox, downloadFiles } = mockSandbox({
+			contentType: `multipart/form-data; boundary=${boundary}`,
+			data: buildMultipartPart({
+				boundary,
+				name: "file",
+				filename: remotePath,
+				bytes: new Uint8Array([1, 2, 3]),
+			}),
+		});
+
+		const bytes = await downloadDaytonaFileBytes({
+			sandbox,
+			remotePath,
+			timeoutSeconds: 600,
+		});
+
+		expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+		expect(downloadFiles).toHaveBeenCalledWith(
+			{ paths: [remotePath] },
+			{ responseType: "arraybuffer", timeout: 600_000 }
+		);
+	});
+
+	it("throws Daytona multipart error parts", async () => {
+		const boundary = "qcut-boundary";
+		const remotePath = "/tmp/qcut-output/missing.mp4";
+		const { sandbox } = mockSandbox({
+			contentType: `multipart/form-data; boundary=${boundary}`,
+			data: buildMultipartPart({
+				boundary,
+				name: "error",
+				filename: remotePath,
+				bytes: new TextEncoder().encode("file not found"),
+			}),
+		});
+
+		await expect(
+			downloadDaytonaFileBytes({
+				sandbox,
+				remotePath,
+				timeoutSeconds: 600,
+			})
+		).rejects.toThrow("file not found");
+	});
+
+	it("returns raw bytes when Daytona responds without multipart", async () => {
+		const remotePath = "/tmp/qcut-output/result.txt";
+		const { sandbox } = mockSandbox({
+			contentType: "application/octet-stream",
+			data: new Uint8Array([4, 5, 6]),
+		});
+
+		const bytes = await downloadDaytonaFileBytes({
+			sandbox,
+			remotePath,
+			timeoutSeconds: 600,
+		});
+
+		expect(bytes).toEqual(new Uint8Array([4, 5, 6]));
+	});
+});

--- a/qcut/packages/license-server/src/services/daytona-download.ts
+++ b/qcut/packages/license-server/src/services/daytona-download.ts
@@ -1,0 +1,313 @@
+const MULTIPART_HEADER_SEPARATOR = "\r\n\r\n";
+const MULTIPART_LINE_ENDING = "\r\n";
+
+type DaytonaDownloadHeaders = Record<string, string | string[] | undefined>;
+
+interface DaytonaDownloadResponse {
+	data: unknown;
+	headers?: DaytonaDownloadHeaders;
+}
+
+interface DaytonaDownloadApiClient {
+	downloadFiles(
+		body: { paths: string[] },
+		options: { responseType: "arraybuffer"; timeout: number }
+	): Promise<DaytonaDownloadResponse>;
+}
+
+interface DaytonaDownloadFileSystem {
+	apiClient?: DaytonaDownloadApiClient;
+}
+
+interface DaytonaDownloadSandbox {
+	fs: DaytonaDownloadFileSystem;
+}
+
+interface MultipartPart {
+	name: string | null;
+	filename: string | null;
+	headers: Record<string, string>;
+	data: Uint8Array;
+}
+
+export async function downloadDaytonaFileBytes({
+	sandbox,
+	remotePath,
+	timeoutSeconds,
+}: {
+	sandbox: DaytonaDownloadSandbox;
+	remotePath: string;
+	timeoutSeconds: number;
+}): Promise<Uint8Array> {
+	const apiClient = sandbox.fs.apiClient;
+	if (!apiClient) {
+		throw new Error("daytona_download_api_unavailable");
+	}
+
+	const response = await apiClient.downloadFiles(
+		{ paths: [remotePath] },
+		{
+			responseType: "arraybuffer",
+			timeout: timeoutSeconds * 1000,
+		}
+	);
+	const bodyBytes = await normalizeDownloadResponseBytes({
+		data: response.data,
+	});
+	const contentType = getHeaderValue({
+		headers: response.headers,
+		key: "content-type",
+	});
+	if (!contentType.toLowerCase().startsWith("multipart/")) {
+		return copyBytes({ bytes: bodyBytes });
+	}
+
+	const boundary = extractMultipartBoundary({ contentType });
+	if (!boundary) {
+		throw new Error("daytona_download_boundary_missing");
+	}
+
+	const parts = parseMultipartBody({ bodyBytes, boundary });
+	const errorPart = parts.find(
+		(part) => part.name === "error" && part.filename === remotePath
+	);
+	if (errorPart) {
+		throw new Error(
+			decodeUtf8({ bytes: errorPart.data }) || "daytona_download_failed"
+		);
+	}
+
+	const filePart =
+		parts.find(
+			(part) => part.name === "file" && part.filename === remotePath
+		) || parts.find((part) => part.name === "file");
+	if (!filePart) {
+		throw new Error("daytona_download_file_missing");
+	}
+
+	return copyBytes({ bytes: filePart.data });
+}
+
+async function normalizeDownloadResponseBytes({
+	data,
+}: {
+	data: unknown;
+}): Promise<Uint8Array> {
+	if (data instanceof ArrayBuffer) {
+		return new Uint8Array(data);
+	}
+	if (ArrayBuffer.isView(data)) {
+		return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+	}
+	if (data instanceof Blob) {
+		return new Uint8Array(await data.arrayBuffer());
+	}
+	if (data instanceof ReadableStream) {
+		return new Uint8Array(await new Response(data).arrayBuffer());
+	}
+	if (typeof data === "string") {
+		return new TextEncoder().encode(data);
+	}
+	throw new Error("daytona_download_response_unsupported");
+}
+
+function getHeaderValue({
+	headers,
+	key,
+}: {
+	headers?: DaytonaDownloadHeaders;
+	key: string;
+}): string {
+	if (!headers) {
+		return "";
+	}
+	const matchingKey = Object.keys(headers).find(
+		(headerKey) => headerKey.toLowerCase() === key.toLowerCase()
+	);
+	if (!matchingKey) {
+		return "";
+	}
+	const value = headers[matchingKey];
+	if (Array.isArray(value)) {
+		return value[0] || "";
+	}
+	return value || "";
+}
+
+function extractMultipartBoundary({
+	contentType,
+}: {
+	contentType: string;
+}): string | null {
+	const match = /boundary="?([^";]+)"?/i.exec(contentType);
+	return match ? match[1] : null;
+}
+
+function parseMultipartBody({
+	bodyBytes,
+	boundary,
+}: {
+	bodyBytes: Uint8Array;
+	boundary: string;
+}): MultipartPart[] {
+	const boundaryBytes = new TextEncoder().encode(`--${boundary}`);
+	const boundaryPositions = findByteSequencePositions({
+		bytes: bodyBytes,
+		sequence: boundaryBytes,
+	});
+	const parts: MultipartPart[] = [];
+	for (let index = 0; index < boundaryPositions.length - 1; index += 1) {
+		const part = parseMultipartPart({
+			bodyBytes,
+			start: boundaryPositions[index],
+			end: boundaryPositions[index + 1],
+			boundaryLength: boundaryBytes.length,
+		});
+		if (part) {
+			parts.push(part);
+		}
+	}
+	return parts;
+}
+
+function parseMultipartPart({
+	bodyBytes,
+	start,
+	end,
+	boundaryLength,
+}: {
+	bodyBytes: Uint8Array;
+	start: number;
+	end: number;
+	boundaryLength: number;
+}): MultipartPart | null {
+	const headerStart = start + boundaryLength + MULTIPART_LINE_ENDING.length;
+	if (headerStart >= end) {
+		return null;
+	}
+
+	const separatorBytes = new TextEncoder().encode(MULTIPART_HEADER_SEPARATOR);
+	const separator = findByteSequence({
+		bytes: bodyBytes,
+		sequence: separatorBytes,
+		start: headerStart,
+		end,
+	});
+	if (separator < 0) {
+		return null;
+	}
+
+	const headersText = decodeUtf8({
+		bytes: bodyBytes.subarray(headerStart, separator),
+	});
+	const headers = parseMultipartHeaders({ headersText });
+	const disposition = headers["content-disposition"] || "";
+	const dataStart = separator + separatorBytes.length;
+	const dataEnd =
+		end >= MULTIPART_LINE_ENDING.length &&
+		decodeUtf8({
+			bytes: bodyBytes.subarray(end - MULTIPART_LINE_ENDING.length, end),
+		}) === MULTIPART_LINE_ENDING
+			? end - MULTIPART_LINE_ENDING.length
+			: end;
+
+	return {
+		name: getDispositionParam({ disposition, key: "name" }),
+		filename: getDispositionParam({ disposition, key: "filename" }),
+		headers,
+		data: bodyBytes.subarray(dataStart, Math.max(dataStart, dataEnd)),
+	};
+}
+
+function parseMultipartHeaders({
+	headersText,
+}: {
+	headersText: string;
+}): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const line of headersText.split(MULTIPART_LINE_ENDING)) {
+		const separator = line.indexOf(":");
+		if (separator <= 0) {
+			continue;
+		}
+		const key = line.slice(0, separator).trim().toLowerCase();
+		const value = line.slice(separator + 1).trim();
+		headers[key] = value;
+	}
+	return headers;
+}
+
+function getDispositionParam({
+	disposition,
+	key,
+}: {
+	disposition: string;
+	key: string;
+}): string | null {
+	const match = new RegExp(`${key}\\*?=([^;]+)`, "i").exec(disposition);
+	if (!match) {
+		return null;
+	}
+	return match[1].replace(/^"|"$/g, "").trim();
+}
+
+function findByteSequencePositions({
+	bytes,
+	sequence,
+}: {
+	bytes: Uint8Array;
+	sequence: Uint8Array;
+}): number[] {
+	const positions: number[] = [];
+	let start = 0;
+	while (start <= bytes.length - sequence.length) {
+		const position = findByteSequence({
+			bytes,
+			sequence,
+			start,
+			end: bytes.length,
+		});
+		if (position < 0) {
+			break;
+		}
+		positions.push(position);
+		start = position + sequence.length;
+	}
+	return positions;
+}
+
+function findByteSequence({
+	bytes,
+	sequence,
+	start,
+	end,
+}: {
+	bytes: Uint8Array;
+	sequence: Uint8Array;
+	start: number;
+	end: number;
+}): number {
+	for (let index = start; index <= end - sequence.length; index += 1) {
+		let matched = true;
+		for (let offset = 0; offset < sequence.length; offset += 1) {
+			if (bytes[index + offset] !== sequence[offset]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) {
+			return index;
+		}
+	}
+	return -1;
+}
+
+function copyBytes({ bytes }: { bytes: Uint8Array }): Uint8Array {
+	const output = new Uint8Array(bytes.byteLength);
+	output.set(bytes);
+	return output;
+}
+
+function decodeUtf8({ bytes }: { bytes: Uint8Array }): string {
+	return new TextDecoder().decode(bytes);
+}

--- a/qcut/packages/license-server/src/services/payment-config.ts
+++ b/qcut/packages/license-server/src/services/payment-config.ts
@@ -1,5 +1,7 @@
 const DEFAULT_CORS_ORIGINS = [
 	"http://localhost:3000",
+	"http://localhost:4177",
+	"http://127.0.0.1:4177",
 	// Electron packaged app uses the `app://` scheme with hostname `.`
 	// (see `electron/main.ts:587` → `app://./index.html`). The browser sends
 	// this as `Origin: app://.` on CORS preflights.

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -15,6 +15,7 @@ PAYMENTS_WEBHOOK_ENABLED = "true"
 PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/packages/qcut-relay/package.json
+++ b/qcut/packages/qcut-relay/package.json
@@ -10,6 +10,7 @@
 		"test": "bunx vitest run --config vitest.config.ts"
 	},
 	"dependencies": {
+		"@daytona/sdk": "^0.175.0",
 		"e2b": "^2.20.0",
 		"jose": "^5.0.0"
 	},

--- a/qcut/packages/qcut-relay/src/audit.ts
+++ b/qcut/packages/qcut-relay/src/audit.ts
@@ -73,22 +73,26 @@ export async function markEnded(
 	env: Env,
 	session_id: string,
 	reason: "disconnect" | "idle_timeout" | "ttl" | "error" | "user_kill",
-	exit_code?: number
+	exit_code?: number,
+	table: "sandbox_sessions" | "agent_sessions" = "sandbox_sessions"
 ): Promise<void> {
-	await rest(env, "PATCH", `sandbox_sessions?id=eq.${session_id}`, {
+	await rest(env, "PATCH", `${table}?id=eq.${session_id}`, {
 		status: "ended",
 		ended_at: new Date().toISOString(),
 		end_reason: reason,
-		exit_code: exit_code ?? null,
+		...(table === "sandbox_sessions" ? { exit_code: exit_code ?? null } : {}),
 	});
 }
 
 export async function fetchSession(
 	env: Env,
-	session_id: string
+	session_id: string,
+	session_kind?: "agent" | "sandbox"
 ): Promise<{
 	id: string;
+	type: "agent" | "sandbox";
 	status: string;
+	provider: string;
 	provider_session_id: string;
 	expires_at: string;
 } | null> {
@@ -98,24 +102,16 @@ export async function fetchSession(
 	const ctl = new AbortController();
 	const timer = setTimeout(() => ctl.abort(), REST_TIMEOUT_MS);
 	try {
-		const r = await fetch(
-			`${env.SUPABASE_URL}/rest/v1/sandbox_sessions?id=eq.${session_id}&select=id,status,provider_session_id,expires_at`,
-			{
-				headers: {
-					apikey: env.SUPABASE_SERVICE_ROLE_KEY,
-					Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
-				},
-				signal: ctl.signal,
-			}
+		if (session_kind === "agent") {
+			return await fetchAgentSession({ env, session_id, signal: ctl.signal });
+		}
+		if (session_kind === "sandbox") {
+			return await fetchSandboxSession({ env, session_id, signal: ctl.signal });
+		}
+		return (
+			(await fetchSandboxSession({ env, session_id, signal: ctl.signal })) ??
+			(await fetchAgentSession({ env, session_id, signal: ctl.signal }))
 		);
-		if (!r.ok) return null;
-		const rows = (await r.json()) as Array<{
-			id: string;
-			status: string;
-			provider_session_id: string;
-			expires_at: string;
-		}>;
-		return rows[0] ?? null;
 	} catch (err) {
 		console.error(
 			`[qcut-relay] fetchSession(${session_id}) threw:`,
@@ -124,5 +120,115 @@ export async function fetchSession(
 		return null;
 	} finally {
 		clearTimeout(timer);
+	}
+}
+
+async function fetchSandboxSession({
+	env,
+	session_id,
+	signal,
+}: {
+	env: Env;
+	session_id: string;
+	signal: AbortSignal;
+}): Promise<{
+	id: string;
+	type: "sandbox";
+	status: string;
+	provider: string;
+	provider_session_id: string;
+	expires_at: string;
+} | null> {
+	try {
+		const r = await fetch(
+			`${env.SUPABASE_URL}/rest/v1/sandbox_sessions?id=eq.${session_id}&select=id,status,provider,provider_session_id,expires_at`,
+			{
+				headers: {
+					apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+					Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+				},
+				signal,
+			}
+		);
+		if (!r.ok) return null;
+		const rows = (await r.json()) as Array<{
+			id: string;
+			status: string;
+			provider?: string;
+			provider_session_id: string;
+			expires_at: string;
+		}>;
+		const row = rows[0];
+		return row
+			? {
+					id: row.id,
+					type: "sandbox",
+					status: row.status,
+					provider: row.provider ?? "e2b",
+					provider_session_id: row.provider_session_id,
+					expires_at: row.expires_at,
+				}
+			: null;
+	} catch (err) {
+		console.error(
+			`[qcut-relay] fetchSandboxSession(${session_id}) threw:`,
+			err instanceof Error ? err.message : String(err)
+		);
+		return null;
+	}
+}
+
+async function fetchAgentSession({
+	env,
+	session_id,
+	signal,
+}: {
+	env: Env;
+	session_id: string;
+	signal: AbortSignal;
+}): Promise<{
+	id: string;
+	type: "agent";
+	status: string;
+	provider: string;
+	provider_session_id: string;
+	expires_at: string;
+} | null> {
+	try {
+		const r = await fetch(
+			`${env.SUPABASE_URL}/rest/v1/agent_sessions?id=eq.${session_id}&select=id,status,provider,provider_session_id,expires_at`,
+			{
+				headers: {
+					apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+					Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+				},
+				signal,
+			}
+		);
+		if (!r.ok) return null;
+		const rows = (await r.json()) as Array<{
+			id: string;
+			status: string;
+			provider: string;
+			provider_session_id: string | null;
+			expires_at: string;
+		}>;
+		const row = rows[0];
+		return row?.provider_session_id
+			? {
+					id: row.id,
+					type: "agent",
+					status: row.status,
+					provider: row.provider,
+					provider_session_id: row.provider_session_id,
+					expires_at: row.expires_at,
+				}
+			: null;
+	} catch (err) {
+		console.error(
+			`[qcut-relay] fetchAgentSession(${session_id}) threw:`,
+			err instanceof Error ? err.message : String(err)
+		);
+		return null;
 	}
 }

--- a/qcut/packages/qcut-relay/src/index.ts
+++ b/qcut/packages/qcut-relay/src/index.ts
@@ -18,6 +18,7 @@ export interface Env {
 	SUPABASE_SERVICE_ROLE_KEY: string;
 	RELAY_SIGNING_SECRET: string;
 	E2B_API_KEY: string;
+	DAYTONA_API_KEY: string;
 }
 
 export default {

--- a/qcut/packages/qcut-relay/src/pty-session.test.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCodexStartupCommand } from "./pty-session";
+
+describe("buildCodexStartupCommand", () => {
+	it("starts Codex with bypassed approvals and QCut skill guidance", () => {
+		const command = buildCodexStartupCommand({
+			sessionId: "agent-session-1",
+			provider: "daytona",
+			expiresAt: "2026-05-16T09:00:00.000Z",
+		});
+
+		expect(command).toContain("/usr/local/bin/qcut-entrypoint /bin/true");
+		expect(command).toContain("--dangerously-bypass-approvals-and-sandbox");
+		expect(command).not.toContain("-a never");
+		expect(command).toContain("-C /home/qcut/qcut");
+		expect(command).toContain("stty echo");
+		expect(command).toContain('[projects."/home/qcut/qcut"]');
+		expect(command).toContain('trust_level = "trusted"');
+		expect(command).toContain("/home/qcut/qcut/AGENTS.md");
+		expect(command).toContain("## QCut Website Chat Agent Defaults");
+		expect(command).toContain(
+			"/home/qcut/qcut/.claude/skills/native-cli/SKILL.md"
+		);
+		expect(command).toContain("/tmp/qcut-output");
+		expect(command).not.toContain("/tmp/qcut-codex-boot.md");
+	});
+});

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -18,6 +18,7 @@
 import { auditEvent, fetchSession, markEnded } from "./audit.js";
 import { verifyToken } from "./verify-token.js";
 import type { Env } from "./index.js";
+import { Daytona } from "@daytona/sdk";
 
 export class PtySession {
 	private env: Env;
@@ -39,7 +40,7 @@ export class PtySession {
 		const token = new URL(req.url).searchParams.get("token");
 		if (!token) return new Response("missing_token", { status: 400 });
 
-		let claims: { session_id: string };
+		let claims: { session_id: string; session_kind?: "agent" | "sandbox" };
 		try {
 			claims = await verifyToken({
 				token,
@@ -49,7 +50,11 @@ export class PtySession {
 			return new Response("invalid_token", { status: 401 });
 		}
 
-		const session = await fetchSession(this.env, claims.session_id);
+		const session = await fetchSession(
+			this.env,
+			claims.session_id,
+			claims.session_kind
+		);
 		if (!session || session.status !== "active") {
 			return new Response("session_not_active", { status: 410 });
 		}
@@ -59,20 +64,13 @@ export class PtySession {
 		}
 		this.attached = true;
 
-		type SandboxHandle = Awaited<
-			ReturnType<typeof import("e2b").Sandbox.connect>
-		>;
-		type PtyHandle = Awaited<ReturnType<SandboxHandle["pty"]["create"]>>;
-		let sandbox: SandboxHandle | undefined;
-		let pty: PtyHandle | undefined;
 		let server: WebSocket | undefined;
+		let sendInput: ((data: Uint8Array | string) => Promise<void>) | undefined;
+		let resize: ((cols: number, rows: number) => Promise<void>) | undefined;
+		let closePty: (() => Promise<void>) | undefined;
+		let closeSandbox: (() => Promise<void>) | undefined;
 
 		try {
-			const e2b = await import("e2b");
-			sandbox = await e2b.Sandbox.connect(session.provider_session_id, {
-				apiKey: this.env.E2B_API_KEY,
-			});
-
 			const pair = new WebSocketPair();
 			const client = pair[0];
 			server = pair[1];
@@ -89,43 +87,84 @@ export class PtySession {
 				}
 			};
 
-			pty = await sandbox.pty.create({
-				cols: 80,
-				rows: 24,
-				timeoutMs: 30 * 60 * 1000,
-				onData: (chunk: Uint8Array) => {
-					bytesOut += chunk.byteLength;
-					sendBuf(chunk);
-					if (Date.now() - lastAudit > 5000 || bytesOut > 8192) {
-						const sample = bytesOut;
-						bytesOut = 0;
-						lastAudit = Date.now();
-						void auditEvent(this.env, claims.session_id, "sandbox_io", {
-							direction: "out",
-							bytes: sample,
-						});
-					}
-				},
-			});
+			const onData = (chunk: Uint8Array | string) => {
+				const bytes =
+					typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk;
+				bytesOut += bytes.byteLength;
+				sendBuf(bytes);
+				if (Date.now() - lastAudit > 5000 || bytesOut > 8192) {
+					const sample = bytesOut;
+					bytesOut = 0;
+					lastAudit = Date.now();
+					void auditEvent(this.env, claims.session_id, "sandbox_io", {
+						direction: "out",
+						bytes: sample,
+						provider: session.provider,
+					});
+				}
+			};
+
+			if (session.provider === "daytona") {
+				const daytona = new Daytona({ apiKey: this.env.DAYTONA_API_KEY });
+				const sandbox = await daytona.get(session.provider_session_id);
+				const pty = await sandbox.process.createPty({
+					id: `qcut-agent-${claims.session_id.slice(0, 12)}`,
+					cols: 100,
+					rows: 30,
+					cwd: "/home/qcut/qcut",
+					onData,
+				});
+				sendInput = (data: Uint8Array | string) => pty.sendInput(data);
+				resize = async (cols: number, rows: number) => {
+					await pty.resize(cols, rows);
+				};
+				closePty = () => pty.kill();
+				closeSandbox = () => Promise.resolve();
+			} else {
+				const e2b = await import("e2b");
+				const sandbox = await e2b.Sandbox.connect(session.provider_session_id, {
+					apiKey: this.env.E2B_API_KEY,
+				});
+				const pty = await sandbox.pty.create({
+					cols: 80,
+					rows: 24,
+					timeoutMs: 30 * 60 * 1000,
+					onData,
+				});
+				sendInput = (data: Uint8Array | string) =>
+					sandbox.pty.sendInput(
+						pty.pid,
+						typeof data === "string" ? new TextEncoder().encode(data) : data
+					);
+				resize = async (cols: number, rows: number) => {
+					await sandbox.pty.resize(pty.pid, { cols, rows });
+				};
+				closePty = async () => {
+					await sandbox.pty.kill(pty.pid);
+				};
+				closeSandbox = async () => {
+					await sandbox.kill();
+				};
+			}
 
 			// Materialize ~/.qcut/.env from the env vars injected at spawn,
-			// then a friendly motd. Drops the user straight at the bash prompt
-			// (which is what E2B's pty.create gives them by default).
-			await sandbox.pty.sendInput(
-				pty.pid,
+			// then a friendly motd. Both providers drop us at a shell.
+			await sendInput(
 				new TextEncoder().encode(
-					"/usr/local/bin/qcut-entrypoint /bin/true && clear && echo 'qcut sandbox · session " +
+					"/usr/local/bin/qcut-entrypoint /bin/true && clear && echo 'qcut terminal · session " +
 						claims.session_id.slice(0, 8) +
+						" · provider " +
+						session.provider +
 						" · expires " +
 						session.expires_at +
-						"' && echo 'type: qcut --help for command reference'\n"
+						"' && echo 'type: qcut --help or run codex from here' && cd /home/qcut/qcut 2>/dev/null || true\n"
 				)
 			);
 			void auditEvent(this.env, claims.session_id, "motd_sent", {});
-			void auditEvent(this.env, claims.session_id, "pty_attached", {});
-
-			const ptyHandle = pty;
-			const sandboxHandle = sandbox;
+			void auditEvent(this.env, claims.session_id, "pty_attached", {
+				provider: session.provider,
+				sessionType: session.type,
+			});
 
 			server.addEventListener("message", (ev: MessageEvent) => {
 				void (async () => {
@@ -139,19 +178,17 @@ export class PtySession {
 								typeof ctrl.rows === "number" &&
 								typeof ctrl.cols === "number"
 							) {
-								await sandboxHandle.pty.resize(ptyHandle.pid, {
-									cols: ctrl.cols,
-									rows: ctrl.rows,
-								});
+								await resize?.(ctrl.cols, ctrl.rows);
+								return;
 							}
 						} catch {
-							/* drop malformed control */
+							await sendInput?.(data);
 						}
 						return;
 					}
 					try {
 						const buf = new Uint8Array(data as ArrayBuffer);
-						await sandboxHandle.pty.sendInput(ptyHandle.pid, buf);
+						await sendInput?.(buf);
 					} catch {
 						/* sandbox gone; ignore */
 					}
@@ -161,12 +198,18 @@ export class PtySession {
 			server.addEventListener("close", () => {
 				void (async () => {
 					try {
-						await sandboxHandle.pty.kill(ptyHandle.pid);
+						await closePty?.();
 					} catch {
 						/* already dead */
 					}
 					this.attached = false;
-					await markEnded(this.env, claims.session_id, "disconnect");
+					if (session.type === "sandbox") {
+						await markEnded(this.env, claims.session_id, "disconnect");
+						return;
+					}
+					await auditEvent(this.env, claims.session_id, "pty_detached", {
+						provider: session.provider,
+					});
 				})();
 			});
 
@@ -177,19 +220,15 @@ export class PtySession {
 			// doesn't stay pinned as `active` and the user can re-spawn.
 			console.error("[pty-session] init failed:", err);
 			this.attached = false;
-			if (sandbox && pty) {
-				try {
-					await sandbox.pty.kill(pty.pid);
-				} catch {
-					/* best-effort */
-				}
+			try {
+				await closePty?.();
+			} catch {
+				/* best-effort */
 			}
-			if (sandbox) {
-				try {
-					await sandbox.kill();
-				} catch {
-					/* best-effort */
-				}
+			try {
+				await closeSandbox?.();
+			} catch {
+				/* best-effort */
 			}
 			if (server) {
 				try {
@@ -199,7 +238,14 @@ export class PtySession {
 				}
 			}
 			try {
-				await markEnded(this.env, claims.session_id, "error");
+				if (session.type === "sandbox") {
+					await markEnded(this.env, claims.session_id, "error");
+				} else {
+					await auditEvent(this.env, claims.session_id, "pty_error", {
+						provider: session.provider,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
 			} catch {
 				/* audit best-effort */
 			}

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -20,6 +20,21 @@ import { verifyToken } from "./verify-token.js";
 import type { Env } from "./index.js";
 import { Daytona } from "@daytona/sdk";
 
+const CODEX_AGENT_INSTRUCTIONS = [
+	"## QCut Website Chat Agent Defaults",
+	"",
+	"You are QCut's website Chat Agent running inside a Daytona sandbox.",
+	"Use the QCut native CLI for QCut work. Do not use external image or video tools when the QCut CLI can do the job.",
+	"The QCut native CLI skill is available at /home/qcut/qcut/.claude/skills/native-cli/SKILL.md.",
+	"Read that skill before nontrivial QCut CLI workflows or whenever command syntax is unclear.",
+	"Useful first checks: qcut --version, qcut --help --json, and qcut system models --json.",
+	"Write final user-requested files under /tmp/qcut-output so the website Artifacts panel can list and download them.",
+	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
+	"yt-dlp and deno are available for authorized video download probes.",
+	"Codex is already running inside an externally isolated Daytona sandbox. Approval prompts and Codex sandboxing have been disabled intentionally for this environment.",
+	"Wait for the user's next message before running a QCut task.",
+].join("\n");
+
 export class PtySession {
 	private env: Env;
 	// Single-attachment guard. The DO id is derived from session_id, so any
@@ -147,17 +162,16 @@ export class PtySession {
 				};
 			}
 
-			// Materialize ~/.qcut/.env from the env vars injected at spawn,
-			// then a friendly motd. Both providers drop us at a shell.
+			// Materialize auth, then replace the shell with an already-authorized Codex session.
+			await sendInput(new TextEncoder().encode("stty -echo\n"));
+			await delay({ ms: 100 });
 			await sendInput(
 				new TextEncoder().encode(
-					"/usr/local/bin/qcut-entrypoint /bin/true && clear && echo 'qcut terminal · session " +
-						claims.session_id.slice(0, 8) +
-						" · provider " +
-						session.provider +
-						" · expires " +
-						session.expires_at +
-						"' && echo 'type: qcut --help or run codex from here' && cd /home/qcut/qcut 2>/dev/null || true\n"
+					buildCodexStartupCommand({
+						sessionId: claims.session_id,
+						provider: session.provider,
+						expiresAt: session.expires_at,
+					})
 				)
 			);
 			void auditEvent(this.env, claims.session_id, "motd_sent", {});
@@ -252,4 +266,54 @@ export class PtySession {
 			return new Response("session_init_failed", { status: 502 });
 		}
 	}
+}
+
+export function buildCodexStartupCommand({
+	sessionId,
+	provider,
+	expiresAt,
+}: {
+	sessionId: string;
+	provider: string;
+	expiresAt: string;
+}): string {
+	const marker = `QCUT_CODEX_AGENT_${sessionId.replace(/[^A-Za-z0-9_]/g, "_")}`;
+	return `${[
+		"/usr/local/bin/qcut-entrypoint /bin/true",
+		"cd /home/qcut/qcut 2>/dev/null || exit 1",
+		"mkdir -p /tmp/qcut-output /tmp/qcut-tools",
+		"mkdir -p /home/qcut/.codex",
+		"if ! grep -Fq '[projects.\"/home/qcut/qcut\"]' /home/qcut/.codex/config.toml 2>/dev/null; then",
+		"cat >> /home/qcut/.codex/config.toml <<'QCUT_CODEX_TRUST'",
+		"",
+		"[projects.\"/home/qcut/qcut\"]",
+		'trust_level = "trusted"',
+		"QCUT_CODEX_TRUST",
+		"fi",
+		"if ! grep -Fq '## QCut Website Chat Agent Defaults' /home/qcut/qcut/AGENTS.md 2>/dev/null; then",
+		`cat >> /home/qcut/qcut/AGENTS.md <<'${marker}'`,
+		"",
+		CODEX_AGENT_INSTRUCTIONS,
+		marker,
+		"fi",
+		"stty echo",
+		"clear",
+		`printf '%s\\n' ${shellSingleQuote({
+			value: `qcut codex terminal | session ${sessionId.slice(0, 8)} | provider ${provider} | expires ${expiresAt}`,
+		})}`,
+		[
+			"exec codex",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--no-alt-screen",
+			"-C /home/qcut/qcut",
+		].join(" "),
+	].join("\n")}\n`;
+}
+
+function shellSingleQuote({ value }: { value: string }): string {
+	return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+function delay({ ms }: { ms: number }): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -286,7 +286,7 @@ export function buildCodexStartupCommand({
 		"if ! grep -Fq '[projects.\"/home/qcut/qcut\"]' /home/qcut/.codex/config.toml 2>/dev/null; then",
 		"cat >> /home/qcut/.codex/config.toml <<'QCUT_CODEX_TRUST'",
 		"",
-		"[projects.\"/home/qcut/qcut\"]",
+		'[projects."/home/qcut/qcut"]',
 		'trust_level = "trusted"',
 		"QCUT_CODEX_TRUST",
 		"fi",

--- a/qcut/packages/qcut-relay/src/verify-token.ts
+++ b/qcut/packages/qcut-relay/src/verify-token.ts
@@ -10,6 +10,7 @@
 
 export interface RelayClaims {
 	session_id: string;
+	session_kind?: "agent" | "sandbox";
 }
 
 export async function verifyToken({
@@ -29,7 +30,7 @@ export async function verifyToken({
 		throw new Error("alg_mismatch");
 	}
 
-	const key = await globalThis.crypto.subtle.importKey(
+	const key = await crypto.subtle.importKey(
 		"raw",
 		new TextEncoder().encode(secret),
 		{ name: "HMAC", hash: "SHA-256" },
@@ -38,7 +39,7 @@ export async function verifyToken({
 	);
 	const data = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
 	const sig = b64decBin(sigB64);
-	const ok = await globalThis.crypto.subtle.verify("HMAC", key, sig, data);
+	const ok = await crypto.subtle.verify("HMAC", key, sig, data);
 	if (!ok) throw new Error("sig_mismatch");
 
 	const payload = JSON.parse(b64decUtf8(payloadB64));
@@ -48,7 +49,11 @@ export async function verifyToken({
 	if (typeof payload.session_id !== "string") {
 		throw new Error("missing_session_id");
 	}
-	return { session_id: payload.session_id };
+	const session_kind =
+		payload.session_kind === "agent" || payload.session_kind === "sandbox"
+			? payload.session_kind
+			: undefined;
+	return { session_id: payload.session_id, session_kind };
 }
 
 /** Peek `session_id` *without* verifying signature — only for routing


### PR DESCRIPTION
## Summary

- add pinned `yt-dlp` and Deno to the Daytona CLI image, including EJS remote-component config and smoke checks
- pin the Daytona runner default image to the verified YouTube-capable GHCR digest
- stream Daytona/Codex/qcut events into `agent_events` while jobs are still running instead of only after completion
- update the Chat Agent website so the pending Codex reply shows a rolling live event summary
- add persistent Daytona-backed `agent_sessions`, optional `agent_jobs.session_id`, session create/reuse/end routes, and worker sandbox reuse with idle cleanup
- update the Chat Agent website to create/reuse a session, pass `sessionId`, show session status, and start a new session on demand
- update implementation docs with session-mode status, production E2E evidence, and follow-up subtasks

## Production Deployment / E2E

- production Supabase now has `agent_sessions` plus `agent_jobs.session_id`
- `qcut-license-server` was deployed to Cloudflare Workers after the migration
- production-shaped `qcut-agent-worker` was restarted from this branch with `QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
- live website assets at `https://quriosity.com.au/chat-agent.html` include the session UI and session client code
- first real Codex session job `970686e6-19d5-4d91-aded-dc227d01b7ae` wrote marker `session-e2e-1778901412` into `/tmp/qcut-tools/session-e2e/marker.txt`; event showed `agent_session_ready.reused=false`, sandbox `2df92162-0f45-4ec6-8a7a-0b7395672f97`
- second real Codex session job `2f488dd9-ba75-4cec-875f-ce03d6dc54d0` read that same marker and replied `SECOND_OK_SAME_SANDBOX_session-e2e-1778901412`; event showed `agent_session_ready.reused=true` and the same sandbox id
- live website-created Codex job `ec2e282d-7a3a-4e9a-9a26-6c552601f19d` succeeded and returned `WEBSITE_CODEX_SESSION_UI_OK`; event showed the same active session and reused sandbox
- screenshot captured locally: `output/playwright/live-chat-agent-session-e2e.png`

## Earlier Live Verification

- GitHub Actions run `25949183927` published `ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516`
- verified image digest: `sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923`
- live Chat Agent YouTube job `3b19b2cd-cb17-4576-add0-89ba9aca2e4e` succeeded with exit `0`; artifacts included downloadable `youtube-e2e.mp4` (464.8 KB)
- live Codex realtime job `4ceb713b-3a97-451d-b219-3304cc99007b` streamed Daytona lifecycle and Codex JSONL events before completion, then returned `STREAM_TEST_DONE`
- live Chat Agent UI job `9d870b84-f2ba-4b43-b9df-c5ac9c2d14a9` showed `daytona_command_started`, `thread.started`, `turn.started`, and `item.started` in the pending Codex bubble while still running, then returned `UI_STREAM_DONE`
- live `qcut --help --json` job `229f19e9-50ad-40f7-a83d-84df1f454c77` succeeded and uploaded only user-facing artifacts: `qcut-exit.json`, `qcut-stdout.txt`, `qcut-stderr.txt`, and `qcut-output.tar`
- local browser render check loaded `http://127.0.0.1:4177/chat-agent.html` and confirmed the session controls render

## Validation

- `docker run --rm --platform linux/amd64 qcut-cli:youtube-fix qcut-smoke`
- `docker run --rm --platform linux/amd64 ghcr.io/quriosity-agent/qcut-cli:youtube-fix-20260516 qcut-smoke`
- local clean-container `yt-dlp` download wrote `/tmp/qcut-output/youtube-test.mp4`
- `bun --cwd packages/agent-worker test -- run-on-daytona.test.ts stream-events.test.ts`
- `bunx tsc -p packages/agent-worker/tsconfig.json --noEmit`
- `bun --cwd packages/license-server test -- agent.test.ts`
- `node --test packages/nexusai-website/js/agent-chat.test.js`
- `bunx biome check packages/db/src/schema.ts packages/license-server/src/routes/agent.ts packages/license-server/src/routes/agent.test.ts packages/agent-worker/src/claim.ts packages/agent-worker/src/main.ts packages/agent-worker/src/run-on-daytona.ts packages/agent-worker/src/run-on-daytona.test.ts packages/agent-worker/src/stream-events.test.ts packages/nexusai-website/chat-agent.html`

## Known Follow-Up

- `bunx tsc -p packages/license-server/tsconfig.json --noEmit` is still blocked by the workspace's existing missing implicit `sharp` type definition
- add a normal migration-runner path so production schema changes do not need a one-off Cloudflare route when the Supabase CLI lacks the DB password
