### PR TITLE
Use GPT Image 2 as Daytona image default

### DIFF
--- a/qcut/.claude/skills/native-cli/SKILL.md
+++ b/qcut/.claude/skills/native-cli/SKILL.md
@@ -82,7 +82,7 @@ For website Daytona Chat Agent sessions, uploaded files are under
 `/tmp/qcut-input` and downloadable outputs must land under
 `/tmp/qcut-output`.
 
-For image generation, the CLI default model is `gpt_image_2_gmi`. Do not pass
+For image generation, the CLI default model is `gpt_image_2_ima`. Do not pass
 `--model/-m` unless the user explicitly requests a specific image model.
 
 The CLI default output directory can be overridden with:

--- a/qcut/.claude/skills/native-cli/SKILL.md
+++ b/qcut/.claude/skills/native-cli/SKILL.md
@@ -82,6 +82,9 @@ For website Daytona Chat Agent sessions, uploaded files are under
 `/tmp/qcut-input` and downloadable outputs must land under
 `/tmp/qcut-output`.
 
+For image generation, the CLI default model is `gpt_image_2_gmi`. Do not pass
+`--model/-m` unless the user explicitly requests a specific image model.
+
 The CLI default output directory can be overridden with:
 
 ```bash
@@ -383,7 +386,7 @@ For agent or programmatic use, import `run()` or `runChain()` directly instead o
 import { run, runChain } from "./cli-runner/index.js";
 
 // Single command
-const result = await run("generate-image -t 'A cat' --model flux");
+const result = await run("generate-image -t 'A cat'");
 // → { success, exit_code, duration_ms, command_id, outputPath?, ... }
 
 // Chained commands (output piped as --input to next)

--- a/qcut/.claude/skills/native-cli/references/REFERENCE.md
+++ b/qcut/.claude/skills/native-cli/references/REFERENCE.md
@@ -19,7 +19,7 @@ Generate an image from a text prompt.
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--text` | `-t` | string | Text prompt (required) |
-| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_gmi`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_gmi`) |
+| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_ima`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_ima`) |
 | `--aspect-ratio` | | string | e.g. `16:9`, `9:16`, `1:1` |
 | `--resolution` | | string | e.g. `1080p`, `720p` |
 | `--negative-prompt` | | string | Negative prompt |
@@ -82,7 +82,7 @@ Generate a grid of images from a prompt. Use `--grid` with `gen image` to produc
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--text` | `-t` | string | | Prompt (required) |
-| `--model` | `-m` | string | `gpt_image_2_gmi` | Image model |
+| `--model` | `-m` | string | `gpt_image_2_ima` | Image model |
 | `--grid` | | string | | Grid layout: `2x2`, `3x3`, `2x3`, `3x2`, `1x2`, `2x1` |
 | `--style` | | string | | Style prefix prepended to prompt |
 | `--grid-upscale` | | float | | Upscale factor after compositing |

--- a/qcut/.claude/skills/native-cli/references/REFERENCE.md
+++ b/qcut/.claude/skills/native-cli/references/REFERENCE.md
@@ -19,7 +19,7 @@ Generate an image from a text prompt.
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--text` | `-t` | string | Text prompt (required) |
-| `--model` | `-m` | string | Model key, e.g. `flux_dev`, `flux_schnell` (default: `nano_banana_pro`) |
+| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_gmi`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_gmi`) |
 | `--aspect-ratio` | | string | e.g. `16:9`, `9:16`, `1:1` |
 | `--resolution` | | string | e.g. `1080p`, `720p` |
 | `--negative-prompt` | | string | Negative prompt |
@@ -82,7 +82,7 @@ Generate a grid of images from a prompt. Use `--grid` with `gen image` to produc
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--text` | `-t` | string | | Prompt (required) |
-| `--model` | `-m` | string | `flux_dev` | Image model |
+| `--model` | `-m` | string | `gpt_image_2_gmi` | Image model |
 | `--grid` | | string | | Grid layout: `2x2`, `3x3`, `2x3`, `3x2`, `1x2`, `2x1` |
 | `--style` | | string | | Style prefix prepended to prompt |
 | `--grid-upscale` | | float | | Upscale factor after compositing |

--- a/qcut/.claude/skills/native-cli/references/reference-pipelines.md
+++ b/qcut/.claude/skills/native-cli/references/reference-pipelines.md
@@ -28,7 +28,7 @@ Run a multi-step YAML pipeline.
 name: my-pipeline
 steps:
   - type: text_to_image       # ModelCategory value
-    model: flux_dev            # model key
+    model: gpt_image_2_gmi     # model key
     params:                    # model-specific params
       image_size: landscape_16_9
     enabled: true              # optional, default true
@@ -38,7 +38,7 @@ steps:
     merge_strategy: COLLECT_ALL
     steps:
       - type: text_to_image
-        model: flux_schnell
+        model: gpt_image_2_gmi
 
 config:
   output_dir: ./output

--- a/qcut/.claude/skills/native-cli/references/reference-pipelines.md
+++ b/qcut/.claude/skills/native-cli/references/reference-pipelines.md
@@ -28,7 +28,7 @@ Run a multi-step YAML pipeline.
 name: my-pipeline
 steps:
   - type: text_to_image       # ModelCategory value
-    model: gpt_image_2_gmi     # model key
+    model: gpt_image_2_ima     # model key
     params:                    # model-specific params
       image_size: landscape_16_9
     enabled: true              # optional, default true
@@ -38,7 +38,7 @@ steps:
     merge_strategy: COLLECT_ALL
     steps:
       - type: text_to_image
-        model: gpt_image_2_gmi
+        model: gpt_image_2_ima
 
 config:
   output_dir: ./output

--- a/qcut/apps/web/src/lib/__tests__/credit-costs.test.ts
+++ b/qcut/apps/web/src/lib/__tests__/credit-costs.test.ts
@@ -106,7 +106,7 @@ describe("credit-costs — registry-driven pricing (1 credit ≈ $0.01)", () => 
 	it.each([
 		// modelKey, expectedCredits — costPerImage in cents rounds to credits.
 		["gpt-image-2-fal", 4], // costPerImage: 4.2 → 4
-		["gpt-image-2-gmi", 4], // costPerImage: 4.2 → 4
+		["gpt-image-2-ima", 4], // costPerImage: 4.2 → 4
 		["nano-banana", 4], // costPerImage: 3.9 → 4
 		["seeddream-v4", 5], // costPerImage: 5
 		["flux-pro-v11-ultra", 7], // costPerImage: 7

--- a/qcut/apps/web/src/lib/text2image-models/__tests__/text2image-models.test.ts
+++ b/qcut/apps/web/src/lib/text2image-models/__tests__/text2image-models.test.ts
@@ -64,12 +64,14 @@ describe("text2image-models registry", () => {
 		expect(TEXT2IMAGE_MODEL_ORDER).not.toContain("seeddream-v4-5-edit");
 	});
 
-	it("gpt-image-2-gmi is registered with OpenAI (via GMI) as the provider", () => {
-		const model = TEXT2IMAGE_MODELS["gpt-image-2-gmi"];
+	it("gpt-image-2-ima is registered with OpenAI via IMA Router as the provider", () => {
+		const model = TEXT2IMAGE_MODELS["gpt-image-2-ima"];
 		expect(model).toBeDefined();
-		expect(model?.provider).toBe("OpenAI (via GMI)");
+		expect(model?.provider).toBe("OpenAI (via IMA Router)");
 		expect(model?.name).toBe("GPT-Image-2");
-		expect(model?.endpoint).toContain("console.gmicloud.ai");
+		expect(model?.endpoint).toContain(
+			"api.imarouter.com/v1/images/generations"
+		);
 	});
 
 	it("gpt-image-2-fal is registered with OpenAI (via FAL) as the provider", () => {
@@ -80,12 +82,12 @@ describe("text2image-models registry", () => {
 		expect(model?.endpoint).toContain("fal.run/openai/gpt-image-2");
 	});
 
-	it("FAL variant takes top-of-order; GMI variant is kept out of the picker", () => {
+	it("FAL variant takes top-of-order; IMA Router variant is kept out of the picker", () => {
 		expect(TEXT2IMAGE_MODEL_ORDER[0]).toBe("gpt-image-2-fal");
-		// GMI variant is registered but excluded from the picker until a
-		// GMI-aware generation client exists (GUI flow routes through FAL).
+		// IMA Router variant is registered but excluded from the picker until an
+		// IMA Router image generation client exists (GUI flow routes through FAL).
 		expect(TEXT2IMAGE_MODEL_ORDER as readonly string[]).not.toContain(
-			"gpt-image-2-gmi"
+			"gpt-image-2-ima"
 		);
 	});
 
@@ -120,6 +122,14 @@ describe("getModelRoutingBadge", () => {
 		).toBe("GMI");
 	});
 
+	it("returns 'IMA Router' for imarouter endpoints", () => {
+		expect(
+			getModelRoutingBadge({
+				endpoint: "https://api.imarouter.com/v1/images/generations",
+			})
+		).toBe("IMA Router");
+	});
+
 	it("returns null for unknown/empty endpoints", () => {
 		expect(getModelRoutingBadge({ endpoint: "" })).toBeNull();
 		expect(
@@ -140,9 +150,9 @@ describe("getModelDisplayName", () => {
 		expect(getModelDisplayName(gpt)).toBe("GPT-Image-2 (FAL)");
 	});
 
-	it("appends (GMI) for the gmicloud-routed variant", () => {
-		const gpt = TEXT2IMAGE_MODELS["gpt-image-2-gmi"];
-		expect(getModelDisplayName(gpt)).toBe("GPT-Image-2 (GMI)");
+	it("appends (IMA Router) for the imarouter-routed variant", () => {
+		const gpt = TEXT2IMAGE_MODELS["gpt-image-2-ima"];
+		expect(getModelDisplayName(gpt)).toBe("GPT-Image-2 (IMA Router)");
 	});
 
 	it("every model in TEXT2IMAGE_MODEL_ORDER gets a recognised badge", () => {

--- a/qcut/apps/web/src/lib/text2image-models/index.ts
+++ b/qcut/apps/web/src/lib/text2image-models/index.ts
@@ -18,9 +18,9 @@ export const TEXT2IMAGE_MODELS: Record<string, Text2ImageModel> = {
 // ============================================
 // Shared priority order (cheapest ➜ premium)
 // ============================================
-// NOTE: `gpt-image-2-gmi` is intentionally absent from the picker order.
+// NOTE: `gpt-image-2-ima` is intentionally absent from the picker order.
 // The model is registered in TEXT2IMAGE_MODELS for CLI/programmatic use, but
-// GUI generation flows through FalAIClient and has no GMI-aware routing yet,
+// GUI generation flows through FalAIClient and has no IMA Router image routing yet,
 // so exposing it in the picker would produce confusing auth/URL failures.
 export const TEXT2IMAGE_MODEL_ORDER = [
 	"gpt-image-2-fal",
@@ -71,18 +71,19 @@ export function getModelRoutingBadge(
 	if (endpoint.includes("fal.run")) return "FAL";
 	if (endpoint.includes("gmicloud.ai") || endpoint.includes("gmi.cloud"))
 		return "GMI";
+	if (endpoint.includes("imarouter.com")) return "IMA Router";
 	return null;
 }
 
 /**
  * Returns the name a user should see in the picker / status labels with a
- * trailing `(FAL)` / `(GMI)` suffix derived from the endpoint. Any legacy
- * hard-coded `(FAL)` / `(GMI)` suffix already present in `model.name` is
- * stripped first so we don't end up with doubles like "X (FAL) (FAL)".
+ * trailing provider suffix derived from the endpoint. Any legacy hard-coded
+ * suffix already present in `model.name` is stripped first so we don't end up
+ * with doubles like "X (FAL) (FAL)".
  */
 export function getModelDisplayName(model: Text2ImageModel): string {
 	const badge = getModelRoutingBadge(model);
-	const base = model.name.replace(/\s*\((FAL|GMI)\)\s*$/i, "");
+	const base = model.name.replace(/\s*\((FAL|GMI|IMA Router)\)\s*$/i, "");
 	return badge ? `${base} (${badge})` : model.name;
 }
 

--- a/qcut/apps/web/src/lib/text2image-models/other-models.ts
+++ b/qcut/apps/web/src/lib/text2image-models/other-models.ts
@@ -73,31 +73,30 @@ export const OTHER_MODELS: Record<string, Text2ImageModel> = {
 			"Images containing readable text",
 			"Strong prompt adherence across complex scenes",
 			"Image editing with mask-based inpainting",
-			"Working fallback while GMI's gpt-image-2 relay is degraded",
+			"Fallback route when the IMA Router GPT Image path is unavailable",
 		],
 
 		strengths: [
-			"Independent of GMI's OpenAI relay outage",
-			"Webp output support (GMI variant does not expose webp)",
+			"Independent FAL routing",
+			"Webp output support",
 			"FAL preset sizes are simpler for UI users than pixel strings",
 			"Native inpainting via image_urls + mask_url",
 		],
 
 		limitations: [
-			"No 'auto' quality tier (GMI variant has it)",
+			"No 'auto' quality tier",
 			"Preset image sizes only — no arbitrary pixel dimensions via QCut UI",
-			"Pricing tier table not published by FAL; flat $0.042 is a GMI-derived estimate",
+			"Pricing tier table not published by FAL; flat $0.042 is an estimate",
 		],
 	},
 
-	"gpt-image-2-gmi": {
-		id: "gpt-image-2-gmi",
+	"gpt-image-2-ima": {
+		id: "gpt-image-2-ima",
 		name: "GPT-Image-2",
 		description:
-			"OpenAI GPT-Image-2 via GMI Cloud — photorealistic generation with accurate in-image text and strong prompt adherence",
-		provider: "OpenAI (via GMI)",
-		endpoint:
-			"https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey/requests",
+			"OpenAI GPT-Image-2 via IMA Router — photorealistic generation with accurate in-image text and strong prompt adherence",
+		provider: "OpenAI (via IMA Router)",
+		endpoint: "https://api.imarouter.com/v1/images/generations",
 
 		qualityRating: 5,
 		speedRating: 4,

--- a/qcut/docs/task/daytona-supabase-agent/implementation/18-gmi-default-image-smoke.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/18-gmi-default-image-smoke.md
@@ -1,0 +1,80 @@
+# GMI Default Image Generation Smoke Test
+
+Date: 2026-05-18 local / 2026-05-19 UTC
+Branch: `Qcut-sandbox-v6`
+Commit under test: `479550e51`
+
+## Goal
+
+Verify that `qcut generate-image` works without passing `--model`, and that the new default image model is GMI GPT Image 2.
+
+## Command
+
+```bash
+bun run pipeline generate-image \
+  --prompts "a small red enamel rocket pin on white background" \
+  --prompts "a tiny blue ceramic robot figurine on white background" \
+  --prompts "a green glass cactus sculpture on white background" \
+  --prompts "a yellow toy submarine product photo on white background" \
+  --prompts "a silver origami bird charm on white background" \
+  --aspect-ratio 1:1 \
+  --output-dir output/gmi-five-image-smoke \
+  --json
+```
+
+No `-m` / `--model` flag was passed.
+
+## Result
+
+Status: pass
+
+The CLI returned `status: "ok"` with 5 image outputs.
+
+```json
+{
+  "command": "generate-image",
+  "cost": 0.21000000000000002,
+  "duration": 192.857
+}
+```
+
+Two transient GMI/proxy `504` retries were observed during the run. The built-in retry path recovered and the batch completed successfully.
+
+## Output Files
+
+| Prompt | Model | Endpoint | Output |
+| --- | --- | --- | --- |
+| a small red enamel rocket pin on white background | `gpt_image_2_gmi` | `gpt-image-2-generate` | `output/gmi-five-image-smoke/gpt_image_2_gmi_a-small-red-enamel-rocket-pin-on-white-background_1779155258113_0.png` |
+| a tiny blue ceramic robot figurine on white background | `gpt_image_2_gmi` | `gpt-image-2-generate` | `output/gmi-five-image-smoke/gpt_image_2_gmi_a-tiny-blue-ceramic-robot-figurine-on-white-background_1779155298905_1.png` |
+| a green glass cactus sculpture on white background | `gpt_image_2_gmi` | `gpt-image-2-generate` | `output/gmi-five-image-smoke/gpt_image_2_gmi_a-green-glass-cactus-sculpture-on-white-background_1779155383443_2.png` |
+| a yellow toy submarine product photo on white background | `gpt_image_2_gmi` | `gpt-image-2-generate` | `output/gmi-five-image-smoke/gpt_image_2_gmi_a-yellow-toy-submarine-product-photo-on-white-background_1779155348312_3.png` |
+| a silver origami bird charm on white background | `gpt_image_2_gmi` | `gpt-image-2-generate` | `output/gmi-five-image-smoke/gpt_image_2_gmi_a-silver-origami-bird-charm-on-white-background_1779155252980_4.png` |
+
+## File Check
+
+All 5 PNG files exist and are readable image files:
+
+```text
+gpt_image_2_gmi_a-green-glass-cactus-sculpture-on-white-background_1779155383443_2.png: 1024 x 1024 PNG
+gpt_image_2_gmi_a-silver-origami-bird-charm-on-white-background_1779155252980_4.png: 1024 x 1024 PNG
+gpt_image_2_gmi_a-small-red-enamel-rocket-pin-on-white-background_1779155258113_0.png: 1254 x 1254 PNG
+gpt_image_2_gmi_a-tiny-blue-ceramic-robot-figurine-on-white-background_1779155298905_1.png: 1024 x 1024 PNG
+gpt_image_2_gmi_a-yellow-toy-submarine-product-photo-on-white-background_1779155348312_3.png: 1024 x 1024 PNG
+```
+
+Each generated image has a sidecar JSON file next to it. The sidecars confirm:
+
+- `model`: `gpt_image_2_gmi`
+- `endpoint`: `gpt-image-2-generate`
+- `cost`: `0.042` per image
+
+## Visual Spot Check
+
+Two outputs were opened and inspected:
+
+- Red enamel rocket pin: non-empty, centered product-style image on white background, matches prompt.
+- Blue ceramic robot figurine: non-empty, centered product-style image on white background, matches prompt.
+
+## Conclusion
+
+The default `generate-image` path is working with GMI. A no-model five-image batch correctly used `gpt_image_2_gmi`, generated real PNG outputs, wrote reproducible sidecar metadata, and recovered from transient GMI/proxy `504` retries.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/19-imarouter-gpt-image-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/19-imarouter-gpt-image-plan.md
@@ -1,0 +1,376 @@
+# IMA Router GPT Image 2 Daytona Plan
+
+Date: 2026-05-19
+Branch: `Qcut-sandbox-v6`
+
+## Goal
+
+Move the Daytona sandbox image path for QCut's GPT Image 2 model from the legacy GMI queue slug to IMA Router's current OpenAI-compatible image task API, then verify it with a small sandbox E2E run and downloadable evidence.
+
+Target user-facing behavior:
+
+- `qcut generate-image` without `--model` still defaults to `gpt_image_2_ima`.
+- `qcut flow portraits --image-model gpt_image_2_ima` uses the same working GPT Image 2 route.
+- `qcut flow storyboard --image-model gpt_image_2_ima` uses the same working GPT Image 2 route.
+- Generated image result URLs are downloaded immediately into `/tmp/qcut-output` or the selected output directory.
+
+## Source Docs Read
+
+- Human docs URL: <https://doc.imarouter.com/#en/tag/gpt-image/POST/v1/images/generations#gpt-image>
+- AI integration entrypoint: <https://doc.imarouter.com/llms.txt>
+- OpenAPI source: <https://doc.imarouter.com/openapi/en.yaml>
+- Model index: <https://doc.imarouter.com/model-index.json>
+- Smoke payloads: <https://doc.imarouter.com/test-cases.json>
+
+Important doc findings:
+
+- Base URL is `https://api.imarouter.com`.
+- Auth is `Authorization: Bearer YOUR_SECRET_TOKEN`; never put the token in a query string.
+- The `#gpt-image` fragment is documentation grouping only. The actual create path is `POST /v1/images/generations`.
+- `gpt-image-2` is async. Submit returns `id` or `task_id`; poll `GET /v1/images/generations/{task_id}`.
+- Terminal success statuses include `succeeded` and `completed`; terminal failure statuses include `failed` and `error`.
+- Result URLs are short-lived, around 30 days, so QCut should download and persist them immediately.
+
+## Pre-Implementation QCut State
+
+Before this patch, the native flow treated the GPT Image 2 default route as a GMI Cloud queue model:
+
+| Area | Current value |
+| --- | --- |
+| Registry key | `gpt_image_2_gmi` |
+| Provider backend | `gmi` |
+| Text endpoint | `gpt-image-2-generate` |
+| Reference endpoint | `gpt-image-2-edit` |
+| Submit shape | `{ model: endpoint, payload }` through GMI queue |
+
+Relevant files:
+
+- `electron/native-pipeline/registry-data/text-to-image.ts`
+- `electron/native-pipeline/vimax/adapters/image-adapter.ts`
+- `electron/native-pipeline/execution/step-executors.ts`
+- `electron/native-pipeline/infra/api-caller.ts`
+- `electron/native-pipeline/infra/api-provider-urls.ts`
+- `packages/license-server/src/routes/ai-proxy.ts`
+- `packages/qcut-relay/src/pty-session.ts`
+
+This explains the recent long latency and `504` retries: the tested path is working through the old GMI queue/proxy route, but it is not yet the documented IMA Router `gpt-image` route.
+
+## Target API Contract
+
+Text-to-image create request:
+
+```json
+{
+  "model": "gpt-image-2",
+  "prompt": "generate a glossy product hero image for a smartwatch",
+  "size": "1024x1024",
+  "quality": "high",
+  "background": "transparent",
+  "output_format": "png"
+}
+```
+
+Image reference / edit request:
+
+```json
+{
+  "model": "gpt-image-2",
+  "prompt": "replace the background with a clean studio backdrop",
+  "images": ["https://example.com/input.png"],
+  "mask": "https://example.com/mask.png",
+  "size": "1536x1024",
+  "quality": "high",
+  "input_fidelity": "high",
+  "moderation": "low",
+  "output_compression": 0,
+  "output_format": "png"
+}
+```
+
+Supported passthrough fields from the OpenAPI doc:
+
+- `size`
+- `quality`
+- `image` / `images`
+- `mask`
+- `background`
+- `input_fidelity`
+- `moderation`
+- `n`
+- `output_compression`
+- `output_format`
+
+## Implementation Plan
+
+### 1. Add an IMA Router image task poller
+
+File: `electron/native-pipeline/infra/api-caller.ts`
+
+Current `pollImaRouterTask()` is video-specific and polls `v1/videos/{task_id}`. Add a focused image poller:
+
+```ts
+pollImaRouterImageTask({ taskId, onProgress, signal })
+```
+
+It should:
+
+- call `GET /v1/images/generations/{task_id}`
+- accept `succeeded` and `completed` as success
+- accept `failed` and `error` as failure
+- read output URL from `data.url`, `url`, or existing `extractOutputUrl()` fallback
+- surface `amount_usd`, `usage`, and raw response under `data`
+- keep the same 30 minute ceiling unless a shorter image-specific timeout is chosen after live testing
+
+### 2. Teach `callModelApi()` how to submit IMA Router image tasks
+
+File: `electron/native-pipeline/infra/api-caller.ts`
+
+Today `provider === "imarouter"` assumes videos and always polls `v1/videos/{task_id}`. Add a small route decision based on endpoint:
+
+- if endpoint is `v1/images/generations`, poll with the new image poller
+- if endpoint is `v1/videos`, keep the existing video poller
+- preserve proxy-first behavior and local-key fallback
+
+Avoid endpoint-name string spread across the codebase by extracting constants:
+
+```ts
+const IMAROUTER_IMAGE_GENERATIONS_PATH = "v1/images/generations";
+const IMAROUTER_VIDEO_GENERATIONS_PATH = "v1/videos";
+```
+
+### 3. Register GPT Image 2 as IMA Router-backed while preserving the public key
+
+File: `electron/native-pipeline/registry-data/text-to-image.ts`
+
+Keep the user-facing QCut key stable:
+
+```ts
+key: "gpt_image_2_ima"
+```
+
+Change the transport fields:
+
+```ts
+provider: "OpenAI (via IMA Router)"
+endpoint: "v1/images/generations"
+providerBackend: "imarouter"
+defaults: {
+  model: "gpt-image-2",
+  size: "1024x1024",
+  quality: "medium",
+  output_format: "png",
+  n: 1
+}
+```
+
+Update after implementation: the primary key was renamed to `gpt_image_2_ima`, and `gpt_image_2_gmi` remains available as a legacy alias so older commands still work.
+
+### 4. Update flow image adapter routing
+
+File: `electron/native-pipeline/vimax/adapters/image-adapter.ts`
+
+Pre-implementation maps:
+
+- `gpt_image_2_gmi` -> `gpt-image-2-generate`
+- reference `gpt_image_2_gmi` -> `gpt-image-2-edit`
+
+Target maps:
+
+- `gpt_image_2_ima` -> `v1/images/generations`
+- reference `gpt_image_2_ima` -> `v1/images/generations`
+- provider should become `imarouter`
+- payload should include `model: "gpt-image-2"` at the top level
+- reference generation should use `images: [url]`, not `image: [url]`
+- mask support should pass `mask` when supplied by future callers
+
+The adapter already uploads local references before edit calls. Keep that behavior, because IMA Router needs public URLs for `image` / `images`.
+
+### 5. Update step executor reference handling
+
+File: `electron/native-pipeline/execution/step-executors.ts`
+
+For `gpt_image_2_ima` with reference images:
+
+- do not switch to a synthetic `gpt-image-2-edit` endpoint
+- keep endpoint `v1/images/generations`
+- set `payload.images = refs.urls`
+- remove legacy `payload.image_urls` and `payload.reference_images`
+- set `payload.model = "gpt-image-2"`
+
+For text-only:
+
+- set `payload.model = "gpt-image-2"`
+- map aspect ratio to `size` as already done for GMI GPT Image 2
+
+### 6. License-server proxy support
+
+Files:
+
+- `packages/license-server/src/routes/ai-proxy.ts`
+- existing proxy tests near GMI / IMA Router coverage
+
+Verify that the proxy accepts:
+
+```json
+{
+  "provider": "imarouter",
+  "endpoint": "https://api.imarouter.com/v1/images/generations",
+  "method": "POST",
+  "body": {
+    "model": "gpt-image-2",
+    "prompt": "..."
+  }
+}
+```
+
+If the proxy currently special-cases IMA Router video polling only, add image create/status handling there too. Keep credit estimates keyed by QCut model key (`gpt_image_2_ima`) so billing remains stable.
+
+### 7. Update docs and skills
+
+Files to check after implementation:
+
+- `.claude/skills/native-cli/SKILL.md`
+- `resources/default-skills/native-cli/SKILL.md`
+- `packages/nexusai-website/js/agent-chat.js`
+- `packages/nexusai-website/cli/partials/gen.html`
+- `packages/nexusai-website/cli/partials/flow.html`
+
+Do not change the public default command guidance unless the QCut key is renamed. The important wording is still:
+
+```text
+Default image model: gpt_image_2_ima
+Do not pass --model/-m unless the user explicitly asks for a specific image model.
+```
+
+## Tests
+
+Unit tests to add or update:
+
+- `electron/native-pipeline/infra/__tests__/api-caller-imarouter.test.ts`
+  - submits image task to `/v1/images/generations`
+  - polls `/v1/images/generations/{task_id}`
+  - extracts `data.url`
+  - handles `succeeded`, `completed`, `failed`, and `error`
+- `electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts`
+  - `gpt_image_2_ima` has `providerBackend: "imarouter"`
+  - endpoint is `v1/images/generations`
+  - defaults include `model: "gpt-image-2"`
+- `electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts`
+  - text generation calls provider `imarouter`
+  - endpoint is `v1/images/generations`
+  - payload uses `model: "gpt-image-2"`
+  - reference generation uses `images: [...]`
+- `electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts`
+  - reference images stay on `/v1/images/generations`
+  - no `gpt-image-2-edit` endpoint remains for IMA Router
+
+Suggested commands:
+
+```bash
+bun test \
+  electron/native-pipeline/infra/__tests__/api-caller-imarouter.test.ts \
+  electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts \
+  electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts \
+  electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+
+cd electron && bun x tsc --noEmit
+```
+
+## Daytona E2E Verification
+
+Use no more than 5 to 6 images.
+
+### A. Single default image smoke
+
+```bash
+qcut generate-image \
+  --prompt "a matte black cube on a clean white background" \
+  -o /tmp/qcut-output/imarouter-gpt-image-smoke \
+  --json
+```
+
+Expected:
+
+- no `--model` passed
+- output sidecar says `model: gpt_image_2_ima`
+- transport evidence says provider `imarouter`
+- generated file is a valid PNG or JPEG
+
+### B. Flow portraits smoke
+
+```bash
+qcut flow characters \
+  --novel /tmp/qcut-input/novel.txt \
+  --llm-model gemini-3.1-flash-lite \
+  -o /tmp/qcut-output/imarouter-flow \
+  --json
+
+qcut flow portraits \
+  --input /tmp/qcut-output/imarouter-flow/characters.json \
+  --max-characters 3 \
+  --views front \
+  --image-model gpt_image_2_ima \
+  -o /tmp/qcut-output/imarouter-flow/portraits \
+  --json
+```
+
+Expected:
+
+- 3 portrait images max
+- `registry.json` lists all portrait paths
+- all images are valid files
+- generated artifacts are visible and downloadable from the sandbox file browser
+
+### C. Flow storyboard smoke
+
+```bash
+qcut flow storyboard \
+  --script /tmp/qcut-input/script.json \
+  --portraits /tmp/qcut-output/imarouter-flow/portraits/portraits/registry.json \
+  --style "cinematic editorial storyboard, consistent characters" \
+  --image-model gpt_image_2_ima \
+  -o /tmp/qcut-output/imarouter-flow/storyboard \
+  --json
+```
+
+Expected:
+
+- cap the script at 2 to 3 scenes for this smoke
+- generated total image count stays under 6
+- storyboard images are valid files
+- downloaded evidence includes command logs, result JSON, registry JSON, and files
+
+## Evidence To Record
+
+After the Daytona run, add a result doc next to this plan:
+
+```text
+docs/task/daytona-supabase-agent/implementation/20-imarouter-gpt-image-e2e.md
+```
+
+Include:
+
+- production or local build identifier
+- exact command input
+- generated output directory
+- task IDs returned by IMA Router, with secrets redacted
+- downloaded file list
+- `file` output proving PNG/JPEG validity
+- screenshot of the sandbox file browser showing the output folder
+- failures and retries, especially `429`, `5xx`, or task status `failed`
+
+## Risks
+
+- Older scripts may still use `gpt_image_2_gmi`; keep that key as a legacy alias until users have moved to `gpt_image_2_ima`.
+- IMA Router result URLs expire. Any code path that only stores remote URLs without downloading will become flaky later.
+- Image reference inputs must be public URLs or uploaded first. Local files need the existing upload step.
+- Proxy support may be video-biased today. The native local path and license-server proxy path both need tests so Daytona behaves like production.
+
+## Done Criteria
+
+- Unit tests cover image submit, poll, success, failure, and reference-image payload shape.
+- `qcut generate-image` default path produces a real image through IMA Router.
+- `qcut flow portraits --image-model gpt_image_2_ima` produces 3 or fewer portrait images through IMA Router.
+- `qcut flow storyboard --image-model gpt_image_2_ima` produces a small storyboard through IMA Router.
+- Daytona file browser can download individual images and the containing folder.
+- A follow-up E2E result md records success/failure evidence.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/20-imarouter-gpt-image-e2e.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/20-imarouter-gpt-image-e2e.md
@@ -5,7 +5,7 @@ Branch: `Qcut-sandbox-v6`
 
 ## Summary
 
-Status: local live verification passed; Codex-in-Daytona preflight failed on the deployed production image because the sandbox image has not picked up this branch yet.
+Status: local live verification passed; real Codex-in-Daytona E2E passed after publishing and pinning a rebuilt CLI image.
 
 The implementation now uses `gpt_image_2_ima` as QCut's public default image key and keeps `gpt_image_2_gmi` as a legacy alias. Both keys route through IMA Router's documented GPT Image API:
 
@@ -17,6 +17,85 @@ The implementation now uses `gpt_image_2_ima` as QCut's public default image key
 Note: the live evidence below was generated immediately before the key rename, so the copied sidecar JSON and filenames still show the legacy alias `gpt_image_2_gmi`. The endpoint evidence is unchanged.
 
 ## Real Codex-In-Daytona Test
+
+Final successful run:
+
+- license-server agent session: `0b236251-2e6c-4244-81d7-8d4e3de7fe21`
+- Daytona sandbox id: `f8bf9ba1-424b-4011-9a69-90f3db151271`
+- deployed image tag: `ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748`
+- license-server deploy version: `1fdd2cfb-3da7-41de-924a-026eec735b4c`
+- result: `SUCCESS`
+- elapsed: `242s`
+- output count: 6 PNG portraits
+- output dimensions: every PNG validated as `1024x1536`
+
+Successful command executed by Codex inside the Daytona sandbox:
+
+```bash
+qcut flow portraits \
+  --input /tmp/qcut-input/characters-six-ima-codex.json \
+  --max-characters 6 \
+  --views front \
+  --image-model gpt_image_2_ima \
+  --concurrency 6 \
+  -o /tmp/qcut-output/portraits-ima-codex-concurrency-6 \
+  --json 2>&1 | tee /tmp/qcut-output/portraits-ima-codex-concurrency-6/live.log
+```
+
+Sandbox evidence files:
+
+```text
+/tmp/qcut-output/codex-real-e2e-done.txt
+/tmp/qcut-output/codex-real-e2e-portraits-ima-concurrency-6.md
+/tmp/qcut-output/portraits-ima-codex-concurrency-6/png-validation.json
+/tmp/qcut-output/portraits-ima-codex-concurrency-6/live.log
+```
+
+Preflight result:
+
+- `qcut --version`: `1.0.0`
+- `qcut system models --json` contains `gpt_image_2_ima`: yes
+- `qcut flow portraits --help --json` contains `--concurrency`: yes
+
+Concurrency evidence from `live.log`: all six `Generating portraits for` lines appeared before any `Generated portraits for` line:
+
+```text
+[portraits] Generating portraits for: Mara Venn
+[portraits] Generating portraits for: Jalen Orr
+[portraits] Generating portraits for: Sera Quill
+[portraits] Generating portraits for: Niko Stray
+[portraits] Generating portraits for: Dr. Ilya Morrow
+[portraits] Generating portraits for: Tala Reeve
+[portraits] Generated portraits for Niko Stray
+[portraits] Generated portraits for Jalen Orr
+[portraits] Generated portraits for Tala Reeve
+[portraits] Generated portraits for Mara Venn
+[portraits] Generated portraits for Dr. Ilya Morrow
+[portraits] Generated portraits for Sera Quill
+```
+
+PNG validation:
+
+```json
+{
+  "status": "SUCCESS",
+  "expected_png_count": 6,
+  "actual_png_count": 6,
+  "valid_png_count": 6,
+  "errors": []
+}
+```
+
+Outputs:
+
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Dr._Ilya_Morrow/front.png` — 1024x1536
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Jalen_Orr/front.png` — 1024x1536
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Mara_Venn/front.png` — 1024x1536
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Niko_Stray/front.png` — 1024x1536
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Sera_Quill/front.png` — 1024x1536
+- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/portraits/Tala_Reeve/front.png` — 1024x1536
+
+Earlier failed production-image preflight:
 
 Session:
 
@@ -56,7 +135,7 @@ Evidence conclusion:
 - 6-image generation: not executed, by design, because the preflight failed
 - PNG outputs: `0`
 
-Conclusion: the deployed Daytona image is older than this branch. The branch changes need to be committed, pushed, and published into `ghcr.io/quriosity-agent/qcut-cli:latest`, then the same Codex-in-Daytona prompt should be rerun.
+Conclusion from the failed run: the deployed Daytona image was older than this branch. Publishing `ghcr.io/quriosity-agent/qcut-cli:latest` was not enough because Daytona still resolved the old cached tag; pinning `QCUT_IMAGE_TAG` to the immutable `imarouter-gpt-image-20260519061748` image tag fixed the real Codex-in-Daytona path.
 
 ## Unit And Type Checks
 

--- a/qcut/docs/task/daytona-supabase-agent/implementation/20-imarouter-gpt-image-e2e.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/20-imarouter-gpt-image-e2e.md
@@ -1,0 +1,418 @@
+# IMA Router GPT Image 2 Verification
+
+Date: 2026-05-19
+Branch: `Qcut-sandbox-v6`
+
+## Summary
+
+Status: local live verification passed; Codex-in-Daytona preflight failed on the deployed production image because the sandbox image has not picked up this branch yet.
+
+The implementation now uses `gpt_image_2_ima` as QCut's public default image key and keeps `gpt_image_2_gmi` as a legacy alias. Both keys route through IMA Router's documented GPT Image API:
+
+- provider: `imarouter`
+- endpoint: `v1/images/generations`
+- API model field: `gpt-image-2`
+- poll endpoint: `GET /v1/images/generations/{task_id}`
+
+Note: the live evidence below was generated immediately before the key rename, so the copied sidecar JSON and filenames still show the legacy alias `gpt_image_2_gmi`. The endpoint evidence is unchanged.
+
+## Real Codex-In-Daytona Test
+
+Session:
+
+- license-server agent session: `7366021f-d7d6-49b5-b7b0-d820e2ae37f5`
+- Daytona sandbox id: `7aec6269-5f86-4e89-9537-142e06e785d4`
+- deployed image observed by session: `ghcr.io/quriosity-agent/qcut-cli:latest`
+
+Method:
+
+- Sent the E2E prompt into the persistent Codex PTY session, matching the production chat-agent path.
+- The prompt required Codex inside the sandbox to run preflight checks first.
+- The prompt explicitly told Codex not to fallback to another model if `gpt_image_2_ima` or `--concurrency` was missing.
+
+Sandbox-written status file:
+
+```text
+/tmp/qcut-output/codex-real-e2e-done.txt
+```
+
+Status file contents:
+
+```text
+FAILED: preflight failed because qcut system models --json does not list gpt_image_2_ima and qcut flow portraits --help --json does not list --concurrency.
+```
+
+Sandbox-written evidence file:
+
+```text
+/tmp/qcut-output/codex-real-e2e-portraits-ima-concurrency-6.md
+```
+
+Evidence conclusion:
+
+- `qcut --version`: `1.0.0`
+- `gpt_image_2_ima`: not listed in `qcut system models --json`
+- `--concurrency`: not listed in `qcut flow portraits --help --json`
+- 6-image generation: not executed, by design, because the preflight failed
+- PNG outputs: `0`
+
+Conclusion: the deployed Daytona image is older than this branch. The branch changes need to be committed, pushed, and published into `ghcr.io/quriosity-agent/qcut-cli:latest`, then the same Codex-in-Daytona prompt should be rerun.
+
+## Unit And Type Checks
+
+Passed:
+
+```bash
+bun test \
+  electron/native-pipeline/infra/__tests__/api-caller-imarouter.test.ts \
+  electron/native-pipeline/infra/__tests__/api-provider-urls.test.ts \
+  electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts \
+  electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts \
+  electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+```
+
+Result: 43 pass.
+
+```bash
+cd packages/license-server && bun run test -- src/routes/ai-proxy.test.ts
+```
+
+Result: 28 pass.
+
+```bash
+bun test \
+  apps/web/src/lib/text2image-models/__tests__/text2image-models.test.ts \
+  apps/web/src/lib/__tests__/credit-costs.test.ts
+```
+
+Result: 55 pass.
+
+```bash
+cd electron && bun x tsc --noEmit
+```
+
+Result: pass.
+
+```bash
+bunx biome check --write \
+  electron/native-pipeline/infra/api-caller.ts \
+  electron/native-pipeline/infra/api-provider-urls.ts \
+  electron/native-pipeline/registry-data/text-to-image.ts \
+  electron/native-pipeline/vimax/adapters/image-adapter.ts \
+  electron/native-pipeline/execution/step-executors.ts \
+  electron/native-pipeline/infra/proxy-client.ts \
+  packages/license-server/src/routes/ai-proxy.ts
+```
+
+Result: pass after formatting 3 files.
+
+```bash
+bunx biome check \
+  apps/web/src/lib/text2image-models/other-models.ts \
+  apps/web/src/lib/text2image-models/index.ts \
+  apps/web/src/lib/text2image-models/__tests__/text2image-models.test.ts
+```
+
+Result: pass.
+
+## Model Catalog Check
+
+The native CLI/flow route is the runtime path under test, but the web text-to-image catalog was also updated so model metadata does not continue to describe the default GPT Image 2 route as GMI:
+
+- `apps/web/src/lib/text2image-models/other-models.ts`
+  - `gpt-image-2-ima` provider is now `OpenAI (via IMA Router)`.
+  - endpoint is now `https://api.imarouter.com/v1/images/generations`.
+- `apps/web/src/lib/text2image-models/index.ts`
+  - routing badge recognizes `imarouter.com` as `IMA Router`.
+  - `gpt-image-2-ima` remains out of the GUI picker until a GUI IMA Router image client exists.
+
+## Local Live Generate-Image
+
+Command:
+
+```bash
+bun run pipeline generate-image \
+  --text "a matte black cube on a clean white background" \
+  --aspect-ratio 1:1 \
+  --output-dir /tmp/qcut-output/imarouter-local-smoke \
+  --json
+```
+
+Result: pass.
+
+CLI result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "command": "generate-image",
+    "endpoint": "v1/images/generations",
+    "outputPath": "/tmp/qcut-output/imarouter-local-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779166807507.png",
+    "cost": 0.042,
+    "duration": 231.357
+  }
+}
+```
+
+Sidecar evidence:
+
+```json
+{
+  "model": "gpt_image_2_gmi",
+  "endpoint": "v1/images/generations",
+  "output": {
+    "path": "/tmp/qcut-output/imarouter-local-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779166807507.png",
+    "video_url": "https://zhubite-imagent-bot.oss-us-east-1.aliyuncs.com/aiagent/aigc_temp/20260519/1efb7b6a47704b3ec7fa0283124eed60_1779166803081071626_1779166803080804388_0.png"
+  }
+}
+```
+
+File check:
+
+```text
+/tmp/qcut-output/imarouter-local-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779166807507.png: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
+```
+
+## Local Live Flow Portraits
+
+Command:
+
+```bash
+bun run pipeline flow portraits \
+  --input /tmp/qcut-input/imarouter-characters.json \
+  --max-characters 2 \
+  --views front \
+  --image-model gpt_image_2_gmi \
+  -o /tmp/qcut-output/imarouter-flow-smoke/portraits \
+  --json
+```
+
+Result: pass.
+
+CLI result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "command": "vimax:generate-portraits",
+    "cost": 0.084,
+    "duration": 217.99,
+    "data": {
+      "characters": 2,
+      "portraits_generated": 2,
+      "registry_path": "/tmp/qcut-output/imarouter-flow-smoke/portraits/portraits/registry.json"
+    }
+  }
+}
+```
+
+File check:
+
+```text
+/tmp/qcut-output/imarouter-flow-smoke/portraits/portraits/Mira_Chen/front.png: PNG image data, 1024 x 1536, 8-bit/color RGB, non-interlaced
+/tmp/qcut-output/imarouter-flow-smoke/portraits/portraits/Jon_Vale/front.png:  PNG image data, 1024 x 1536, 8-bit/color RGB, non-interlaced
+```
+
+Registry:
+
+```json
+{
+  "project_id": "cli-project",
+  "portraits": {
+    "Mira Chen": {
+      "character_name": "Mira Chen",
+      "description": "",
+      "front_view": "/tmp/qcut-output/imarouter-flow-smoke/portraits/portraits/Mira_Chen/front.png"
+    },
+    "Jon Vale": {
+      "character_name": "Jon Vale",
+      "description": "",
+      "front_view": "/tmp/qcut-output/imarouter-flow-smoke/portraits/portraits/Jon_Vale/front.png"
+    }
+  }
+}
+```
+
+## Local Live Flow Storyboard
+
+Command:
+
+```bash
+bun run pipeline flow storyboard \
+  --script /tmp/qcut-input/imarouter-script.json \
+  --style "clean cinematic storyboard frame, consistent character design" \
+  --image-model gpt_image_2_gmi \
+  -o /tmp/qcut-output/imarouter-storyboard-smoke/storyboard \
+  --json
+```
+
+Result: pass.
+
+CLI result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "command": "vimax:generate-storyboard",
+    "outputPath": "/tmp/qcut-output/imarouter-storyboard-smoke/storyboard",
+    "cost": 0.042,
+    "duration": 125.101,
+    "data": {
+      "title": "Neon Repair",
+      "images": 1,
+      "total_cost": 0.042
+    }
+  }
+}
+```
+
+File check:
+
+```text
+/tmp/qcut-output/imarouter-storyboard-smoke/storyboard/Neon_Repair/scene_001_medium_Workshop_Light.png: PNG image data, 1536 x 1024, 8-bit/color RGB, non-interlaced
+```
+
+## E2E Evidence Bundle
+
+Verifier output directory:
+
+```text
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z
+```
+
+The bundle copies the generated image, two portraits, one storyboard image, sidecar JSON, portrait registry, file checks, and a machine-readable verification summary.
+
+Verification summary:
+
+```json
+{
+  "status": "passed",
+  "evidenceDir": "output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z",
+  "checks": {
+    "defaultModel": true,
+    "endpoint": true,
+    "generatedPath": "/tmp/qcut-output/imarouter-local-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779166807507.png",
+    "portraitCount": 2,
+    "storyboardCopied": true
+  }
+}
+```
+
+File check:
+
+```text
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z/generate-image.png: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z/portrait-jon.png:   PNG image data, 1024 x 1536, 8-bit/color RGB, non-interlaced
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z/portrait-mira.png:  PNG image data, 1024 x 1536, 8-bit/color RGB, non-interlaced
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z/storyboard.png:     PNG image data, 1536 x 1024, 8-bit/color RGB, non-interlaced
+```
+
+## Container E2E
+
+This pass also built the CLI container image from the current branch and ran a clean-container smoke test using the same mounted output-folder behavior expected in the sandbox.
+
+Build command:
+
+```bash
+docker buildx build \
+  --file Dockerfile.cli \
+  --platform linux/amd64 \
+  --tag qcut-cli:imarouter-e2e \
+  --build-arg QCUT_VERSION=imarouter-e2e \
+  --load .
+```
+
+Result: pass.
+
+Run command:
+
+```bash
+docker run --rm \
+  --env-file ~/.qcut/.env \
+  -v /tmp/qcut-docker-e2e:/tmp/qcut-output \
+  qcut-cli:imarouter-e2e \
+  bash -lc 'qcut generate-image --text "a matte black cube on a clean white background" --aspect-ratio 1:1 --output-dir /tmp/qcut-output/imarouter-docker-smoke --json'
+```
+
+Result: generation passed. The container image does not include the `file` utility, so the image-type check was run from the host against the mounted output folder.
+
+CLI result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "command": "generate-image",
+    "endpoint": "v1/images/generations",
+    "outputPath": "/tmp/qcut-output/imarouter-docker-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779168151741.png",
+    "cost": 0.042,
+    "duration": 101.83
+  }
+}
+```
+
+Sidecar evidence:
+
+```json
+{
+  "model": "gpt_image_2_gmi",
+  "endpoint": "v1/images/generations",
+  "output": {
+    "path": "/tmp/qcut-output/imarouter-docker-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779168151741.png",
+    "video_url": "https://zhubite-imagent-bot.oss-us-east-1.aliyuncs.com/aiagent/aigc_temp/20260519/3ac2d1114a4982e614e6a73c1a4e9e8b_1779168147657614614_1779168147657367351_0.png"
+  }
+}
+```
+
+File check:
+
+```text
+/tmp/qcut-docker-e2e/imarouter-docker-smoke/gpt_image_2_gmi_a-matte-black-cube-on-a-clean-white-background_1779168151741.png: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
+```
+
+Downloadable evidence was copied into:
+
+```text
+output/imarouter-gpt-image-e2e-2026-05-19T05-13-44Z/docker-smoke
+```
+
+## Daytona Status
+
+Real Daytona cloud was not run from this machine in this pass.
+
+Observed blockers and constraints:
+
+```text
+daytona CLI: missing from PATH
+~/.qcut/.env: available for local/container runs
+branch-built cloud image: not deployed from this pass
+```
+
+Also, a meaningful Daytona verification needs a CLI image built from this branch. Testing the current production sandbox image before build/push/deploy would only verify the old image, not this implementation.
+
+## Follow-Up Daytona Command
+
+After building and deploying a CLI image from this branch, run this inside the sandbox:
+
+```bash
+set -eu
+rm -rf /tmp/qcut-output/imarouter-e2e
+mkdir -p /tmp/qcut-output/imarouter-e2e
+qcut generate-image \
+  --text "a matte black cube on a clean white background" \
+  --aspect-ratio 1:1 \
+  --output-dir /tmp/qcut-output/imarouter-e2e \
+  --json | tee /tmp/qcut-output/imarouter-e2e/result.json
+find /tmp/qcut-output/imarouter-e2e -maxdepth 1 -type f -print | sort > /tmp/qcut-output/imarouter-e2e/files.txt
+file /tmp/qcut-output/imarouter-e2e/* > /tmp/qcut-output/imarouter-e2e/file-check.txt
+```
+
+Expected:
+
+- sidecar JSON includes `"model": "gpt_image_2_ima"` for new default runs, or `"model": "gpt_image_2_gmi"` for legacy alias runs.
+- sidecar JSON includes `"endpoint": "v1/images/generations"`
+- generated image is a valid PNG or JPEG
+- folder download includes result JSON, sidecar JSON, file check, and generated image

--- a/qcut/electron/__tests__/cli-pipeline.test.ts
+++ b/qcut/electron/__tests__/cli-pipeline.test.ts
@@ -296,7 +296,7 @@ describe("CLI pipeline", () => {
 	});
 
 	describe("CLIPipelineRunner — generate validation", () => {
-		it("defaults to gpt_image_2_gmi when model is missing for generate-image", async () => {
+		it("defaults to gpt_image_2_ima when model is missing for generate-image", async () => {
 			const mockExecuteStep = vi
 				.spyOn(PipelineExecutor.prototype, "executeStep")
 				.mockResolvedValue({
@@ -314,7 +314,7 @@ describe("CLI pipeline", () => {
 			);
 
 			expect(result.success).toBe(true);
-			expect(mockExecuteStep.mock.calls[0][0].model).toBe("gpt_image_2_gmi");
+			expect(mockExecuteStep.mock.calls[0][0].model).toBe("gpt_image_2_ima");
 			mockExecuteStep.mockRestore();
 		});
 

--- a/qcut/electron/__tests__/cli-pipeline.test.ts
+++ b/qcut/electron/__tests__/cli-pipeline.test.ts
@@ -296,7 +296,7 @@ describe("CLI pipeline", () => {
 	});
 
 	describe("CLIPipelineRunner — generate validation", () => {
-		it("defaults to nano_banana_pro when model is missing for generate-image", async () => {
+		it("defaults to gpt_image_2_gmi when model is missing for generate-image", async () => {
 			const mockExecuteStep = vi
 				.spyOn(PipelineExecutor.prototype, "executeStep")
 				.mockResolvedValue({
@@ -314,6 +314,7 @@ describe("CLI pipeline", () => {
 			);
 
 			expect(result.success).toBe(true);
+			expect(mockExecuteStep.mock.calls[0][0].model).toBe("gpt_image_2_gmi");
 			mockExecuteStep.mockRestore();
 		});
 

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
@@ -195,19 +195,27 @@ async function runSingleGeneration(
 	params: Record<string, unknown>
 ): Promise<CLIResult> {
 	const startTime = Date.now();
-	const model = ModelRegistry.get(options.model!);
+	const modelKey = options.model;
+	if (!modelKey) {
+		return {
+			success: false,
+			error: "Missing model",
+			duration: (Date.now() - startTime) / 1000,
+		};
+	}
+	const model = ModelRegistry.get(modelKey);
 	const prefix = jobIndex >= 0 ? `[${jobIndex + 1}] ` : "";
 
 	onProgress({
 		stage: "starting",
 		percent: 0,
 		message: `${prefix}Starting ${model.name}...`,
-		model: options.model,
+		model: modelKey,
 	});
 
 	const step: PipelineStep = {
 		type: model.categories[0],
-		model: options.model!,
+		model: modelKey,
 		params,
 		enabled: true,
 		retryCount: 0,
@@ -227,7 +235,7 @@ async function runSingleGeneration(
 				stage: "processing",
 				percent,
 				message: `${prefix}${message}`,
-				model: options.model,
+				model: modelKey,
 			});
 		},
 		signal,
@@ -284,10 +292,10 @@ async function runSingleGeneration(
 		stage: "complete",
 		percent: 100,
 		message: `${prefix}Done`,
-		model: options.model,
+		model: modelKey,
 	});
 
-	const cost = result.cost ?? estimateCost(options.model!, params).totalCost;
+	const cost = result.cost ?? estimateCost(modelKey, params).totalCost;
 
 	// Sidecar JSON next to the output captures the prompt + every param
 	// the run was given. Lets users reproduce a generation without
@@ -300,11 +308,8 @@ async function runSingleGeneration(
 		await writeSidecarJson(
 			sidecarBase,
 			options.command,
-			options.model,
-			result.endpoint ??
-				(ModelRegistry.has(options.model ?? "")
-					? ModelRegistry.get(options.model!).endpoint
-					: undefined),
+			modelKey,
+			result.endpoint ?? model.endpoint,
 			promptText,
 			params,
 			options,

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
@@ -62,7 +62,7 @@ export function getDefaultModelForCommand({
 }: {
 	command: string;
 }): string | undefined {
-	if (command === "generate-image") return "nano_banana_pro";
+	if (command === "generate-image") return "gpt_image_2_gmi";
 	if (command === "create-video") return "imarouter_seedance_2_0_fast_t2v";
 	return undefined;
 }
@@ -139,7 +139,12 @@ async function writeSidecarJson(
 	prompt: string,
 	params: Record<string, unknown>,
 	options: CLIRunOptions,
-	result: { outputUrl?: string; outputPath?: string; cost?: number },
+	result: {
+		endpoint?: string;
+		outputUrl?: string;
+		outputPath?: string;
+		cost?: number;
+	},
 	timestamp: number,
 	durationSeconds: number
 ): Promise<void> {
@@ -296,13 +301,19 @@ async function runSingleGeneration(
 			sidecarBase,
 			options.command,
 			options.model,
-			ModelRegistry.has(options.model ?? "")
-				? ModelRegistry.get(options.model!).endpoint
-				: undefined,
+			result.endpoint ??
+				(ModelRegistry.has(options.model ?? "")
+					? ModelRegistry.get(options.model!).endpoint
+					: undefined),
 			promptText,
 			params,
 			options,
-			{ outputUrl: result.outputUrl, outputPath: result.outputPath, cost },
+			{
+				endpoint: result.endpoint,
+				outputUrl: result.outputUrl,
+				outputPath: result.outputPath,
+				cost,
+			},
 			outputTimestamp,
 			(Date.now() - startTime) / 1000
 		);
@@ -310,6 +321,7 @@ async function runSingleGeneration(
 
 	return {
 		success: true,
+		endpoint: result.endpoint,
 		outputPath: result.outputPath,
 		outputPaths: result.outputPath ? [result.outputPath] : undefined,
 		cost,
@@ -458,6 +470,13 @@ export async function handleGenerate(
 		(options.model === "wan_v2_7_edit" || options.model === "wan_v2_7_pro_edit")
 	) {
 		params.image_urls = [options.imageUrl];
+	}
+	if (
+		options.command === "generate-image" &&
+		options.referenceImages &&
+		options.referenceImages.length > 0
+	) {
+		params.image_urls = options.referenceImages;
 	}
 
 	// Validate --count

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
@@ -62,7 +62,7 @@ export function getDefaultModelForCommand({
 }: {
 	command: string;
 }): string | undefined {
-	if (command === "generate-image") return "gpt_image_2_gmi";
+	if (command === "generate-image") return "gpt_image_2_ima";
 	if (command === "create-video") return "imarouter_seedance_2_0_fast_t2v";
 	return undefined;
 }

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-grid.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-grid.ts
@@ -17,7 +17,7 @@ import type { CLIRunOptions, CLIResult, ProgressFn } from "./types.js";
 
 const VALID_LAYOUTS = ["2x2", "3x3", "2x3", "3x2", "1x2", "2x1"] as const;
 type GridLayout = (typeof VALID_LAYOUTS)[number];
-const DEFAULT_GRID_IMAGE_MODEL = "gpt_image_2_gmi";
+const DEFAULT_GRID_IMAGE_MODEL = "gpt_image_2_ima";
 
 export async function handleGenerateGrid(
 	options: CLIRunOptions,

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-grid.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-grid.ts
@@ -17,6 +17,7 @@ import type { CLIRunOptions, CLIResult, ProgressFn } from "./types.js";
 
 const VALID_LAYOUTS = ["2x2", "3x3", "2x3", "3x2", "1x2", "2x1"] as const;
 type GridLayout = (typeof VALID_LAYOUTS)[number];
+const DEFAULT_GRID_IMAGE_MODEL = "gpt_image_2_gmi";
 
 export async function handleGenerateGrid(
 	options: CLIRunOptions,
@@ -33,7 +34,7 @@ export async function handleGenerateGrid(
 			};
 		}
 
-		const model = options.model || "flux_dev";
+		const model = options.model || DEFAULT_GRID_IMAGE_MODEL;
 		if (!ModelRegistry.has(model)) {
 			return { success: false, error: `Unknown model '${model}'` };
 		}

--- a/qcut/electron/native-pipeline/cli/cli-runner/types.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/types.ts
@@ -337,6 +337,7 @@ export interface CLIRunOptions {
 /** Standard result returned by a CLI command handler. */
 export interface CLIResult {
 	success: boolean;
+	endpoint?: string;
 	outputPath?: string;
 	outputPaths?: string[];
 	error?: string;

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -38,7 +38,7 @@ export const GLOBAL_FLAGS: FlagDef[] = [
 		short: "-o",
 		default: "$QCUT_OUTPUT_DIR or ~/Documents/QCut/exports",
 	}),
-	f("--model", "string", "Model key (e.g. gpt_image_2_gmi, kling_2_6_pro)", {
+	f("--model", "string", "Model key (e.g. gpt_image_2_ima, kling_2_6_pro)", {
 		short: "-m",
 	}),
 	f("--policy", "string", "Path to a JSON action policy file"),
@@ -211,8 +211,9 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			f("--text", "string", "Text prompt", { short: "-t", required: true }),
 			f("--model", "string", "Model key", {
 				short: "-m",
-				default: "gpt_image_2_gmi",
+				default: "gpt_image_2_ima",
 				enum: [
+					"gpt_image_2_ima",
 					"gpt_image_2_gmi",
 					"gpt_image_2_fal",
 					"flux_dev",
@@ -372,7 +373,7 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			}),
 			f("--model", "string", "Model key", {
 				short: "-m",
-				default: "gpt_image_2_gmi",
+				default: "gpt_image_2_ima",
 			}),
 			f("--layout", "string", "Grid layout", {
 				default: "2x2",
@@ -1661,6 +1662,7 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			f("--reference-model", "string", "Reference model"),
 			f("--reference-strength", "number", "Reference strength (0-1)"),
 			f("--views", "string", "Portrait views to generate"),
+			f("--concurrency", "number", "Parallel characters in flight (default 3)"),
 			f("--save-registry", "boolean", "Save portrait registry", {
 				default: true,
 			}),

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -38,7 +38,7 @@ export const GLOBAL_FLAGS: FlagDef[] = [
 		short: "-o",
 		default: "$QCUT_OUTPUT_DIR or ~/Documents/QCut/exports",
 	}),
-	f("--model", "string", "Model key (e.g. kling_2_6_pro, flux_dev)", {
+	f("--model", "string", "Model key (e.g. gpt_image_2_gmi, kling_2_6_pro)", {
 		short: "-m",
 	}),
 	f("--policy", "string", "Path to a JSON action policy file"),
@@ -370,7 +370,10 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 				short: "-t",
 				required: true,
 			}),
-			f("--model", "string", "Model key", { short: "-m", default: "flux_dev" }),
+			f("--model", "string", "Model key", {
+				short: "-m",
+				default: "gpt_image_2_gmi",
+			}),
 			f("--layout", "string", "Grid layout", {
 				default: "2x2",
 				enum: ["2x2", "3x3", "2x3", "3x2", "1x2", "2x1"],

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -211,8 +211,10 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			f("--text", "string", "Text prompt", { short: "-t", required: true }),
 			f("--model", "string", "Model key", {
 				short: "-m",
-				default: "flux_dev",
+				default: "gpt_image_2_gmi",
 				enum: [
+					"gpt_image_2_gmi",
+					"gpt_image_2_fal",
 					"flux_dev",
 					"flux_pro",
 					"kling_2_6_pro",
@@ -235,6 +237,7 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 				"Multiple prompts for batch generation (repeatable)"
 			),
 			f("--image-url", "string", "Reference image URL"),
+			f("--reference-images", "string[]", "Reference images (repeatable)"),
 			f("--grid", "string", "Generate image grid (e.g. 2x2, 3x3, 2x3)", {
 				enum: ["2x2", "3x3", "2x3", "3x2", "1x2", "2x1"],
 			}),
@@ -243,7 +246,8 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 		],
 		examples: [
 			"qcut-pipeline generate-image -t 'A cat in space'",
-			"qcut-pipeline generate-image -t 'Ocean sunset' -m flux_dev --aspect-ratio 16:9",
+			"qcut-pipeline generate-image -t 'Ocean sunset' --aspect-ratio 16:9",
+			"qcut-pipeline generate-image -t 'Make the character wear a red jacket' --image-url https://example.com/character.png",
 			"qcut-pipeline generate-image -t 'Logo design' --count 4 --json",
 			"qcut-pipeline generate-image -t 'Seasons of a tree' --grid 2x2",
 		],

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/character-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/character-handlers.ts
@@ -418,6 +418,9 @@ export async function handleVimaxGeneratePortraits(
 			image_model: options.imageModel,
 			llm_model: options.llmModel,
 			output_dir: portraitsDir,
+			...(options.concurrency !== undefined
+				? { concurrency: options.concurrency }
+				: {}),
 			...(views ? { views } : {}),
 			...(resolvedStyle ? { style: resolvedStyle } : {}),
 		});

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/character-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/character-handlers.ts
@@ -354,7 +354,11 @@ export async function handleVimaxGeneratePortraits(
 
 		// Print pre-flight estimate before burning image credits.
 		printEstimate(
-			estimatePortraits(characters.length, views ? views.length : 1)
+			estimatePortraits(
+				characters.length,
+				views ? views.length : 1,
+				options.concurrency
+			)
 		);
 
 		// Honour --style (preset slug or free-form), or reuse the style

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
@@ -8,7 +8,7 @@ vi.mock("../../infra/api-caller.js", async () => {
 	};
 });
 
-import { callModelApi } from "../../infra/api-caller.js";
+import { callModelApi, uploadToFalStorage } from "../../infra/api-caller.js";
 import { ModelRegistry } from "../../infra/registry.js";
 import { registerTextToImageModels } from "../../registry-data/text-to-image.js";
 import { executeStep } from "../step-executors.js";
@@ -23,6 +23,10 @@ const mockedCallModelApi = callModelApi as unknown as {
 	mockResolvedValue: (value: unknown) => void;
 	mock: { calls: Array<[ApiCall]> };
 };
+const mockedUploadToFalStorage = uploadToFalStorage as unknown as {
+	mockResolvedValue: (value: unknown) => void;
+	mock: { calls: Array<[string]> };
+};
 
 beforeEach(() => {
 	if (!ModelRegistry.has("gpt_image_2_gmi")) {
@@ -34,6 +38,10 @@ beforeEach(() => {
 		outputUrl: "https://gmi.cloud/image/out.png",
 		duration: 1,
 		data: {},
+	});
+	mockedUploadToFalStorage.mockResolvedValue({
+		success: true,
+		url: "https://fal.media/uploaded/local-ref.png",
 	});
 });
 
@@ -56,6 +64,55 @@ describe("executeTextToImage — GPT Image 2", () => {
 		expect(call.payload.size).toBe("1536x1024");
 		expect(call.payload).not.toHaveProperty("image_size");
 		expect(call.payload).not.toHaveProperty("aspect_ratio");
+	});
+
+	it("uses the GMI edit model id when reference images are provided", async () => {
+		const model = ModelRegistry.get("gpt_image_2_gmi");
+
+		await executeStep(
+			model,
+			{
+				text: "make the same astronaut bronze",
+				imageUrl: "https://example.com/astronaut.png",
+			},
+			{
+				aspect_ratio: "1:1",
+				image_urls: ["https://example.com/helmet.png"],
+			},
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("gmi");
+		expect(call.endpoint).toBe("gpt-image-2-edit");
+		expect(call.payload.prompt).toBe("make the same astronaut bronze");
+		expect(call.payload.image).toEqual([
+			"https://example.com/astronaut.png",
+			"https://example.com/helmet.png",
+		]);
+		expect(call.payload.size).toBe("1024x1024");
+		expect(call.payload).not.toHaveProperty("image_urls");
+		expect(call.payload).not.toHaveProperty("aspect_ratio");
+	});
+
+	it("uploads local GMI reference images before calling the edit model", async () => {
+		const model = ModelRegistry.get("gpt_image_2_gmi");
+
+		await executeStep(
+			model,
+			{ text: "turn this into a clean icon", imageUrl: "/tmp/local-ref.png" },
+			{},
+			{}
+		);
+
+		expect(mockedUploadToFalStorage.mock.calls[0][0]).toBe(
+			"/tmp/local-ref.png"
+		);
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.endpoint).toBe("gpt-image-2-edit");
+		expect(call.payload.image).toEqual([
+			"https://fal.media/uploaded/local-ref.png",
+		]);
 	});
 
 	it("keeps FAL GPT Image 2 on image_size presets", async () => {

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
@@ -134,4 +134,55 @@ describe("executeTextToImage — GPT Image 2", () => {
 		expect(call.payload).not.toHaveProperty("size");
 		expect(call.payload).not.toHaveProperty("aspect_ratio");
 	});
+
+	it("uses the FAL GPT Image 2 edit endpoint when reference images are provided", async () => {
+		const model = ModelRegistry.get("gpt_image_2_fal");
+
+		await executeStep(
+			model,
+			{
+				text: "make the same astronaut bronze",
+				imageUrl: "https://example.com/astronaut.png",
+			},
+			{
+				aspect_ratio: "1:1",
+				image_urls: ["https://example.com/helmet.png"],
+			},
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("fal");
+		expect(call.endpoint).toBe("openai/gpt-image-2/edit");
+		expect(call.payload.prompt).toBe("make the same astronaut bronze");
+		expect(call.payload.image_urls).toEqual([
+			"https://example.com/astronaut.png",
+			"https://example.com/helmet.png",
+		]);
+		expect(call.payload.image_size).toBe("auto");
+		expect(call.payload).not.toHaveProperty("image");
+		expect(call.payload).not.toHaveProperty("reference_images");
+		expect(call.payload).not.toHaveProperty("aspect_ratio");
+	});
+
+	it("uploads local FAL GPT Image 2 references before calling the edit endpoint", async () => {
+		const model = ModelRegistry.get("gpt_image_2_fal");
+
+		await executeStep(
+			model,
+			{ text: "turn this into a clean icon", imageUrl: "/tmp/local-ref.png" },
+			{},
+			{}
+		);
+
+		expect(mockedUploadToFalStorage.mock.calls[0][0]).toBe(
+			"/tmp/local-ref.png"
+		);
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.endpoint).toBe("openai/gpt-image-2/edit");
+		expect(call.payload.image_urls).toEqual([
+			"https://fal.media/uploaded/local-ref.png",
+		]);
+		expect(call.payload.image_size).toBe("auto");
+	});
 });

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
@@ -29,7 +29,7 @@ const mockedUploadToFalStorage = uploadToFalStorage as unknown as {
 };
 
 beforeEach(() => {
-	if (!ModelRegistry.has("gpt_image_2_gmi")) {
+	if (!ModelRegistry.has("gpt_image_2_ima")) {
 		registerTextToImageModels();
 	}
 	vi.clearAllMocks();
@@ -46,8 +46,8 @@ beforeEach(() => {
 });
 
 describe("executeTextToImage — GPT Image 2", () => {
-	it("uses the GMI generate model id and maps aspect ratio to OpenAI size", async () => {
-		const model = ModelRegistry.get("gpt_image_2_gmi");
+	it("uses the IMA Router GPT Image 2 model id and maps aspect ratio to OpenAI size", async () => {
+		const model = ModelRegistry.get("gpt_image_2_ima");
 
 		await executeStep(
 			model,
@@ -58,16 +58,17 @@ describe("executeTextToImage — GPT Image 2", () => {
 
 		expect(mockedCallModelApi).toHaveBeenCalledTimes(1);
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.provider).toBe("gmi");
-		expect(call.endpoint).toBe("gpt-image-2-generate");
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/images/generations");
+		expect(call.payload.model).toBe("gpt-image-2");
 		expect(call.payload.prompt).toBe("a red apple on a white plate");
 		expect(call.payload.size).toBe("1536x1024");
 		expect(call.payload).not.toHaveProperty("image_size");
 		expect(call.payload).not.toHaveProperty("aspect_ratio");
 	});
 
-	it("uses the GMI edit model id when reference images are provided", async () => {
-		const model = ModelRegistry.get("gpt_image_2_gmi");
+	it("uses the IMA Router image endpoint when reference images are provided", async () => {
+		const model = ModelRegistry.get("gpt_image_2_ima");
 
 		await executeStep(
 			model,
@@ -83,10 +84,11 @@ describe("executeTextToImage — GPT Image 2", () => {
 		);
 
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.provider).toBe("gmi");
-		expect(call.endpoint).toBe("gpt-image-2-edit");
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/images/generations");
+		expect(call.payload.model).toBe("gpt-image-2");
 		expect(call.payload.prompt).toBe("make the same astronaut bronze");
-		expect(call.payload.image).toEqual([
+		expect(call.payload.images).toEqual([
 			"https://example.com/astronaut.png",
 			"https://example.com/helmet.png",
 		]);
@@ -95,8 +97,8 @@ describe("executeTextToImage — GPT Image 2", () => {
 		expect(call.payload).not.toHaveProperty("aspect_ratio");
 	});
 
-	it("uploads local GMI reference images before calling the edit model", async () => {
-		const model = ModelRegistry.get("gpt_image_2_gmi");
+	it("uploads local IMA Router reference images before calling the image endpoint", async () => {
+		const model = ModelRegistry.get("gpt_image_2_ima");
 
 		await executeStep(
 			model,
@@ -109,8 +111,8 @@ describe("executeTextToImage — GPT Image 2", () => {
 			"/tmp/local-ref.png"
 		);
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.endpoint).toBe("gpt-image-2-edit");
-		expect(call.payload.image).toEqual([
+		expect(call.endpoint).toBe("v1/images/generations");
+		expect(call.payload.images).toEqual([
 			"https://fal.media/uploaded/local-ref.png",
 		]);
 	});

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-gpt-image.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infra/api-caller.js", async () => {
+	return {
+		callModelApi: vi.fn(),
+		downloadOutput: vi.fn(async (_url: string, dest: string) => dest),
+		uploadToFalStorage: vi.fn(),
+	};
+});
+
+import { callModelApi } from "../../infra/api-caller.js";
+import { ModelRegistry } from "../../infra/registry.js";
+import { registerTextToImageModels } from "../../registry-data/text-to-image.js";
+import { executeStep } from "../step-executors.js";
+
+type ApiCall = {
+	provider?: string;
+	endpoint?: string;
+	payload: Record<string, unknown>;
+};
+
+const mockedCallModelApi = callModelApi as unknown as {
+	mockResolvedValue: (value: unknown) => void;
+	mock: { calls: Array<[ApiCall]> };
+};
+
+beforeEach(() => {
+	if (!ModelRegistry.has("gpt_image_2_gmi")) {
+		registerTextToImageModels();
+	}
+	vi.clearAllMocks();
+	mockedCallModelApi.mockResolvedValue({
+		success: true,
+		outputUrl: "https://gmi.cloud/image/out.png",
+		duration: 1,
+		data: {},
+	});
+});
+
+describe("executeTextToImage — GPT Image 2", () => {
+	it("uses the GMI generate model id and maps aspect ratio to OpenAI size", async () => {
+		const model = ModelRegistry.get("gpt_image_2_gmi");
+
+		await executeStep(
+			model,
+			{ text: "a red apple on a white plate" },
+			{ aspect_ratio: "3:2" },
+			{}
+		);
+
+		expect(mockedCallModelApi).toHaveBeenCalledTimes(1);
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("gmi");
+		expect(call.endpoint).toBe("gpt-image-2-generate");
+		expect(call.payload.prompt).toBe("a red apple on a white plate");
+		expect(call.payload.size).toBe("1536x1024");
+		expect(call.payload).not.toHaveProperty("image_size");
+		expect(call.payload).not.toHaveProperty("aspect_ratio");
+	});
+
+	it("keeps FAL GPT Image 2 on image_size presets", async () => {
+		const model = ModelRegistry.get("gpt_image_2_fal");
+
+		await executeStep(
+			model,
+			{ text: "a blue cup on a white table" },
+			{ aspect_ratio: "16:9" },
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("fal");
+		expect(call.endpoint).toBe("openai/gpt-image-2");
+		expect(call.payload.image_size).toBe("1536x1024");
+		expect(call.payload).not.toHaveProperty("size");
+		expect(call.payload).not.toHaveProperty("aspect_ratio");
+	});
+});

--- a/qcut/electron/native-pipeline/execution/executor.ts
+++ b/qcut/electron/native-pipeline/execution/executor.ts
@@ -49,6 +49,7 @@ export interface PipelineProgress {
 
 export interface StepResult {
 	success: boolean;
+	endpoint?: string;
 	outputPath?: string;
 	outputUrl?: string;
 	text?: string;
@@ -187,6 +188,7 @@ export class PipelineExecutor {
 		const result = await executeStep(model, input, step.params, options);
 		return {
 			success: result.success,
+			endpoint: result.endpoint,
 			outputPath: result.outputPath,
 			outputUrl: result.outputUrl,
 			text: result.text,

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -146,7 +146,10 @@ async function resolveReferenceImages({
 	{ success: true; urls: string[] } | { success: false; error: string }
 > {
 	const shouldUploadLocal =
-		provider === "fal" || provider === "gmi" || provider === "gmi-llm";
+		provider === "fal" ||
+		provider === "gmi" ||
+		provider === "gmi-llm" ||
+		provider === "imarouter";
 	const uploads = refs.map(async (ref): Promise<ReferenceImageResolution> => {
 		if (isRemoteUrl(ref) || !shouldUploadLocal)
 			return { success: true, url: ref };
@@ -389,7 +392,15 @@ async function executeTextToImage(
 	payload.prompt = input.text || payload.prompt;
 	const referenceImages = collectReferenceImages({ input, payload });
 	let endpoint = model.endpoint;
-	if (referenceImages.length > 0 && provider === "gmi") {
+	const isImaRouterGptImage2 =
+		model.key === "gpt_image_2_ima" || model.key === "gpt_image_2_gmi";
+	if (isImaRouterGptImage2) {
+		payload.model = "gpt-image-2";
+	}
+	if (
+		referenceImages.length > 0 &&
+		(provider === "gmi" || provider === "imarouter")
+	) {
 		const refs = await resolveReferenceImages({
 			refs: referenceImages,
 			provider,
@@ -402,10 +413,15 @@ async function executeTextToImage(
 				duration: 0,
 			};
 		}
-		payload.image = refs.urls;
+		if (provider === "imarouter" && isImaRouterGptImage2) {
+			payload.images = refs.urls;
+			delete payload.image;
+		} else {
+			payload.image = refs.urls;
+		}
 		delete payload.image_urls;
 		delete payload.reference_images;
-		if (model.key === "gpt_image_2_gmi") {
+		if (provider === "gmi" && isImaRouterGptImage2) {
 			endpoint = "gpt-image-2-edit";
 		}
 	}
@@ -429,7 +445,10 @@ async function executeTextToImage(
 	}
 
 	// GPT Image uses image_size with pixel dimensions
-	if (model.endpoint.includes("gpt-image") && payload.aspect_ratio) {
+	if (
+		(model.endpoint.includes("gpt-image") || isImaRouterGptImage2) &&
+		payload.aspect_ratio
+	) {
 		const gptSizeMap: Record<string, string> = {
 			"1:1": "1024x1024",
 			"16:9": "1536x1024",
@@ -438,7 +457,7 @@ async function executeTextToImage(
 			"2:3": "1024x1536",
 		};
 		const size = gptSizeMap[payload.aspect_ratio as string] || "1024x1024";
-		if (provider === "gmi") {
+		if (provider === "gmi" || provider === "imarouter") {
 			payload.size = size;
 			delete payload.image_size;
 		} else {

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -394,12 +394,13 @@ async function executeTextToImage(
 	let endpoint = model.endpoint;
 	const isImaRouterGptImage2 =
 		model.key === "gpt_image_2_ima" || model.key === "gpt_image_2_gmi";
+	const isFalGptImage2 = model.key === "gpt_image_2_fal";
 	if (isImaRouterGptImage2) {
 		payload.model = "gpt-image-2";
 	}
 	if (
 		referenceImages.length > 0 &&
-		(provider === "gmi" || provider === "imarouter")
+		(provider === "gmi" || provider === "imarouter" || isFalGptImage2)
 	) {
 		const refs = await resolveReferenceImages({
 			refs: referenceImages,
@@ -416,10 +417,18 @@ async function executeTextToImage(
 		if (provider === "imarouter" && isImaRouterGptImage2) {
 			payload.images = refs.urls;
 			delete payload.image;
+		} else if (isFalGptImage2) {
+			payload.image_urls = refs.urls;
+			payload.image_size = "auto";
+			delete payload.aspect_ratio;
+			delete payload.image;
+			endpoint = "openai/gpt-image-2/edit";
 		} else {
 			payload.image = refs.urls;
 		}
-		delete payload.image_urls;
+		if (!isFalGptImage2) {
+			delete payload.image_urls;
+		}
 		delete payload.reference_images;
 		if (provider === "gmi" && isImaRouterGptImage2) {
 			endpoint = "gpt-image-2-edit";

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -27,6 +27,7 @@ export interface StepInput {
 
 export interface StepOutput {
 	success: boolean;
+	endpoint?: string;
 	outputUrl?: string;
 	outputPath?: string;
 	text?: string;
@@ -99,6 +100,80 @@ function getProviderForEndpoint(endpoint: string): ProviderName {
 	)
 		return "openrouter";
 	return "fal";
+}
+
+function isRemoteUrl(url: string): boolean {
+	return /^https?:\/\//i.test(url);
+}
+
+function collectReferenceImages({
+	input,
+	payload,
+}: {
+	input: StepInput;
+	payload: Record<string, unknown>;
+}): string[] {
+	const refs: string[] = [];
+	const append = (value: unknown) => {
+		if (typeof value === "string" && value.trim()) refs.push(value);
+	};
+	append(input.imageUrl);
+	for (const key of ["image", "image_urls", "reference_images"]) {
+		const value = payload[key];
+		if (Array.isArray(value)) {
+			for (const item of value) append(item);
+		}
+	}
+	return [...new Set(refs)];
+}
+
+type ReferenceImageResolution =
+	| { success: true; url: string }
+	| { success: false; error: string };
+
+async function resolveReferenceImages({
+	refs,
+	provider,
+	options,
+}: {
+	refs: string[];
+	provider: ProviderName;
+	options: {
+		onProgress?: (p: number, m: string) => void;
+		signal?: AbortSignal;
+	};
+}): Promise<
+	{ success: true; urls: string[] } | { success: false; error: string }
+> {
+	const shouldUploadLocal =
+		provider === "fal" || provider === "gmi" || provider === "gmi-llm";
+	const uploads = refs.map(async (ref): Promise<ReferenceImageResolution> => {
+		if (isRemoteUrl(ref) || !shouldUploadLocal)
+			return { success: true, url: ref };
+		if (options.signal?.aborted) {
+			return {
+				success: false,
+				error: "Step cancelled before reference upload",
+			};
+		}
+		options.onProgress?.(10, "Uploading reference image...");
+		const upload = await uploadToFalStorage(ref);
+		if (!upload.success || !upload.url) {
+			return {
+				success: false,
+				error: upload.error || "Failed to upload reference image",
+			};
+		}
+		return { success: true, url: upload.url };
+	});
+	const resolved = await Promise.all(uploads);
+	const failed = resolved.find((item) => !item.success);
+	if (failed) return { success: false, error: failed.error };
+	const urls = resolved.flatMap((item) => (item.success ? [item.url] : []));
+	return {
+		success: true,
+		urls,
+	};
 }
 
 /**
@@ -312,6 +387,28 @@ async function executeTextToImage(
 	}
 ): Promise<StepOutput> {
 	payload.prompt = input.text || payload.prompt;
+	const referenceImages = collectReferenceImages({ input, payload });
+	let endpoint = model.endpoint;
+	if (referenceImages.length > 0 && provider === "gmi") {
+		const refs = await resolveReferenceImages({
+			refs: referenceImages,
+			provider,
+			options,
+		});
+		if (!refs.success) {
+			return {
+				success: false,
+				error: refs.error,
+				duration: 0,
+			};
+		}
+		payload.image = refs.urls;
+		delete payload.image_urls;
+		delete payload.reference_images;
+		if (model.key === "gpt_image_2_gmi") {
+			endpoint = "gpt-image-2-edit";
+		}
+	}
 
 	// Models that use image_size instead of aspect_ratio
 	const usesImageSize =
@@ -351,14 +448,14 @@ async function executeTextToImage(
 	}
 
 	const result = await callModelApi({
-		endpoint: model.endpoint,
+		endpoint,
 		modelKey: model.key,
 		payload,
 		provider,
 		onProgress: options.onProgress,
 		signal: options.signal,
 	});
-	return mapApiResult(result, options.outputDir);
+	return mapApiResult(result, options.outputDir, endpoint);
 }
 
 async function executeTextToVideo(
@@ -601,8 +698,10 @@ async function executeImageToImage(
 	if (input.imageUrl) {
 		let resolvedUrl = input.imageUrl;
 
-		// Upload local files to FAL storage for FAL-routed endpoints
-		if (provider === "fal" && !input.imageUrl.startsWith("http")) {
+		if (
+			(provider === "fal" || provider === "gmi" || provider === "gmi-llm") &&
+			!isRemoteUrl(input.imageUrl)
+		) {
 			options.onProgress?.(10, "Uploading image to FAL storage...");
 			const upload = await uploadToFalStorage(input.imageUrl);
 			if (!upload.success || !upload.url) {
@@ -1111,11 +1210,13 @@ function extractTextFromResult(data: unknown): string | undefined {
 /** Map a raw API result to a normalized step output. */
 async function mapApiResult(
 	result: ApiCallResult,
-	outputDir?: string
+	outputDir?: string,
+	endpoint?: string
 ): Promise<StepOutput> {
 	if (!result.success) {
 		return {
 			success: false,
+			endpoint,
 			error: result.error,
 			duration: result.duration,
 		};
@@ -1135,6 +1236,7 @@ async function mapApiResult(
 
 	return {
 		success: true,
+		endpoint,
 		outputUrl: result.outputUrl,
 		outputPath,
 		data: result.data,

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -340,8 +340,13 @@ async function executeTextToImage(
 			"3:2": "1536x1024",
 			"2:3": "1024x1536",
 		};
-		payload.image_size =
-			gptSizeMap[payload.aspect_ratio as string] || "1024x1024";
+		const size = gptSizeMap[payload.aspect_ratio as string] || "1024x1024";
+		if (provider === "gmi") {
+			payload.size = size;
+			delete payload.image_size;
+		} else {
+			payload.image_size = size;
+		}
 		delete payload.aspect_ratio;
 	}
 

--- a/qcut/electron/native-pipeline/infra/__tests__/api-caller-gmi.test.ts
+++ b/qcut/electron/native-pipeline/infra/__tests__/api-caller-gmi.test.ts
@@ -165,7 +165,6 @@ describe("callModelApi with GMI provider", () => {
 	});
 
 	it("calls onProgress during GMI polling", async () => {
-		vi.useFakeTimers();
 		const onProgress = vi.fn();
 
 		// Submit
@@ -179,7 +178,10 @@ describe("callModelApi with GMI provider", () => {
 		mockFetch.mockResolvedValueOnce({
 			ok: true,
 			json: () =>
-				Promise.resolve({ request_id: "gmi-req-prog", status: "processing" }),
+				Promise.resolve({
+					request_id: "gmi-req-prog",
+					status: "processing",
+				}),
 		});
 
 		// Poll 2: success
@@ -193,25 +195,18 @@ describe("callModelApi with GMI provider", () => {
 				}),
 		});
 
-		const resultPromise = callModelApi({
+		const result = await callModelApi({
 			endpoint: "veo-3.1-lite-generate-001",
 			payload: { prompt: "test" },
 			provider: "gmi",
 			onProgress,
 		});
 
-		// Advance past poll sleep intervals
-		await vi.advanceTimersByTimeAsync(15000);
-
-		const result = await resultPromise;
-
 		expect(result.success).toBe(true);
 		expect(onProgress).toHaveBeenCalled();
 		// Last call should be 100% completion
 		const lastCall = onProgress.mock.calls[onProgress.mock.calls.length - 1];
 		expect(lastCall[0]).toBe(100);
-
-		vi.useRealTimers();
 	});
 
 	it("returns error when no GMI API key is configured", async () => {
@@ -255,5 +250,34 @@ describe("callModelApi with GMI provider", () => {
 			model: "kling-v3-omni",
 			payload: { prompt: "test", mode: "pro", duration: "5" },
 		});
+	});
+
+	it("extracts image URLs from successful GMI image outcomes", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve({ request_id: "gmi-image-req" }),
+			text: () => Promise.resolve(""),
+		});
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					request_id: "gmi-image-req",
+					status: "success",
+					outcome: {
+						images: [{ url: "https://gmi.cloud/image/out.png" }],
+					},
+				}),
+		});
+
+		const result = await callModelApi({
+			endpoint: "gpt-image-2-generate",
+			payload: { prompt: "test", size: "1024x1024" },
+			provider: "gmi",
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.outputUrl).toBe("https://gmi.cloud/image/out.png");
 	});
 });

--- a/qcut/electron/native-pipeline/infra/__tests__/api-caller-imarouter.test.ts
+++ b/qcut/electron/native-pipeline/infra/__tests__/api-caller-imarouter.test.ts
@@ -71,6 +71,87 @@ describe("callModelApi with IMA Router provider", () => {
 		expect(submitBody.metadata.resolution).toBe("1080p");
 	});
 
+	it("submits to /v1/images/generations and polls image status until success", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () =>
+				Promise.resolve({ code: "success", data: { task_id: "img_task_1" } }),
+			text: () => Promise.resolve(""),
+		});
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					code: "success",
+					data: {
+						task_id: "img_task_1",
+						status: "succeeded",
+						format: "png",
+						url: "https://imarouter.example/image.png",
+						amount_usd: 0.042,
+					},
+				}),
+		});
+
+		const result = await callModelApi({
+			endpoint: "v1/images/generations",
+			payload: {
+				model: "gpt-image-2",
+				prompt: "A matte black cube",
+				size: "1024x1024",
+				quality: "medium",
+				output_format: "png",
+			},
+			provider: "imarouter",
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.outputUrl).toBe("https://imarouter.example/image.png");
+
+		const submitCall = mockFetch.mock.calls[0];
+		expect(submitCall[0]).toBe(
+			"https://api.imarouter.com/v1/images/generations"
+		);
+		expect(JSON.parse(submitCall[1].body)).toEqual({
+			model: "gpt-image-2",
+			prompt: "A matte black cube",
+			size: "1024x1024",
+			quality: "medium",
+			output_format: "png",
+		});
+		const pollCall = mockFetch.mock.calls[1];
+		expect(pollCall[0]).toBe(
+			"https://api.imarouter.com/v1/images/generations/img_task_1"
+		);
+	});
+
+	it("surfaces failed image tasks", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve({ task_id: "img_fail" }),
+			text: () => Promise.resolve(""),
+		});
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					data: {
+						status: "failed",
+						error: { message: "image prompt rejected" },
+					},
+				}),
+		});
+
+		const result = await callModelApi({
+			endpoint: "v1/images/generations",
+			payload: { model: "gpt-image-2", prompt: "test" },
+			provider: "imarouter",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("image prompt rejected");
+	});
+
 	it("surfaces a 4xx submit error", async () => {
 		mockFetch.mockResolvedValueOnce({
 			ok: false,

--- a/qcut/electron/native-pipeline/infra/__tests__/api-provider-urls.test.ts
+++ b/qcut/electron/native-pipeline/infra/__tests__/api-provider-urls.test.ts
@@ -105,6 +105,18 @@ describe("extractOutputUrl", () => {
 			})
 		).toBe("https://imarouter.example/v.mp4");
 	});
+
+	it("extracts IMA Router image data.url shape", () => {
+		expect(
+			extractOutputUrl({
+				code: "success",
+				data: {
+					status: "succeeded",
+					url: "https://imarouter.example/image.png",
+				},
+			})
+		).toBe("https://imarouter.example/image.png");
+	});
 });
 
 describe("buildProviderUrl", () => {

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -707,12 +707,10 @@ async function pollGmiQueue(
 			if (options?.onProgress) {
 				options.onProgress(100, "Completed");
 			}
-			const videoUrl =
-				status.outcome?.video_url || status.outcome?.media_urls?.[0]?.url;
 			return {
 				success: true,
 				data: status,
-				outputUrl: videoUrl,
+				outputUrl: extractOutputUrl(status.outcome ?? status),
 				duration: (Date.now() - startTime) / 1000,
 			};
 		}

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -92,11 +92,33 @@ interface GmiStatusResponse {
 interface ImaRouterSubmitResponse {
 	task_id?: string;
 	id?: string;
+	data?: {
+		task_id?: string;
+		id?: string;
+	};
 	code?: number | string;
 	message?: string;
 }
 
 interface ImaRouterStatusResponse {
+	code?: string;
+	data?: {
+		task_id?: string;
+		status?:
+			| "queued"
+			| "processing"
+			| "succeeded"
+			| "completed"
+			| "failed"
+			| "error"
+			| string;
+		format?: string;
+		url?: string;
+		error?: { code?: number | string; message?: string } | string | null;
+		metadata?: unknown;
+		amount_usd?: number;
+		usage?: unknown;
+	};
 	status?: "queued" | "in_progress" | "completed" | "failed" | string;
 	progress?: number;
 	results?: Array<{ url?: string }>;
@@ -351,6 +373,8 @@ export { GEMINI_BASE, OPENROUTER_BASE, VOLCENGINE_BASE };
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const GMI_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_RETRIES = 3;
+const IMAROUTER_IMAGE_GENERATIONS_PATH = "v1/images/generations";
+const IMAROUTER_VIDEO_GENERATIONS_PATH = "v1/videos";
 
 export { getAdaptivePollInterval };
 
@@ -745,6 +769,30 @@ async function pollGmiQueue(
 
 const IMAROUTER_MAX_POLL_MS = 30 * 60 * 1000; // 30 min ceiling
 
+function getImaRouterStatusPayload(
+	status: ImaRouterStatusResponse
+): Record<string, unknown> {
+	const data = status.data;
+	if (data && typeof data === "object") return data as Record<string, unknown>;
+	return status as Record<string, unknown>;
+}
+
+function getImaRouterStatus(status: ImaRouterStatusResponse): string {
+	const payload = getImaRouterStatusPayload(status);
+	return String(payload.status ?? status.status ?? "").toLowerCase();
+}
+
+function getImaRouterErrorMessage(status: ImaRouterStatusResponse): string {
+	const payload = getImaRouterStatusPayload(status);
+	const error = payload.error ?? status.error;
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object") {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+	return status.message ?? "task failed";
+}
+
 /**
  * Poll an IMA Router video task until completion, failure, or timeout.
  *
@@ -766,7 +814,10 @@ async function pollImaRouterTask(
 	const startTime = Date.now();
 	const apiKey = await getApiKey("imarouter");
 	const headers = buildHeaders("imarouter", apiKey);
-	const statusUrl = buildProviderUrl("imarouter", `v1/videos/${taskId}`);
+	const statusUrl = buildProviderUrl(
+		"imarouter",
+		`${IMAROUTER_VIDEO_GENERATIONS_PATH}/${taskId}`
+	);
 
 	let lastPercent = -1;
 	while (Date.now() - startTime < IMAROUTER_MAX_POLL_MS) {
@@ -788,6 +839,7 @@ async function pollImaRouterTask(
 			};
 		}
 		const status = (await res.json()) as ImaRouterStatusResponse;
+		const state = getImaRouterStatus(status);
 
 		const percent =
 			typeof status.progress === "number"
@@ -798,19 +850,17 @@ async function pollImaRouterTask(
 			options.onProgress(percent, status.status ?? "in_progress");
 		}
 
-		if (status.status === "completed") {
+		if (state === "completed" || state === "succeeded") {
+			const payload = getImaRouterStatusPayload(status);
 			return {
 				success: true,
 				data: status,
-				outputUrl: extractOutputUrl(status),
+				outputUrl: extractOutputUrl(payload) ?? extractOutputUrl(status),
 				duration: (Date.now() - startTime) / 1000,
 			};
 		}
-		if (status.status === "failed") {
-			const errMsg =
-				typeof status.error === "string"
-					? status.error
-					: (status.error?.message ?? status.message ?? "task failed");
+		if (state === "failed" || state === "error") {
+			const errMsg = getImaRouterErrorMessage(status);
 			return {
 				success: false,
 				error: `IMA Router task ${taskId} failed: ${errMsg}`,
@@ -829,7 +879,83 @@ async function pollImaRouterTask(
 	};
 }
 
-export { extractOutputUrl, pollImaRouterTask };
+async function pollImaRouterImageTask(
+	taskId: string,
+	options?: {
+		onProgress?: (percent: number, message: string) => void;
+		signal?: AbortSignal;
+	}
+): Promise<ApiCallResult> {
+	const startTime = Date.now();
+	const apiKey = await getApiKey("imarouter");
+	const headers = buildHeaders("imarouter", apiKey);
+	const statusUrl = buildProviderUrl(
+		"imarouter",
+		`${IMAROUTER_IMAGE_GENERATIONS_PATH}/${taskId}`
+	);
+
+	let lastPercent = -1;
+	while (Date.now() - startTime < IMAROUTER_MAX_POLL_MS) {
+		if (options?.signal?.aborted) {
+			return {
+				success: false,
+				error: "Cancelled",
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		const res = await fetch(statusUrl, { headers, signal: options?.signal });
+		if (!res.ok) {
+			const body = await res.text();
+			return {
+				success: false,
+				error: `IMA Router image status error ${res.status}: ${redactErrorPreview(body)}`,
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		const status = (await res.json()) as ImaRouterStatusResponse;
+		const payload = getImaRouterStatusPayload(status);
+		const state = getImaRouterStatus(status);
+		const percent =
+			typeof status.progress === "number"
+				? Math.max(0, Math.min(100, Math.round(status.progress)))
+				: state === "succeeded" || state === "completed"
+					? 100
+					: lastPercent;
+		if (options?.onProgress && percent !== lastPercent) {
+			lastPercent = percent;
+			options.onProgress(percent, state || "processing");
+		}
+
+		if (state === "succeeded" || state === "completed") {
+			return {
+				success: true,
+				data: status,
+				outputUrl: extractOutputUrl(payload) ?? extractOutputUrl(status),
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+		if (state === "failed" || state === "error") {
+			return {
+				success: false,
+				error: `IMA Router image task ${taskId} failed: ${getImaRouterErrorMessage(status)}`,
+				duration: (Date.now() - startTime) / 1000,
+			};
+		}
+
+		const interval = getAdaptivePollInterval(Date.now() - startTime);
+		await new Promise((r) => setTimeout(r, interval));
+	}
+
+	return {
+		success: false,
+		error: `IMA Router image task ${taskId} timed out after ${IMAROUTER_MAX_POLL_MS / 1000}s`,
+		duration: (Date.now() - startTime) / 1000,
+	};
+}
+
+export { extractOutputUrl, pollImaRouterTask, pollImaRouterImageTask };
 
 /**
  * Call a provider endpoint and normalize the result payload.
@@ -1022,9 +1148,9 @@ export async function callModelApi(
 				signal: combinedSignal,
 			});
 		} else if (provider === "imarouter") {
-			// IMA Router: POST /v1/videos with the full payload (no model-name
-			// envelope like GMI); endpoint is the path, payload already includes
-			// `model`, `prompt`, etc. assembled by the step executor.
+			// IMA Router: POST the full payload (no GMI-style { model, payload }
+			// envelope). Videos and images share the `{ id | task_id }` async task
+			// shape but use different polling paths.
 			const submitRes = await fetchWithRetry(
 				url,
 				{
@@ -1046,7 +1172,11 @@ export async function callModelApi(
 			}
 
 			const submitData = (await submitRes.json()) as ImaRouterSubmitResponse;
-			const taskId = submitData.task_id || submitData.id;
+			const taskId =
+				submitData.task_id ||
+				submitData.id ||
+				submitData.data?.task_id ||
+				submitData.data?.id;
 			if (!taskId) {
 				return {
 					success: false,
@@ -1055,10 +1185,14 @@ export async function callModelApi(
 				};
 			}
 
-			return pollImaRouterTask(taskId, {
+			const pollOptions = {
 				onProgress: options.onProgress,
 				signal: combinedSignal,
-			});
+			};
+			if (endpoint.replace(/^\/+/, "") === IMAROUTER_IMAGE_GENERATIONS_PATH) {
+				return pollImaRouterImageTask(taskId, pollOptions);
+			}
+			return pollImaRouterTask(taskId, pollOptions);
 		}
 
 		const response = await fetchWithRetry(

--- a/qcut/electron/native-pipeline/infra/api-provider-urls.ts
+++ b/qcut/electron/native-pipeline/infra/api-provider-urls.ts
@@ -86,6 +86,10 @@ export function extractOutputUrl(data: unknown): string | undefined {
 		const first = obj.results[0] as Record<string, unknown>;
 		if (typeof first?.url === "string") return first.url;
 	}
+	if (typeof obj.data === "object" && obj.data !== null) {
+		const data = obj.data as Record<string, unknown>;
+		if (typeof data.url === "string") return data.url;
+	}
 	// GMI outcome shape: `{ outcome: { video_url: "..." } }` for Seedance 2.0 and
 	// Veo-family models. Proxy-mode responses go through this function, so
 	// missing the bare snake_case string here means the video URL is dropped

--- a/qcut/electron/native-pipeline/infra/proxy-client.ts
+++ b/qcut/electron/native-pipeline/infra/proxy-client.ts
@@ -456,6 +456,10 @@ export async function callModelApiViaProxy(
 		}
 
 		if (provider === "imarouter") {
+			const nestedData =
+				data.data && typeof data.data === "object"
+					? (data.data as Record<string, unknown>)
+					: {};
 			// Submit response shape: `{ task_id }` (or `{ id }` in older builds).
 			// pollViaProxy uppercases the status enum so IMA Router's lowercase
 			// `completed | failed` falls into the existing COMPLETED / FAILED
@@ -466,7 +470,11 @@ export async function callModelApiViaProxy(
 					? data.task_id
 					: typeof data.id === "string"
 						? data.id
-						: "";
+						: typeof nestedData.task_id === "string"
+							? nestedData.task_id
+							: typeof nestedData.id === "string"
+								? nestedData.id
+								: "";
 			if (taskId) {
 				return pollViaProxy({
 					provider: "imarouter",
@@ -532,16 +540,29 @@ async function pollViaProxy({
 
 		const poll = await proxyPollStatus({
 			provider,
-			endpoint: provider === "fal" ? endpoint : undefined,
+			endpoint:
+				provider === "fal" || provider === "imarouter" ? endpoint : undefined,
 			requestId,
 			statusUrl,
 			signal,
 		});
 
 		const status = poll.data as Record<string, unknown>;
-		const statusStr = String(status?.status ?? "").toUpperCase();
+		const statusPayload =
+			provider === "imarouter" &&
+			status?.data &&
+			typeof status.data === "object"
+				? (status.data as Record<string, unknown>)
+				: status;
+		const statusStr = String(
+			statusPayload?.status ?? status?.status ?? ""
+		).toUpperCase();
 
-		if (statusStr === "COMPLETED" || statusStr === "SUCCESS") {
+		if (
+			statusStr === "COMPLETED" ||
+			statusStr === "SUCCESS" ||
+			statusStr === "SUCCEEDED"
+		) {
 			if (provider === "fal") {
 				const result = await proxyFetchResult({
 					provider: "fal",
@@ -588,15 +609,25 @@ async function pollViaProxy({
 			return {
 				success: true,
 				data: status,
-				outputUrl: extractOutputUrl(outcome ?? status),
+				outputUrl: extractOutputUrl(outcome ?? statusPayload ?? status),
 				duration: (Date.now() - startTime) / 1000,
 			};
 		}
 
-		if (statusStr === "FAILED" || statusStr === "CANCELLED") {
+		if (
+			statusStr === "FAILED" ||
+			statusStr === "CANCELLED" ||
+			statusStr === "ERROR"
+		) {
+			const error = statusPayload?.error ?? status?.error;
+			const message =
+				typeof error === "string"
+					? error
+					: ((error as { message?: string } | undefined)?.message ??
+						"unknown error");
 			return {
 				success: false,
-				error: `Job ${statusStr.toLowerCase()}: ${String(status?.error ?? "unknown error")}`,
+				error: `Job ${statusStr.toLowerCase()}: ${message}`,
 				duration: (Date.now() - startTime) / 1000,
 			};
 		}

--- a/qcut/electron/native-pipeline/output/__tests__/stage-reporter.test.ts
+++ b/qcut/electron/native-pipeline/output/__tests__/stage-reporter.test.ts
@@ -44,14 +44,16 @@ describe("estimateCharacters", () => {
 });
 
 describe("estimatePortraits", () => {
-	it("scales linearly with character count and view count", () => {
-		const one = estimatePortraits(1, 1);
-		const five = estimatePortraits(5, 1);
+	it("scales cost linearly and duration by concurrency waves", () => {
+		const one = estimatePortraits(1, 1, 3);
+		const five = estimatePortraits(5, 1, 3);
 		expect(five.estLowCostUsd).toBeCloseTo(one.estLowCostUsd * 5, 5);
 		expect(five.estHighCostUsd).toBeCloseTo(one.estHighCostUsd * 5, 5);
+		expect(five.estLowSeconds).toBeCloseTo(one.estLowSeconds * 2, 5);
 
-		const multiView = estimatePortraits(1, 4);
-		expect(multiView.estLowSeconds).toBeCloseTo(one.estLowSeconds * 4, 5);
+		const multiView = estimatePortraits(1, 4, 2);
+		expect(multiView.estLowSeconds).toBeCloseTo(one.estLowSeconds * 2, 5);
+		expect(multiView.inputSummary).toContain("concurrency 2");
 	});
 });
 

--- a/qcut/electron/native-pipeline/output/stage-reporter.ts
+++ b/qcut/electron/native-pipeline/output/stage-reporter.ts
@@ -48,20 +48,22 @@ export function estimateCharacters(novelChars: number): StageEstimate {
 /** Estimate stage 2 (portraits) from character count. */
 export function estimatePortraits(
 	characterCount: number,
-	views = 1
+	views = 1,
+	concurrency = 3
 ): StageEstimate {
-	// Observed: flash-image portrait ~30-90s, $0.02/image.
 	const calls = characterCount * views;
+	const workers = Math.max(1, Math.floor(concurrency));
+	const waves = Math.max(1, Math.ceil(calls / workers));
 	return {
 		title: "Stage 2 — Generate portraits",
-		inputSummary: `${characterCount} characters × ${views} view(s) = ${calls} image calls`,
-		estLowSeconds: 30 * calls,
-		estHighSeconds: 90 * calls,
+		inputSummary: `${characterCount} characters × ${views} view(s) = ${calls} image calls, concurrency ${workers}`,
+		estLowSeconds: 30 * waves,
+		estHighSeconds: 90 * waves,
 		estLowCostUsd: 0.02 * calls,
 		estHighCostUsd: 0.03 * calls,
 		notes: [
-			"Portraits are generated sequentially — budget grows linearly",
-			"GMI flash-image default; swap with --image-model for other providers",
+			`Runs up to ${workers} portrait image calls concurrently`,
+			"Default image model is gpt_image_2_ima; pass --image-model to override",
 		],
 	};
 }

--- a/qcut/electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts
+++ b/qcut/electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts
@@ -54,24 +54,33 @@ describe("text-to-image registry", () => {
 		expect(ModelRegistry.has("imagen4")).toBe(true);
 	});
 
-	it("registers gpt_image_2_gmi against GMI Cloud with image-editing support", () => {
-		expect(ModelRegistry.has("gpt_image_2_gmi")).toBe(true);
-		const model = ModelRegistry.get("gpt_image_2_gmi");
-		expect(model.name).toBe("GPT-Image-2 (GMI)");
-		expect(model.provider).toBe("OpenAI (via GMI)");
-		expect(model.endpoint).toBe("gpt-image-2-generate");
-		expect(model.providerBackend).toBe("gmi");
+	it("registers gpt_image_2_ima against IMA Router with image-editing support", () => {
+		expect(ModelRegistry.has("gpt_image_2_ima")).toBe(true);
+		const model = ModelRegistry.get("gpt_image_2_ima");
+		expect(model.name).toBe("GPT-Image-2 (IMA Router)");
+		expect(model.provider).toBe("OpenAI (via IMA Router)");
+		expect(model.endpoint).toBe("v1/images/generations");
+		expect(model.providerBackend).toBe("imarouter");
 		expect(model.categories).toContain("text_to_image");
 		expect(model.categories).toContain("image_to_image");
 		expect(model.costEstimate).toBe(0.042);
 	});
 
-	it("gpt_image_2_gmi defaults match GMI's medium 1024x1024 tier", () => {
-		const model = ModelRegistry.get("gpt_image_2_gmi");
+	it("gpt_image_2_ima defaults match IMA Router's medium 1024x1024 tier", () => {
+		const model = ModelRegistry.get("gpt_image_2_ima");
+		expect(model.defaults?.model).toBe("gpt-image-2");
 		expect(model.defaults?.size).toBe("1024x1024");
 		expect(model.defaults?.quality).toBe("medium");
 		expect(model.defaults?.output_format).toBe("png");
 		expect(model.defaults?.n).toBe(1);
+	});
+
+	it("keeps gpt_image_2_gmi as a legacy alias for IMA Router", () => {
+		expect(ModelRegistry.has("gpt_image_2_gmi")).toBe(true);
+		const model = ModelRegistry.get("gpt_image_2_gmi");
+		expect(model.providerBackend).toBe("imarouter");
+		expect(model.endpoint).toBe("v1/images/generations");
+		expect(model.defaults?.model).toBe("gpt-image-2");
 	});
 
 	it("does not register the bare gpt_image_2 key post-rename", () => {
@@ -98,12 +107,12 @@ describe("text-to-image registry", () => {
 		expect(model.defaults?.num_images).toBe(1);
 	});
 
-	it("FAL and GMI variants are distinct, symmetric entries", () => {
+	it("FAL and default GPT Image 2 variants are distinct entries", () => {
 		const fal = ModelRegistry.get("gpt_image_2_fal");
-		const gmi = ModelRegistry.get("gpt_image_2_gmi");
+		const ima = ModelRegistry.get("gpt_image_2_ima");
 		expect(fal.providerBackend).toBe("fal");
-		expect(gmi.providerBackend).toBe("gmi");
-		expect(fal.endpoint).not.toBe(gmi.endpoint);
-		expect(fal.provider).not.toBe(gmi.provider);
+		expect(ima.providerBackend).toBe("imarouter");
+		expect(fal.endpoint).not.toBe(ima.endpoint);
+		expect(fal.provider).not.toBe(ima.provider);
 	});
 });

--- a/qcut/electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts
+++ b/qcut/electron/native-pipeline/registry-data/__tests__/text-to-image.test.ts
@@ -59,7 +59,7 @@ describe("text-to-image registry", () => {
 		const model = ModelRegistry.get("gpt_image_2_gmi");
 		expect(model.name).toBe("GPT-Image-2 (GMI)");
 		expect(model.provider).toBe("OpenAI (via GMI)");
-		expect(model.endpoint).toBe("gpt-image-2");
+		expect(model.endpoint).toBe("gpt-image-2-generate");
 		expect(model.providerBackend).toBe("gmi");
 		expect(model.categories).toContain("text_to_image");
 		expect(model.categories).toContain("image_to_image");

--- a/qcut/electron/native-pipeline/registry-data/text-to-image.ts
+++ b/qcut/electron/native-pipeline/registry-data/text-to-image.ts
@@ -3,7 +3,7 @@
  * @module electron/native-pipeline/registry-data/text-to-image
  */
 
-import { ModelRegistry } from "../infra/registry.js";
+import { ModelRegistry, type ModelDefinitionInput } from "../infra/registry.js";
 
 /** Register all text-to-image models in the pipeline registry. */
 export function registerTextToImageModels(): void {
@@ -288,19 +288,20 @@ export function registerTextToImageModels(): void {
 		processingTime: 20,
 	});
 
-	// ── GMI Cloud Image Models ──────────────────────────────────
+	// ── IMA Router Image Models ──────────────────────────────────
 
-	ModelRegistry.register({
-		key: "gpt_image_2_gmi",
-		name: "GPT-Image-2 (GMI)",
-		provider: "OpenAI (via GMI)",
-		endpoint: "gpt-image-2-generate",
+	const gptImage2ImaModel = {
+		key: "gpt_image_2_ima",
+		name: "GPT-Image-2 (IMA Router)",
+		provider: "OpenAI (via IMA Router)",
+		endpoint: "v1/images/generations",
 		categories: ["text_to_image", "image_to_image"],
 		description:
-			"OpenAI GPT-Image-2 via GMI Cloud — photorealistic, strong prompt adherence, accurate in-image text",
+			"OpenAI GPT-Image-2 via IMA Router — photorealistic, strong prompt adherence, accurate in-image text",
 		pricing: { per_image: 0.042 },
 		aspectRatios: ["1:1", "3:2", "2:3"],
 		defaults: {
+			model: "gpt-image-2",
 			size: "1024x1024",
 			quality: "medium",
 			output_format: "png",
@@ -315,7 +316,16 @@ export function registerTextToImageModels(): void {
 		],
 		costEstimate: 0.042,
 		processingTime: 30,
-		providerBackend: "gmi",
+		providerBackend: "imarouter",
+	} satisfies ModelDefinitionInput;
+
+	ModelRegistry.register(gptImage2ImaModel);
+	ModelRegistry.register({
+		...gptImage2ImaModel,
+		key: "gpt_image_2_gmi",
+		name: "GPT-Image-2 (IMA Router, legacy GMI alias)",
+		description:
+			"Deprecated alias for gpt_image_2_ima; routes to OpenAI GPT-Image-2 via IMA Router",
 	});
 
 	ModelRegistry.register({

--- a/qcut/electron/native-pipeline/registry-data/text-to-image.ts
+++ b/qcut/electron/native-pipeline/registry-data/text-to-image.ts
@@ -294,7 +294,7 @@ export function registerTextToImageModels(): void {
 		key: "gpt_image_2_gmi",
 		name: "GPT-Image-2 (GMI)",
 		provider: "OpenAI (via GMI)",
-		endpoint: "gpt-image-2",
+		endpoint: "gpt-image-2-generate",
 		categories: ["text_to_image", "image_to_image"],
 		description:
 			"OpenAI GPT-Image-2 via GMI Cloud — photorealistic, strong prompt adherence, accurate in-image text",

--- a/qcut/electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts
@@ -46,17 +46,23 @@ beforeEach(() => {
 describe("ImageGeneratorAdapter — GPT Image 2", () => {
 	it("advertises GPT Image 2 models for flow image generation", () => {
 		expect(ImageGeneratorAdapter.getAvailableModels()).toContain(
+			"gpt_image_2_ima"
+		);
+		expect(ImageGeneratorAdapter.getAvailableModels()).toContain(
 			"gpt_image_2_gmi"
 		);
 		expect(ImageGeneratorAdapter.getAvailableModels()).toContain(
 			"gpt_image_2_fal"
 		);
 		expect(ImageGeneratorAdapter.getAvailableReferenceModels()).toContain(
-			"gpt_image_2_gmi"
+			"gpt_image_2_ima"
 		);
 		expect(ImageGeneratorAdapter.getAvailableReferenceModels()).toContain(
 			"gpt_image_2_fal"
 		);
+		expect(
+			ImageGeneratorAdapter.supportsReferenceImages("gpt_image_2_ima")
+		).toBe(true);
 		expect(
 			ImageGeneratorAdapter.supportsReferenceImages("gpt_image_2_gmi")
 		).toBe(true);
@@ -65,9 +71,9 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 		).toBe(true);
 	});
 
-	it("routes flow portrait/storyboard text generation through GMI GPT Image 2", async () => {
+	it("routes flow portrait/storyboard text generation through IMA Router GPT Image 2", async () => {
 		const adapter = new ImageGeneratorAdapter({
-			model: "gpt_image_2_gmi",
+			model: "gpt_image_2_ima",
 			output_dir: "/tmp/qcut-vimax",
 		});
 
@@ -77,9 +83,10 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 		});
 
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.provider).toBe("gmi");
-		expect(call.endpoint).toBe("gpt-image-2-generate");
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/images/generations");
 		expect(call.payload).toEqual({
+			model: "gpt-image-2",
 			prompt: "portrait of a brass space captain",
 			size: "1024x1536",
 			quality: "medium",
@@ -111,9 +118,38 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 		});
 	});
 
-	it("routes GMI reference generation through the GPT Image 2 edit endpoint", async () => {
+	it("routes the legacy gpt_image_2_gmi alias through IMA Router", async () => {
 		const adapter = new ImageGeneratorAdapter({
-			reference_model: "gpt_image_2_gmi",
+			model: "gpt_image_2_gmi",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generate("portrait of a brass space captain", {
+			aspect_ratio: "1:1",
+			output_path: "/tmp/qcut-vimax/legacy.png",
+		});
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/images/generations");
+		expect(call.payload.model).toBe("gpt-image-2");
+	});
+
+	it("rejects unknown text-to-image models instead of falling back", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			model: "gpt_image_2_typo",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await expect(adapter.generate("portrait")).rejects.toThrow(
+			"Unknown image model 'gpt_image_2_typo'"
+		);
+		expect(mockedCallModelApi.mock.calls).toHaveLength(0);
+	});
+
+	it("routes IMA Router reference generation through the GPT Image 2 image endpoint", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			reference_model: "gpt_image_2_ima",
 			output_dir: "/tmp/qcut-vimax",
 		});
 
@@ -121,18 +157,19 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 			"keep identity, change outfit to a red jacket",
 			"https://example.com/portrait.png",
 			{
-				model: "gpt_image_2_gmi",
+				model: "gpt_image_2_ima",
 				aspect_ratio: "1:1",
 				output_path: "/tmp/qcut-vimax/gmi-ref.png",
 			}
 		);
 
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.provider).toBe("gmi");
-		expect(call.endpoint).toBe("gpt-image-2-edit");
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/images/generations");
 		expect(call.payload).toEqual({
+			model: "gpt-image-2",
 			prompt: "keep identity, change outfit to a red jacket",
-			image: ["https://example.com/portrait.png"],
+			images: ["https://example.com/portrait.png"],
 			size: "1024x1024",
 			quality: "medium",
 			output_format: "png",
@@ -168,9 +205,21 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 		});
 	});
 
+	it("rejects unknown reference models instead of falling back", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			reference_model: "gpt_image_2_typo",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await expect(
+			adapter.generateWithReference("portrait", "https://example.com/ref.png")
+		).rejects.toThrow("Unknown reference image model 'gpt_image_2_typo'");
+		expect(mockedCallModelApi.mock.calls).toHaveLength(0);
+	});
+
 	it("uploads local GPT Image 2 reference images before edit calls", async () => {
 		const adapter = new ImageGeneratorAdapter({
-			reference_model: "gpt_image_2_gmi",
+			reference_model: "gpt_image_2_ima",
 			output_dir: "/tmp/qcut-vimax",
 		});
 
@@ -178,7 +227,7 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 			"make a matching product still",
 			"/tmp/local-portrait.png",
 			{
-				model: "gpt_image_2_gmi",
+				model: "gpt_image_2_ima",
 				output_path: "/tmp/qcut-vimax/local-ref.png",
 			}
 		);
@@ -187,7 +236,7 @@ describe("ImageGeneratorAdapter — GPT Image 2", () => {
 			"/tmp/local-portrait.png"
 		);
 		const call = mockedCallModelApi.mock.calls[0][0];
-		expect(call.payload.image).toEqual([
+		expect(call.payload.images).toEqual([
 			"https://cdn.example.com/uploaded-ref.png",
 		]);
 	});

--- a/qcut/electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../infra/api-caller.js", () => ({
+	callModelApi: vi.fn(),
+	downloadOutput: vi.fn(async (_url: string, dest: string) => dest),
+	uploadToFalStorage: vi.fn(),
+}));
+
+vi.mock("../../../infra/proxy-client.js", () => ({
+	isProxyAvailable: vi.fn(async () => true),
+}));
+
+import { callModelApi, uploadToFalStorage } from "../../../infra/api-caller.js";
+import { ImageGeneratorAdapter } from "../image-adapter.js";
+
+type ApiCall = {
+	endpoint: string;
+	provider: string;
+	payload: Record<string, unknown>;
+};
+
+const mockedCallModelApi = callModelApi as unknown as {
+	mockResolvedValue: (value: unknown) => void;
+	mock: { calls: Array<[ApiCall]> };
+};
+
+const mockedUploadToFalStorage = uploadToFalStorage as unknown as {
+	mockResolvedValue: (value: unknown) => void;
+	mock: { calls: Array<[string]> };
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockedCallModelApi.mockResolvedValue({
+		success: true,
+		outputUrl: "https://cdn.example.com/out.png",
+		duration: 1,
+		data: {},
+	});
+	mockedUploadToFalStorage.mockResolvedValue({
+		success: true,
+		url: "https://cdn.example.com/uploaded-ref.png",
+	});
+});
+
+describe("ImageGeneratorAdapter — GPT Image 2", () => {
+	it("advertises GPT Image 2 models for flow image generation", () => {
+		expect(ImageGeneratorAdapter.getAvailableModels()).toContain(
+			"gpt_image_2_gmi"
+		);
+		expect(ImageGeneratorAdapter.getAvailableModels()).toContain(
+			"gpt_image_2_fal"
+		);
+		expect(ImageGeneratorAdapter.getAvailableReferenceModels()).toContain(
+			"gpt_image_2_gmi"
+		);
+		expect(ImageGeneratorAdapter.getAvailableReferenceModels()).toContain(
+			"gpt_image_2_fal"
+		);
+		expect(
+			ImageGeneratorAdapter.supportsReferenceImages("gpt_image_2_gmi")
+		).toBe(true);
+		expect(
+			ImageGeneratorAdapter.supportsReferenceImages("gpt_image_2_fal")
+		).toBe(true);
+	});
+
+	it("routes flow portrait/storyboard text generation through GMI GPT Image 2", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			model: "gpt_image_2_gmi",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generate("portrait of a brass space captain", {
+			aspect_ratio: "9:16",
+			output_path: "/tmp/qcut-vimax/gmi.png",
+		});
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("gmi");
+		expect(call.endpoint).toBe("gpt-image-2-generate");
+		expect(call.payload).toEqual({
+			prompt: "portrait of a brass space captain",
+			size: "1024x1536",
+			quality: "medium",
+			output_format: "png",
+			n: 1,
+		});
+	});
+
+	it("routes flow portrait/storyboard text generation through FAL GPT Image 2", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			model: "gpt_image_2_fal",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generate("wide storyboard frame of a quiet train station", {
+			aspect_ratio: "16:9",
+			output_path: "/tmp/qcut-vimax/fal.png",
+		});
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("fal");
+		expect(call.endpoint).toBe("openai/gpt-image-2");
+		expect(call.payload).toEqual({
+			prompt: "wide storyboard frame of a quiet train station",
+			image_size: "landscape_16_9",
+			quality: "high",
+			output_format: "png",
+			num_images: 1,
+		});
+	});
+
+	it("routes GMI reference generation through the GPT Image 2 edit endpoint", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			reference_model: "gpt_image_2_gmi",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generateWithReference(
+			"keep identity, change outfit to a red jacket",
+			"https://example.com/portrait.png",
+			{
+				model: "gpt_image_2_gmi",
+				aspect_ratio: "1:1",
+				output_path: "/tmp/qcut-vimax/gmi-ref.png",
+			}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("gmi");
+		expect(call.endpoint).toBe("gpt-image-2-edit");
+		expect(call.payload).toEqual({
+			prompt: "keep identity, change outfit to a red jacket",
+			image: ["https://example.com/portrait.png"],
+			size: "1024x1024",
+			quality: "medium",
+			output_format: "png",
+			n: 1,
+		});
+	});
+
+	it("routes FAL reference generation through the GPT Image 2 edit endpoint", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			reference_model: "gpt_image_2_fal",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generateWithReference(
+			"make this storyboard image rainy",
+			"https://example.com/shot.png",
+			{
+				model: "gpt_image_2_fal",
+				output_path: "/tmp/qcut-vimax/fal-ref.png",
+			}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("fal");
+		expect(call.endpoint).toBe("openai/gpt-image-2/edit");
+		expect(call.payload).toEqual({
+			prompt: "make this storyboard image rainy",
+			image_urls: ["https://example.com/shot.png"],
+			image_size: "auto",
+			quality: "high",
+			num_images: 1,
+			output_format: "png",
+		});
+	});
+
+	it("uploads local GPT Image 2 reference images before edit calls", async () => {
+		const adapter = new ImageGeneratorAdapter({
+			reference_model: "gpt_image_2_gmi",
+			output_dir: "/tmp/qcut-vimax",
+		});
+
+		await adapter.generateWithReference(
+			"make a matching product still",
+			"/tmp/local-portrait.png",
+			{
+				model: "gpt_image_2_gmi",
+				output_path: "/tmp/qcut-vimax/local-ref.png",
+			}
+		);
+
+		expect(mockedUploadToFalStorage.mock.calls[0][0]).toBe(
+			"/tmp/local-portrait.png"
+		);
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.payload.image).toEqual([
+			"https://cdn.example.com/uploaded-ref.png",
+		]);
+	});
+});

--- a/qcut/electron/native-pipeline/vimax/adapters/image-adapter.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/image-adapter.ts
@@ -14,7 +14,11 @@ import {
 	type AdapterConfig,
 	createAdapterConfig,
 } from "./base-adapter.js";
-import { callModelApi, downloadOutput } from "../../infra/api-caller.js";
+import {
+	callModelApi,
+	downloadOutput,
+	uploadToFalStorage,
+} from "../../infra/api-caller.js";
 import { isProxyAvailable } from "../../infra/proxy-client.js";
 import type { ImageOutput } from "../types/output.js";
 import { createImageOutput } from "../types/output.js";
@@ -53,12 +57,14 @@ const MODEL_MAP: Record<string, string> = {
 	imagen4: "google/imagen-4",
 	nano_banana_pro: "fal-ai/nano-banana-pro",
 	nano_banana_2: "fal-ai/nano-banana-2",
+	gpt_image_2_fal: "openai/gpt-image-2",
 	gpt_image_1_5: "fal-ai/gpt-image-1-5",
 	seedream_v3: "fal-ai/seedream-v3",
 };
 
 /** Model → GMI endpoint for text-to-image. */
 const GMI_MODEL_MAP: Record<string, string> = {
+	gpt_image_2_gmi: "gpt-image-2-generate",
 	gmi_gemini_3_pro_image: "gemini-3-pro-image-preview",
 	gmi_gemini_31_flash_image: "gemini-3.1-flash-image-preview",
 	gmi_seedream_4: "seedream-4.0",
@@ -69,6 +75,8 @@ const GMI_MODEL_MAP: Record<string, string> = {
 const REFERENCE_MODEL_MAP: Record<string, string> = {
 	nano_banana_pro: "fal-ai/nano-banana-pro/edit",
 	nano_banana_2: "fal-ai/nano-banana-2/edit",
+	gpt_image_2_fal: "openai/gpt-image-2/edit",
+	gpt_image_2_gmi: "gpt-image-2-edit",
 	flux_kontext: "fal-ai/flux-kontext/max/image-to-image",
 	flux_redux: "fal-ai/flux-pro/v1.1-ultra/redux",
 	seededit_v3: "fal-ai/seededit-v3",
@@ -94,6 +102,8 @@ const COST_MAP: Record<string, number> = {
 	imagen4: 0.004,
 	nano_banana_pro: 0.002,
 	nano_banana_2: 0.08,
+	gpt_image_2_fal: 0.042,
+	gpt_image_2_gmi: 0.042,
 	gmi_gemini_3_pro_image: 0.04,
 	gmi_gemini_31_flash_image: 0.02,
 	gmi_seedream_4: 0.02,
@@ -102,6 +112,8 @@ const COST_MAP: Record<string, number> = {
 	seedream_v3: 0.002,
 	nano_banana_pro_edit: 0.15,
 	nano_banana_2_edit: 0.08,
+	gpt_image_2_fal_edit: 0.042,
+	gpt_image_2_gmi_edit: 0.042,
 	flux_kontext: 0.025,
 	flux_redux: 0.02,
 	seededit_v3: 0.025,
@@ -115,6 +127,8 @@ const MAX_STEPS_MAP: Record<string, number> = {
 	imagen4: 50,
 	nano_banana_pro: 50,
 	nano_banana_2: 50,
+	gpt_image_2_fal: 50,
+	gpt_image_2_gmi: 50,
 	gpt_image_1_5: 50,
 	seedream_v3: 50,
 	flux_kontext: 28,
@@ -132,6 +146,38 @@ function aspectToSize(aspectRatio: string): string {
 		"3:4": "portrait_4_3",
 	};
 	return sizes[aspectRatio] ?? "square";
+}
+
+function aspectToFalGptSize(aspectRatio: string): string {
+	return aspectRatio === "1:1" ? "square_hd" : aspectToSize(aspectRatio);
+}
+
+function aspectToGmiGptSize(aspectRatio: string): string {
+	const sizes: Record<string, string> = {
+		"1:1": "1024x1024",
+		"16:9": "1536x1024",
+		"9:16": "1024x1536",
+		"3:2": "1536x1024",
+		"2:3": "1024x1536",
+	};
+	return sizes[aspectRatio] ?? "1024x1024";
+}
+
+function isRemoteUrl(url: string): boolean {
+	return /^https?:\/\//i.test(url);
+}
+
+async function resolveReferenceImageUrl({
+	referenceImage,
+}: {
+	referenceImage: string;
+}): Promise<string> {
+	if (isRemoteUrl(referenceImage)) return referenceImage;
+	const upload = await uploadToFalStorage(referenceImage);
+	if (!upload.success || !upload.url) {
+		throw new Error(upload.error || "Failed to upload reference image");
+	}
+	return upload.url;
 }
 
 export interface ModelInfo {
@@ -152,12 +198,12 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 
 	/** Returns list of supported text-to-image model keys. */
 	static getAvailableModels(): string[] {
-		return Object.keys(MODEL_MAP);
+		return [...Object.keys(MODEL_MAP), ...Object.keys(GMI_MODEL_MAP)];
 	}
 
 	/** Returns metadata for a specific model. */
 	static getModelInfo(model: string): ModelInfo | undefined {
-		const endpoint = MODEL_MAP[model];
+		const endpoint = MODEL_MAP[model] ?? GMI_MODEL_MAP[model];
 		if (!endpoint) return;
 		return {
 			key: model,
@@ -227,7 +273,23 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 			: (MODEL_MAP[model] ?? MODEL_MAP.flux_dev);
 
 		let payload: Record<string, unknown>;
-		if (isGmi) {
+		if (model === "gpt_image_2_gmi") {
+			payload = {
+				prompt,
+				size: aspectToGmiGptSize(aspectRatio),
+				quality: "medium",
+				output_format: "png",
+				n: 1,
+			};
+		} else if (model === "gpt_image_2_fal") {
+			payload = {
+				prompt,
+				image_size: aspectToFalGptSize(aspectRatio),
+				quality: "high",
+				output_format: "png",
+				num_images: 1,
+			};
+		} else if (isGmi) {
 			payload = {
 				prompt,
 				aspect_ratio: aspectRatio,
@@ -316,13 +378,39 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		const startTime = Date.now();
 		const endpoint =
 			REFERENCE_MODEL_MAP[model] ?? REFERENCE_MODEL_MAP.nano_banana_pro;
+		const isGmi = model === "gpt_image_2_gmi";
+		const provider = isGmi ? "gmi" : "fal";
+		const resolvedReferenceImage =
+			model === "gpt_image_2_gmi" || model === "gpt_image_2_fal"
+				? await resolveReferenceImageUrl({
+						referenceImage,
+					})
+				: referenceImage;
 
 		let payload: Record<string, unknown>;
 
-		if (ARRAY_IMAGE_MODELS.has(model)) {
+		if (model === "gpt_image_2_gmi") {
 			payload = {
 				prompt,
-				image_urls: [referenceImage],
+				image: [resolvedReferenceImage],
+				size: aspectToGmiGptSize(aspectRatio),
+				quality: "medium",
+				output_format: "png",
+				n: 1,
+			};
+		} else if (model === "gpt_image_2_fal") {
+			payload = {
+				prompt,
+				image_urls: [resolvedReferenceImage],
+				image_size: "auto",
+				quality: "high",
+				num_images: 1,
+				output_format: "png",
+			};
+		} else if (ARRAY_IMAGE_MODELS.has(model)) {
+			payload = {
+				prompt,
+				image_urls: [resolvedReferenceImage],
 				aspect_ratio: aspectRatio || "16:9",
 				num_images: 1,
 			};
@@ -331,7 +419,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 			const numSteps = Math.min(this.config.num_inference_steps, maxSteps);
 			payload = {
 				prompt,
-				image_url: referenceImage,
+				image_url: resolvedReferenceImage,
 				strength: refStrength,
 				image_size: aspectToSize(aspectRatio),
 				num_inference_steps: numSteps,
@@ -342,7 +430,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		const result = await callModelApi({
 			endpoint,
 			payload,
-			provider: "fal",
+			provider,
 		});
 
 		const generationTime = (Date.now() - startTime) / 1000;
@@ -361,7 +449,12 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 			await downloadOutput(result.outputUrl, imagePath);
 		}
 
-		const costKey = ARRAY_IMAGE_MODELS.has(model) ? `${model}_edit` : model;
+		const costKey =
+			ARRAY_IMAGE_MODELS.has(model) ||
+			model === "gpt_image_2_gmi" ||
+			model === "gpt_image_2_fal"
+				? `${model}_edit`
+				: model;
 
 		return createImageOutput({
 			image_path: imagePath,
@@ -374,7 +467,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 			cost: COST_MAP[costKey] ?? COST_MAP[model] ?? 0.025,
 			metadata: {
 				aspect_ratio: aspectRatio,
-				reference_image: referenceImage,
+				reference_image: resolvedReferenceImage,
 				reference_strength: refStrength,
 				with_reference: true,
 			},

--- a/qcut/electron/native-pipeline/vimax/adapters/image-adapter.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/image-adapter.ts
@@ -64,11 +64,16 @@ const MODEL_MAP: Record<string, string> = {
 
 /** Model → GMI endpoint for text-to-image. */
 const GMI_MODEL_MAP: Record<string, string> = {
-	gpt_image_2_gmi: "gpt-image-2-generate",
 	gmi_gemini_3_pro_image: "gemini-3-pro-image-preview",
 	gmi_gemini_31_flash_image: "gemini-3.1-flash-image-preview",
 	gmi_seedream_4: "seedream-4.0",
 	gmi_seedream_5_lite: "seedream-5.0-lite",
+};
+
+/** Model → IMA Router endpoint for text-to-image. */
+const IMAROUTER_MODEL_MAP: Record<string, string> = {
+	gpt_image_2_ima: "v1/images/generations",
+	gpt_image_2_gmi: "v1/images/generations",
 };
 
 /** Model → FAL endpoint for image-to-image with reference. */
@@ -76,7 +81,8 @@ const REFERENCE_MODEL_MAP: Record<string, string> = {
 	nano_banana_pro: "fal-ai/nano-banana-pro/edit",
 	nano_banana_2: "fal-ai/nano-banana-2/edit",
 	gpt_image_2_fal: "openai/gpt-image-2/edit",
-	gpt_image_2_gmi: "gpt-image-2-edit",
+	gpt_image_2_ima: "v1/images/generations",
+	gpt_image_2_gmi: "v1/images/generations",
 	flux_kontext: "fal-ai/flux-kontext/max/image-to-image",
 	flux_redux: "fal-ai/flux-pro/v1.1-ultra/redux",
 	seededit_v3: "fal-ai/seededit-v3",
@@ -103,6 +109,7 @@ const COST_MAP: Record<string, number> = {
 	nano_banana_pro: 0.002,
 	nano_banana_2: 0.08,
 	gpt_image_2_fal: 0.042,
+	gpt_image_2_ima: 0.042,
 	gpt_image_2_gmi: 0.042,
 	gmi_gemini_3_pro_image: 0.04,
 	gmi_gemini_31_flash_image: 0.02,
@@ -113,6 +120,7 @@ const COST_MAP: Record<string, number> = {
 	nano_banana_pro_edit: 0.15,
 	nano_banana_2_edit: 0.08,
 	gpt_image_2_fal_edit: 0.042,
+	gpt_image_2_ima_edit: 0.042,
 	gpt_image_2_gmi_edit: 0.042,
 	flux_kontext: 0.025,
 	flux_redux: 0.02,
@@ -128,6 +136,7 @@ const MAX_STEPS_MAP: Record<string, number> = {
 	nano_banana_pro: 50,
 	nano_banana_2: 50,
 	gpt_image_2_fal: 50,
+	gpt_image_2_ima: 50,
 	gpt_image_2_gmi: 50,
 	gpt_image_1_5: 50,
 	seedream_v3: 50,
@@ -161,6 +170,73 @@ function aspectToGmiGptSize(aspectRatio: string): string {
 		"2:3": "1024x1536",
 	};
 	return sizes[aspectRatio] ?? "1024x1024";
+}
+
+function isImaRouterGptImage2(model: string): boolean {
+	return model === "gpt_image_2_ima" || model === "gpt_image_2_gmi";
+}
+
+type ImageProvider = "fal" | "gmi" | "imarouter";
+
+function resolveTextToImageModel({ model }: { model: string }): {
+	endpoint: string;
+	provider: ImageProvider;
+	isGmi: boolean;
+	isImaRouter: boolean;
+} {
+	const falEndpoint = MODEL_MAP[model];
+	if (falEndpoint) {
+		return {
+			endpoint: falEndpoint,
+			provider: "fal",
+			isGmi: false,
+			isImaRouter: false,
+		};
+	}
+
+	const gmiEndpoint = GMI_MODEL_MAP[model];
+	if (gmiEndpoint) {
+		return {
+			endpoint: gmiEndpoint,
+			provider: "gmi",
+			isGmi: true,
+			isImaRouter: false,
+		};
+	}
+
+	const imaRouterEndpoint = IMAROUTER_MODEL_MAP[model];
+	if (imaRouterEndpoint) {
+		return {
+			endpoint: imaRouterEndpoint,
+			provider: "imarouter",
+			isGmi: false,
+			isImaRouter: true,
+		};
+	}
+
+	throw new Error(
+		`Unknown image model '${model}'. Run 'qcut system models --json' to list supported image models.`
+	);
+}
+
+function resolveReferenceImageModel({ model }: { model: string }): {
+	endpoint: string;
+	provider: ImageProvider;
+	isImaRouter: boolean;
+} {
+	const endpoint = REFERENCE_MODEL_MAP[model];
+	if (!endpoint) {
+		throw new Error(
+			`Unknown reference image model '${model}'. Run 'qcut system models --json' to list supported image models.`
+		);
+	}
+
+	const isImaRouter = isImaRouterGptImage2(model);
+	return {
+		endpoint,
+		provider: isImaRouter ? "imarouter" : "fal",
+		isImaRouter,
+	};
 }
 
 function isRemoteUrl(url: string): boolean {
@@ -198,12 +274,17 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 
 	/** Returns list of supported text-to-image model keys. */
 	static getAvailableModels(): string[] {
-		return [...Object.keys(MODEL_MAP), ...Object.keys(GMI_MODEL_MAP)];
+		return [
+			...Object.keys(MODEL_MAP),
+			...Object.keys(GMI_MODEL_MAP),
+			...Object.keys(IMAROUTER_MODEL_MAP),
+		];
 	}
 
 	/** Returns metadata for a specific model. */
 	static getModelInfo(model: string): ModelInfo | undefined {
-		const endpoint = MODEL_MAP[model] ?? GMI_MODEL_MAP[model];
+		const endpoint =
+			MODEL_MAP[model] ?? GMI_MODEL_MAP[model] ?? IMAROUTER_MODEL_MAP[model];
 		if (!endpoint) return;
 		return {
 			key: model,
@@ -226,12 +307,14 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		// only needs to know whether SOMETHING upstream will work.
 		const falKey = process.env.FAL_KEY ?? process.env.FAL_API_KEY ?? "";
 		const gmiKey = process.env.GMI_API_KEY ?? "";
-		const hasLocalKey = falKey.length > 0 || gmiKey.length > 0;
+		const imaRouterKey = process.env.IMAROUTER_API_KEY ?? "";
+		const hasLocalKey =
+			falKey.length > 0 || gmiKey.length > 0 || imaRouterKey.length > 0;
 		const hasProxy = await isProxyAvailable().catch(() => false);
 		this._hasApiKey = hasLocalKey || hasProxy;
 		if (!this._hasApiKey) {
 			console.warn(
-				"[vimax.image] No FAL_KEY/GMI_API_KEY and no proxy session — using mock mode"
+				"[vimax.image] No FAL_KEY/GMI_API_KEY/IMAROUTER_API_KEY and no proxy session — using mock mode"
 			);
 		}
 		return true;
@@ -256,6 +339,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 
 		const model = options?.model ?? this.config.model;
 		const aspectRatio = options?.aspect_ratio ?? this.config.aspect_ratio;
+		const resolvedModel = resolveTextToImageModel({ model });
 
 		if (!this._hasApiKey) {
 			return this._mockGenerate(
@@ -267,14 +351,12 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		}
 
 		const startTime = Date.now();
-		const isGmi = model in GMI_MODEL_MAP;
-		const endpoint = isGmi
-			? GMI_MODEL_MAP[model]
-			: (MODEL_MAP[model] ?? MODEL_MAP.flux_dev);
+		const { endpoint, isGmi, isImaRouter, provider } = resolvedModel;
 
 		let payload: Record<string, unknown>;
-		if (model === "gpt_image_2_gmi") {
+		if (isImaRouterGptImage2(model)) {
 			payload = {
+				model: "gpt-image-2",
 				prompt,
 				size: aspectToGmiGptSize(aspectRatio),
 				quality: "medium",
@@ -317,7 +399,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		const result = await callModelApi({
 			endpoint,
 			payload,
-			provider: isGmi ? "gmi" : "fal",
+			provider,
 		});
 
 		const generationTime = (Date.now() - startTime) / 1000;
@@ -363,6 +445,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		const aspectRatio = options?.aspect_ratio ?? this.config.aspect_ratio;
 		const refStrength =
 			options?.reference_strength ?? this.config.reference_strength;
+		const resolvedModel = resolveReferenceImageModel({ model });
 
 		if (!this._hasApiKey) {
 			return this._mockGenerateWithReference(
@@ -376,12 +459,9 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 		}
 
 		const startTime = Date.now();
-		const endpoint =
-			REFERENCE_MODEL_MAP[model] ?? REFERENCE_MODEL_MAP.nano_banana_pro;
-		const isGmi = model === "gpt_image_2_gmi";
-		const provider = isGmi ? "gmi" : "fal";
+		const { endpoint, isImaRouter, provider } = resolvedModel;
 		const resolvedReferenceImage =
-			model === "gpt_image_2_gmi" || model === "gpt_image_2_fal"
+			isImaRouterGptImage2(model) || model === "gpt_image_2_fal"
 				? await resolveReferenceImageUrl({
 						referenceImage,
 					})
@@ -389,10 +469,11 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 
 		let payload: Record<string, unknown>;
 
-		if (model === "gpt_image_2_gmi") {
+		if (isImaRouterGptImage2(model)) {
 			payload = {
+				model: "gpt-image-2",
 				prompt,
-				image: [resolvedReferenceImage],
+				images: [resolvedReferenceImage],
 				size: aspectToGmiGptSize(aspectRatio),
 				quality: "medium",
 				output_format: "png",
@@ -451,7 +532,7 @@ export class ImageGeneratorAdapter extends BaseAdapter<string, ImageOutput> {
 
 		const costKey =
 			ARRAY_IMAGE_MODELS.has(model) ||
-			model === "gpt_image_2_gmi" ||
+			isImaRouterGptImage2(model) ||
 			model === "gpt_image_2_fal"
 				? `${model}_edit`
 				: model;

--- a/qcut/electron/native-pipeline/vimax/agents/__tests__/character-portraits.test.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/__tests__/character-portraits.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { AgentResult } from "../base-agent.js";
+import { CharacterPortraitsGenerator } from "../character-portraits.js";
+import type {
+	CharacterInNovel,
+	CharacterPortrait,
+} from "../../types/character.js";
+
+function character({ name }: { name: string }): CharacterInNovel {
+	return {
+		name,
+		description: `${name} description`,
+		appearance: `${name} appearance`,
+		role: "supporting",
+		relationships: [],
+	};
+}
+
+function wait({ ms }: { ms: number }): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("CharacterPortraitsGenerator", () => {
+	it("generates character portraits concurrently up to the configured limit", async () => {
+		const generator = new CharacterPortraitsGenerator({ concurrency: 2 });
+		const delays: Record<string, number> = { Alice: 60, Bob: 20, Cleo: 10 };
+		let active = 0;
+		let maxActive = 0;
+
+		generator.process = async (
+			input: CharacterInNovel
+		): Promise<AgentResult<CharacterPortrait>> => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			await wait({ ms: delays[input.name] ?? 1 });
+			active--;
+			return {
+				success: true,
+				result: {
+					character_name: input.name,
+					description: "",
+					front_view: `/tmp/${input.name}.png`,
+				},
+				metadata: { cost: 1 },
+			};
+		};
+
+		const result = await generator.generateBatch([
+			character({ name: "Alice" }),
+			character({ name: "Bob" }),
+			character({ name: "Cleo" }),
+		]);
+
+		expect(result.success).toBe(true);
+		expect(maxActive).toBe(2);
+		expect(result.metadata.concurrency).toBe(2);
+		expect(Object.keys(result.result ?? {})).toEqual(["Alice", "Bob", "Cleo"]);
+		expect(result.metadata.cost).toBe(3);
+	});
+
+	it("defaults portrait generation concurrency to three characters", async () => {
+		const generator = new CharacterPortraitsGenerator();
+		let active = 0;
+		let maxActive = 0;
+
+		generator.process = async (
+			input: CharacterInNovel
+		): Promise<AgentResult<CharacterPortrait>> => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			await wait({ ms: 20 });
+			active--;
+			return {
+				success: true,
+				result: {
+					character_name: input.name,
+					description: "",
+					front_view: `/tmp/${input.name}.png`,
+				},
+				metadata: { cost: 1 },
+			};
+		};
+
+		await generator.generateBatch([
+			character({ name: "Alice" }),
+			character({ name: "Bob" }),
+			character({ name: "Cleo" }),
+			character({ name: "Dax" }),
+		]);
+
+		expect(maxActive).toBe(3);
+	});
+});

--- a/qcut/electron/native-pipeline/vimax/agents/character-portraits.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/character-portraits.ts
@@ -35,6 +35,7 @@ export interface PortraitsGeneratorConfig extends AgentConfig {
 	style: string;
 	aspect_ratio: string;
 	output_dir: string;
+	concurrency: number;
 }
 
 /** Create a {@link PortraitsGeneratorConfig} with sensible defaults. */
@@ -52,6 +53,7 @@ export function createPortraitsGeneratorConfig(
 		style: "detailed character portrait, natural lighting, photorealistic",
 		aspect_ratio: "9:16",
 		output_dir: "media/generated/vimax/portraits",
+		concurrency: 3,
 		...partial,
 	};
 }
@@ -82,6 +84,17 @@ function safeSlug(value: string): string {
 	return safe || "unknown";
 }
 
+function normalizeConcurrency({
+	concurrency,
+	itemCount,
+}: {
+	concurrency: number;
+	itemCount: number;
+}): number {
+	const normalized = Number.isFinite(concurrency) ? Math.trunc(concurrency) : 3;
+	return Math.max(1, Math.min(normalized, itemCount));
+}
+
 /** Agent that generates multi-angle character portraits for visual consistency. */
 export class CharacterPortraitsGenerator extends BaseAgent<
 	CharacterInNovel,
@@ -90,12 +103,23 @@ export class CharacterPortraitsGenerator extends BaseAgent<
 	declare config: PortraitsGeneratorConfig;
 	private _imageAdapter: ImageGeneratorAdapter | null = null;
 	private _llm: LLMAdapter | null = null;
+	private _adapterInit: Promise<void> | null = null;
 
 	constructor(config?: Partial<PortraitsGeneratorConfig>) {
 		super(createPortraitsGeneratorConfig(config));
 	}
 
 	private async _ensureAdapters(): Promise<void> {
+		if (!this._adapterInit) {
+			this._adapterInit = this._initializeAdapters().catch((err: unknown) => {
+				this._adapterInit = null;
+				throw err;
+			});
+		}
+		await this._adapterInit;
+	}
+
+	private async _initializeAdapters(): Promise<void> {
 		if (!this._imageAdapter) {
 			this._imageAdapter = new ImageGeneratorAdapter({
 				model: this.config.image_model,
@@ -220,12 +244,39 @@ export class CharacterPortraitsGenerator extends BaseAgent<
 	async generateBatch(
 		characters: CharacterInNovel[]
 	): Promise<AgentResult<Record<string, CharacterPortrait>>> {
+		if (characters.length === 0) {
+			return agentOk(
+				{},
+				{ cost: 0, errors: undefined, concurrency: 0, characters: 0 }
+			);
+		}
+
+		const results = new Array<AgentResult<CharacterPortrait>>(
+			characters.length
+		);
+		const concurrency = normalizeConcurrency({
+			concurrency: this.config.concurrency,
+			itemCount: characters.length,
+		});
+		let nextIndex = 0;
+
+		const runNext = async (): Promise<void> => {
+			const index = nextIndex++;
+			if (index >= characters.length) return;
+			results[index] = await this.process(characters[index]);
+			return runNext();
+		};
+
+		const workers = Array.from({ length: concurrency }, () => runNext());
+		await Promise.all(workers);
+
 		const portraits: Record<string, CharacterPortrait> = {};
 		let totalCost = 0;
 		const errors: string[] = [];
 
-		for (const char of characters) {
-			const result = await this.process(char);
+		for (let index = 0; index < characters.length; index++) {
+			const char = characters[index];
+			const result = results[index];
 			if (result.success && result.result) {
 				portraits[char.name] = result.result;
 				totalCost += (result.metadata.cost as number) ?? 0;
@@ -242,6 +293,7 @@ export class CharacterPortraitsGenerator extends BaseAgent<
 
 		return agentOk(portraits, {
 			cost: totalCost,
+			concurrency,
 			errors: errors.length > 0 ? errors : undefined,
 		});
 	}

--- a/qcut/packages/license-server/src/routes/agent.test.ts
+++ b/qcut/packages/license-server/src/routes/agent.test.ts
@@ -47,6 +47,8 @@ const {
 } = await import("./agent");
 
 const ORIGINAL_ENV = { ...process.env };
+const DEFAULT_PINNED_QCUT_IMAGE =
+	"ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748";
 
 function resetEnv(): void {
 	for (const key of Object.keys(process.env)) {
@@ -379,6 +381,48 @@ describe("POST /api/agent/sessions/:sessionId/end", () => {
 });
 
 describe("POST /api/agent/sessions/:sessionId/pty-token", () => {
+	it("uses the pinned default Daytona image when no override is configured", async () => {
+		process.env.DAYTONA_API_KEY = "daytona-test";
+		process.env.RELAY_SIGNING_SECRET = "relay-secret";
+		delete process.env.QCUT_IMAGE_TAG;
+		mockSelectRowsOnce({ rows: [makeAgentSession()] });
+		mockSelectWhereRowsOnce({ rows: [] });
+		const { set } = mockUpdateChain();
+		daytonaMocks.createSandbox.mockResolvedValue({
+			data: { id: "sandbox-1", state: "starting" },
+		});
+
+		const res = await buildApp().request(
+			"/api/agent/sessions/agent-session-1/pty-token",
+			{
+				method: "POST",
+				headers: jsonHeaders(),
+				body: JSON.stringify({}),
+			}
+		);
+
+		const body = await res.json();
+		expect(res.status, JSON.stringify(body)).toBe(202);
+		expect(daytonaMocks.ImageBase).toHaveBeenCalledWith(
+			DEFAULT_PINNED_QCUT_IMAGE
+		);
+		expect(daytonaMocks.createSandbox).toHaveBeenCalledWith(
+			expect.objectContaining({
+				buildInfo: {
+					dockerfileContent: `FROM ${DEFAULT_PINNED_QCUT_IMAGE}\n`,
+				},
+			}),
+			undefined,
+			{ timeout: 45_000 }
+		);
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerSessionId: "sandbox-1",
+				imageTag: DEFAULT_PINNED_QCUT_IMAGE,
+			})
+		);
+	});
+
 	it("starts a Daytona sandbox without waiting for the cold image to boot", async () => {
 		process.env.DAYTONA_API_KEY = "daytona-test";
 		process.env.RELAY_SIGNING_SECRET = "relay-secret";

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -30,7 +30,8 @@ const TERMINAL_INPUT_DIR = "/tmp/qcut-input";
 const TERMINAL_OUTPUT_DIR = "/tmp/qcut-output";
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9_\-./:=,@+]+$/;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
-const DEFAULT_DAYTONA_IMAGE = "ghcr.io/quriosity-agent/qcut-cli:latest";
+const DEFAULT_DAYTONA_IMAGE =
+	"ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748";
 const TEXT_ARTIFACT_KINDS = new Set(["json", "log"]);
 const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
 	".gif": "image/gif",

--- a/qcut/packages/license-server/src/routes/agent.ts
+++ b/qcut/packages/license-server/src/routes/agent.ts
@@ -30,8 +30,7 @@ const TERMINAL_INPUT_DIR = "/tmp/qcut-input";
 const TERMINAL_OUTPUT_DIR = "/tmp/qcut-output";
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9_\-./:=,@+]+$/;
 const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
-const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
+const DEFAULT_DAYTONA_IMAGE = "ghcr.io/quriosity-agent/qcut-cli:latest";
 const TEXT_ARTIFACT_KINDS = new Set(["json", "log"]);
 const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
 	".gif": "image/gif",
@@ -964,7 +963,7 @@ async function downloadAgentSessionFilesystemDirectory({
 		const fileBytes = await downloadDaytonaFileBytes({
 			sandbox,
 			remotePath: archivePath,
-			timeoutSeconds: 5 * 60,
+			timeoutSeconds: 10 * 60,
 		});
 		const archiveFilename = `${filename}.tar.gz`;
 		const headers: Record<string, string> = {

--- a/qcut/packages/license-server/src/routes/ai-proxy.test.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.test.ts
@@ -516,6 +516,25 @@ describe("GET /api/ai/status", () => {
 		expect(opts.headers.Authorization).toBe("Bearer test-imarouter-key");
 	});
 
+	it("polls IMA Router image status when endpoint is images/generations", async () => {
+		mockProviderResponse({
+			data: {
+				status: "succeeded",
+				url: "https://imarouter.example/out.png",
+			},
+		});
+
+		await buildApp().request(
+			"/api/ai/status?provider=imarouter&endpoint=v1%2Fimages%2Fgenerations&requestId=img_123"
+		);
+
+		const [url, opts] = mockFetch.mock.calls[0];
+		expect(url).toBe(
+			"https://api.imarouter.com/v1/images/generations/img_123"
+		);
+		expect(opts.headers.Authorization).toBe("Bearer test-imarouter-key");
+	});
+
 	it("returns 400 for providers that don't support polling", async () => {
 		const res = await buildApp().request(
 			"/api/ai/status?provider=gemini&requestId=abc"

--- a/qcut/packages/license-server/src/routes/ai-proxy.test.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.test.ts
@@ -529,9 +529,7 @@ describe("GET /api/ai/status", () => {
 		);
 
 		const [url, opts] = mockFetch.mock.calls[0];
-		expect(url).toBe(
-			"https://api.imarouter.com/v1/images/generations/img_123"
-		);
+		expect(url).toBe("https://api.imarouter.com/v1/images/generations/img_123");
 		expect(opts.headers.Authorization).toBe("Bearer test-imarouter-key");
 	});
 

--- a/qcut/packages/license-server/src/routes/ai-proxy.ts
+++ b/qcut/packages/license-server/src/routes/ai-proxy.ts
@@ -343,11 +343,14 @@ aiProxyRoutes.get("/status", async (c) => {
 		} else if (provider === "gmi") {
 			statusUrl = `https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey/requests/${requestId}`;
 		} else if (provider === "imarouter") {
-			// IMA Router poll shape: GET /v1/videos/{task_id} → { status,
-			// progress, results: [{ url }] }. Status enum is lowercase
-			// `queued | in_progress | completed | failed` (proxy-client
-			// normalises to upper-case in pollViaProxy).
-			statusUrl = `https://api.imarouter.com/v1/videos/${requestId}`;
+			if (endpoint.length > 0 && !VALID_ENDPOINT_PATH.test(endpoint)) {
+				return c.json({ error: "Invalid endpoint format" }, 400);
+			}
+			const basePath =
+				endpoint.replace(/^\/+/, "") === "v1/images/generations"
+					? "v1/images/generations"
+					: "v1/videos";
+			statusUrl = `https://api.imarouter.com/${basePath}/${requestId}`;
 		} else {
 			return c.json(
 				{ error: `Polling not supported for provider: ${provider}` },

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -15,7 +15,7 @@ PAYMENTS_WEBHOOK_ENABLED = "true"
 PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:latest"
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -15,7 +15,7 @@ PAYMENTS_WEBHOOK_ENABLED = "true"
 PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:91577894c04bbb7dbf1358f289050cc41e37b5c80291351cc85a2c931c9e673d"
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:latest"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -32,7 +32,7 @@ const CODEX_AGENT_INSTRUCTIONS = [
 	"When a user references an uploaded file, inspect /tmp/qcut-input before asking them to resend it.",
 	"Write final user-requested files under /tmp/qcut-output so the website Sandbox files panel can list and download them.",
 	"The QCut CLI default output directory is set with QCUT_OUTPUT_DIR=/tmp/qcut-output in this sandbox.",
-	"For image generation, the QCut CLI default model is gpt_image_2_gmi. Do not pass --model/-m unless the user explicitly requests a specific image model.",
+	"For image generation, the QCut CLI default model is gpt_image_2_ima. Do not pass --model/-m unless the user explicitly requests a specific image model.",
 	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
 	"yt-dlp and deno are available for authorized video download probes.",
 	"Codex is already running inside an externally isolated Daytona sandbox. Approval prompts and Codex sandboxing have been disabled intentionally for this environment.",

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -32,6 +32,7 @@ const CODEX_AGENT_INSTRUCTIONS = [
 	"When a user references an uploaded file, inspect /tmp/qcut-input before asking them to resend it.",
 	"Write final user-requested files under /tmp/qcut-output so the website Sandbox files panel can list and download them.",
 	"The QCut CLI default output directory is set with QCUT_OUTPUT_DIR=/tmp/qcut-output in this sandbox.",
+	"For image generation, the QCut CLI default model is gpt_image_2_gmi. Do not pass --model/-m unless the user explicitly requests a specific image model.",
 	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
 	"yt-dlp and deno are available for authorized video download probes.",
 	"Codex is already running inside an externally isolated Daytona sandbox. Approval prompts and Codex sandboxing have been disabled intentionally for this environment.",

--- a/qcut/resources/default-skills/native-cli/SKILL.md
+++ b/qcut/resources/default-skills/native-cli/SKILL.md
@@ -82,7 +82,7 @@ For website Daytona Chat Agent sessions, uploaded files are under
 `/tmp/qcut-input` and downloadable outputs must land under
 `/tmp/qcut-output`.
 
-For image generation, the CLI default model is `gpt_image_2_gmi`. Do not pass
+For image generation, the CLI default model is `gpt_image_2_ima`. Do not pass
 `--model/-m` unless the user explicitly requests a specific image model.
 
 The CLI default output directory can be overridden with:

--- a/qcut/resources/default-skills/native-cli/SKILL.md
+++ b/qcut/resources/default-skills/native-cli/SKILL.md
@@ -82,6 +82,9 @@ For website Daytona Chat Agent sessions, uploaded files are under
 `/tmp/qcut-input` and downloadable outputs must land under
 `/tmp/qcut-output`.
 
+For image generation, the CLI default model is `gpt_image_2_gmi`. Do not pass
+`--model/-m` unless the user explicitly requests a specific image model.
+
 The CLI default output directory can be overridden with:
 
 ```bash
@@ -383,7 +386,7 @@ For agent or programmatic use, import `run()` or `runChain()` directly instead o
 import { run, runChain } from "./cli-runner/index.js";
 
 // Single command
-const result = await run("generate-image -t 'A cat' --model flux");
+const result = await run("generate-image -t 'A cat'");
 // → { success, exit_code, duration_ms, command_id, outputPath?, ... }
 
 // Chained commands (output piped as --input to next)

--- a/qcut/resources/default-skills/native-cli/references/REFERENCE.md
+++ b/qcut/resources/default-skills/native-cli/references/REFERENCE.md
@@ -19,7 +19,7 @@ Generate an image from a text prompt.
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--text` | `-t` | string | Text prompt (required) |
-| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_gmi`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_gmi`) |
+| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_ima`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_ima`) |
 | `--aspect-ratio` | | string | e.g. `16:9`, `9:16`, `1:1` |
 | `--resolution` | | string | e.g. `1080p`, `720p` |
 | `--negative-prompt` | | string | Negative prompt |
@@ -82,7 +82,7 @@ Generate a grid of images from a prompt. Use `--grid` with `gen image` to produc
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--text` | `-t` | string | | Prompt (required) |
-| `--model` | `-m` | string | `gpt_image_2_gmi` | Image model |
+| `--model` | `-m` | string | `gpt_image_2_ima` | Image model |
 | `--grid` | | string | | Grid layout: `2x2`, `3x3`, `2x3`, `3x2`, `1x2`, `2x1` |
 | `--style` | | string | | Style prefix prepended to prompt |
 | `--grid-upscale` | | float | | Upscale factor after compositing |

--- a/qcut/resources/default-skills/native-cli/references/REFERENCE.md
+++ b/qcut/resources/default-skills/native-cli/references/REFERENCE.md
@@ -19,7 +19,7 @@ Generate an image from a text prompt.
 | Flag | Short | Type | Description |
 |------|-------|------|-------------|
 | `--text` | `-t` | string | Text prompt (required) |
-| `--model` | `-m` | string | Model key, e.g. `flux_dev`, `flux_schnell` (default: `nano_banana_pro`) |
+| `--model` | `-m` | string | Model key, e.g. `gpt_image_2_gmi`, `gpt_image_2_fal`, `flux_dev` (default: `gpt_image_2_gmi`) |
 | `--aspect-ratio` | | string | e.g. `16:9`, `9:16`, `1:1` |
 | `--resolution` | | string | e.g. `1080p`, `720p` |
 | `--negative-prompt` | | string | Negative prompt |
@@ -82,7 +82,7 @@ Generate a grid of images from a prompt. Use `--grid` with `gen image` to produc
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--text` | `-t` | string | | Prompt (required) |
-| `--model` | `-m` | string | `flux_dev` | Image model |
+| `--model` | `-m` | string | `gpt_image_2_gmi` | Image model |
 | `--grid` | | string | | Grid layout: `2x2`, `3x3`, `2x3`, `3x2`, `1x2`, `2x1` |
 | `--style` | | string | | Style prefix prepended to prompt |
 | `--grid-upscale` | | float | | Upscale factor after compositing |

--- a/qcut/resources/default-skills/native-cli/references/reference-pipelines.md
+++ b/qcut/resources/default-skills/native-cli/references/reference-pipelines.md
@@ -28,7 +28,7 @@ Run a multi-step YAML pipeline.
 name: my-pipeline
 steps:
   - type: text_to_image       # ModelCategory value
-    model: flux_dev            # model key
+    model: gpt_image_2_gmi     # model key
     params:                    # model-specific params
       image_size: landscape_16_9
     enabled: true              # optional, default true
@@ -38,7 +38,7 @@ steps:
     merge_strategy: COLLECT_ALL
     steps:
       - type: text_to_image
-        model: flux_schnell
+        model: gpt_image_2_gmi
 
 config:
   output_dir: ./output

--- a/qcut/resources/default-skills/native-cli/references/reference-pipelines.md
+++ b/qcut/resources/default-skills/native-cli/references/reference-pipelines.md
@@ -28,7 +28,7 @@ Run a multi-step YAML pipeline.
 name: my-pipeline
 steps:
   - type: text_to_image       # ModelCategory value
-    model: gpt_image_2_gmi     # model key
+    model: gpt_image_2_ima     # model key
     params:                    # model-specific params
       image_size: landscape_16_9
     enabled: true              # optional, default true
@@ -38,7 +38,7 @@ steps:
     merge_strategy: COLLECT_ALL
     steps:
       - type: text_to_image
-        model: gpt_image_2_gmi
+        model: gpt_image_2_ima
 
 config:
   output_dir: ./output


### PR DESCRIPTION
## Summary

- Route QCut GPT Image 2 default key to IMA Router as `gpt_image_2_ima`, while keeping `gpt_image_2_gmi` as a legacy alias.
- Update `generate-image`, `generate-grid`, `flow portraits`, `flow storyboard`, docs, skills, and Daytona website prompt guidance so Codex no longer gets steered toward Flux/GMI defaults.
- Add IMA Router image task polling/proxy handling for `POST /v1/images/generations` and `GET /v1/images/generations/{task_id}`.
- Add `--concurrency` to `flow portraits` and run character portrait generation concurrently across characters.
- Reject unknown image/reference models instead of silently falling back to `flux_dev` / `nano_banana_pro`.
- Pin production `QCUT_IMAGE_TAG` to the rebuilt CLI image tag `ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748` because Daytona continued resolving old cached `latest` layers.

## Validation

- `bunx biome check --write electron/native-pipeline/vimax/adapters/image-adapter.ts electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts`
- `bunx biome check packages/license-server/src/routes/ai-proxy.test.ts electron/native-pipeline/output/stage-reporter.ts electron/native-pipeline/output/__tests__/stage-reporter.test.ts electron/native-pipeline/cli/vimax-cli-handlers/character-handlers.ts`
- `bun test electron/native-pipeline/output/__tests__/stage-reporter.test.ts electron/native-pipeline/vimax/agents/__tests__/character-portraits.test.ts electron/native-pipeline/vimax/adapters/__tests__/image-adapter-gpt-image.test.ts` — 21 pass.
- `bun --cwd packages/license-server test -- src/routes/ai-proxy.test.ts` — 28 pass.
- `cd electron && bun x tsc --noEmit`
- `node --test packages/nexusai-website/js/agent-chat.test.js` — 32 pass.
- `bun run pipeline system models --json | jq -r '.data.data.models[] | select(.key=="gpt_image_2_ima" or .key=="gpt_image_2_gmi") | .key'` — lists both keys locally.
- `bun run pipeline flow portraits --help --json | jq -r '.. | strings? // empty' | rg -- '--concurrency|gpt_image_2_ima'` — lists `--concurrency` locally.

## Deployment

- Pushed `Qcut-sandbox-v6`.
- Pushed `packages/nexusai-website` master commit `8887a68` for Codex prompt/default guidance.
- Triggered GHCR CLI image workflow from this branch: https://github.com/Quriosity-agent/qcut/actions/runs/26079950774
- Image workflow built and smoke-tested `ghcr.io/quriosity-agent/qcut-cli:imarouter-gpt-image-20260519061748` and also pushed `:latest`.
- Deployed `qcut-license-server` to production with `QCUT_IMAGE_TAG` pinned to that immutable image tag. Version ID: `1fdd2cfb-3da7-41de-924a-026eec735b4c`.

## Real E2E Evidence

Local real IMA Router portrait run succeeded with 6 images and `--concurrency 6`:

```bash
bun run pipeline flow portraits \
  --input /tmp/qcut-output/characters-six-ima.json \
  --max-characters 6 \
  --views front \
  --image-model gpt_image_2_ima \
  --concurrency 6 \
  -o /tmp/qcut-output/portraits-ima-concurrency-6 \
  --json
```

Real Codex-in-Daytona E2E also succeeded after the pinned-image deploy:

- agent session: `0b236251-2e6c-4244-81d7-8d4e3de7fe21`
- Daytona sandbox id: `f8bf9ba1-424b-4011-9a69-90f3db151271`
- `/tmp/qcut-output/codex-real-e2e-done.txt`: `SUCCESS`
- `/tmp/qcut-output/codex-real-e2e-portraits-ima-concurrency-6.md`: records the command, preflight, concurrency lines, output paths, and result.
- `/tmp/qcut-output/portraits-ima-codex-concurrency-6/png-validation.json`: 6 expected, 6 found, 6 valid PNGs.

The successful Codex-in-Daytona command:

```bash
qcut flow portraits \
  --input /tmp/qcut-input/characters-six-ima-codex.json \
  --max-characters 6 \
  --views front \
  --image-model gpt_image_2_ima \
  --concurrency 6 \
  -o /tmp/qcut-output/portraits-ima-codex-concurrency-6 \
  --json
```

Result: 6 PNGs, each 1024x1536. The log shows all six `Generating portraits for` lines before the first `Generated portraits for` line, confirming concurrent dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added IMA Router support for image generation with improved default model selection.
  * Introduced reference image handling for enhanced image editing workflows.
  * Added concurrency control for parallel character portrait generation.

* **Improvements**
  * Updated default image generation model with better endpoint routing and metadata tracking.
  * Enhanced image task polling with support for multiple provider backends.

* **Documentation**
  * Updated CLI documentation and guides to reflect new image generation defaults and capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Quriosity-agent/qcut/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->