### PR TITLE
[codex] Support novel2movie video references

### DIFF
--- a/qcut/.claude/skills/native-cli/references/REFERENCE.md
+++ b/qcut/.claude/skills/native-cli/references/REFERENCE.md
@@ -115,7 +115,7 @@ Analyze a video with AI vision.
 |------|-------|------|---------|-------------|
 | `--input` | `-i` | string | | Video file or URL (required) |
 | `--video-url` | | string | | Alias for input |
-| `--model` | `-m` | string | `gemini_qa` | Vision model |
+| `--model` | `-m` | string | `openrouter_gemini_3_5_flash_video` | Vision model |
 | `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript` |
 | `--prompt` | | string | | Custom prompt (overrides analysis-type) |
 | `--text` | `-t` | string | | Alias for prompt |
@@ -162,7 +162,7 @@ Extract highlight clips from a video using subtitle-based LLM analysis. Runs a 4
 | `--input` | `-i` | string | | Input video file path (required) |
 | `--srt-file` | `-s` | string | | SRT/VTT subtitle file (auto-detects if omitted) |
 | `--output` | `-o` | string | | Output directory for clips and metadata |
-| `--model` | `-m` | string | `google/gemini-3-flash-preview` | LLM model for analysis |
+| `--model` | `-m` | string | `google/gemini-3.5-flash` | LLM model for analysis |
 | `--min-score` | | number | `0.7` | Minimum score threshold 0–1 |
 | `--step` | | number | | Run only a specific step (1–4) |
 | `--chunk-minutes` | | number | `30` | Subtitle chunk interval in minutes |

--- a/qcut/.claude/skills/qcut-toolkit/ai-content-pipeline/REFERENCE.md
+++ b/qcut/.claude/skills/qcut-toolkit/ai-content-pipeline/REFERENCE.md
@@ -339,7 +339,7 @@ QCut's Claude HTTP server (port 8765) exposes video analysis endpoints that acce
 
 | Type | Description | Provider |
 |------|-------------|----------|
-| `timeline` (default) | Detailed second-by-second breakdown | FAL (Gemini via OpenRouter) |
+| `timeline` (default) | Detailed second-by-second breakdown | OpenRouter Gemini 3.5 Flash |
 | `describe` | Video description and summary | Gemini direct |
 | `transcribe` | Audio transcription with timestamps | Gemini direct |
 
@@ -347,7 +347,8 @@ QCut's Claude HTTP server (port 8765) exposes video analysis endpoints that acce
 
 | Key | Provider | Model ID | Notes |
 |-----|----------|----------|-------|
-| `gemini-2.5-flash` (default) | FAL | `google/gemini-2.5-flash` | Fast, cost-effective |
+| `openrouter_gemini_3_5_flash_video` (default) | OpenRouter | `google/gemini-3.5-flash` | Fast multimodal video analysis |
+| `gemini-2.5-flash` | FAL | `google/gemini-2.5-flash` | Legacy FAL route |
 | `gemini-2.5-pro` | FAL | `google/gemini-2.5-pro` | Higher quality |
 | `gemini-3-pro` | FAL | `google/gemini-3-pro-preview` | Highest quality |
 | `gemini-direct` | Gemini | `gemini-2.0-flash-exp` | Requires GEMINI_API_KEY |

--- a/qcut/docs/task/daytona-supabase-agent/implementation/25-novel2movie-reference-e2e-timing.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/25-novel2movie-reference-e2e-timing.md
@@ -92,3 +92,77 @@ That means five remote jobs are serialized. The earlier portrait and storyboard 
 ## Follow-Up
 
 If we want this command to be faster for `--max-clips 5`, the next engineering step is bounded video concurrency, likely `--video-concurrency` with a default of 1 and a hard cap such as 2 or 3. That needs provider/cost consideration because concurrent Seedance jobs can spend credits faster and can hit upstream rate limits.
+
+## Parallel Video Trial
+
+Implemented bounded video concurrency for `CameraImageGenerator`.
+
+New CLI option:
+
+```bash
+qcut flow novel2movie --novel story.txt --max-scenes 20 --max-clips 2 --video-concurrency 2
+```
+
+Defaults and caps:
+
+- Default `video_concurrency`: `1`
+- Hard cap: `6`
+- `--video-concurrency` is preferred for `novel2movie`
+- Existing generic `--concurrency` is also accepted as a fallback
+- Output videos and `video_reference_audit.json` remain in script shot order even when remote tasks finish out of order
+
+Real E2E command:
+
+```bash
+bun /Users/peter/Desktop/code/qcut/qcut/electron/native-pipeline/cli/cli.ts \
+  flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 2 \
+  --video-concurrency 2 \
+  -o /tmp/qcut-kpop-parallel-e2e/output \
+  --json
+```
+
+Real E2E output:
+
+- Run directory: `/tmp/qcut-kpop-parallel-e2e/output/story_202605211559`
+- Downloaded artifact directory: `/Users/peter/Downloads/qcut-kpop-parallel-e2e-artifacts`
+- Final movie: `/Users/peter/Downloads/qcut-kpop-parallel-e2e-artifacts/final_movie.mp4`
+- Final duration: 22.08 seconds
+- Final size: 31 MB
+- Clips generated: 2
+- Provider cost reported by QCut: `$6.762`
+- Summary errors: `[]`
+
+Log evidence:
+
+```text
+[camera_gen] Running 2 video task(s) with concurrency 2
+[camera_gen] SHOT_001: video refs=0, storyboard=yes
+[camera_gen] SHOT_005: video refs=2, storyboard=yes
+[vimax.video] imarouter_seedance_2_0_ref2v: 100% completed
+[vimax.video] imarouter_seedance_2_0_ref2v: 100% completed
+```
+
+This confirms both clips were submitted into the video stage concurrently.
+
+Timing:
+
+| Stage | Evidence | Approx time | Parallel? | Notes |
+| --- | --- | ---: | --- | --- |
+| Full command | `/usr/bin/time`: `real 984.65` | 16m25s | mixed | Full run, including LLM/images/videos |
+| Character extraction | `characters.json` 08:59:37 | ~4s | no | One LLM call |
+| Portrait generation | portrait files 09:00:07 and 09:00:10 | ~33s | yes | Two portrait tasks overlapped |
+| Storyboard generation | storyboard files 09:00:45 and 09:01:21 | ~71s | yes | Two image tasks with concurrency 2 |
+| Video generation | `SHOT_001` 09:11:10, `SHOT_005` 09:15:58 | ~14m37s | yes | Both started together, but one provider job finished much later |
+| Concatenate final movie | final movie 09:15:58 | <1s | no | Cheap local concat |
+
+Reference audit:
+
+| Clip | Storyboard image | Portrait reference count | Notes |
+| --- | --- | ---: | --- |
+| `SHOT_001` | yes | 0 | Establishing/environment shot |
+| `SHOT_005` | yes | 2 | Multi-reference: Lin Yue + Park Mina |
+
+Conclusion: parallel clip generation works with IMA Router Seedance Ref2V, but the provider can still queue or complete one job much later than another. For production, defaulting to `1` remains safest; user-requested runs can use `--video-concurrency 2` when speed matters and cost/rate-limit risk is acceptable.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/25-novel2movie-reference-e2e-timing.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/25-novel2movie-reference-e2e-timing.md
@@ -1,0 +1,94 @@
+# Novel2Movie Reference E2E Timing
+
+Date: 2026-05-21
+
+Command under test:
+
+```bash
+qcut flow novel2movie --novel story.txt --max-scenes 20 --max-clips 5
+```
+
+Scenario: Chinese / East Asian K-pop supermodel fashion story with two adult characters, Lin Yue and Park Mina.
+
+Output:
+
+- Local run directory: `/tmp/qcut-kpop-asian-ref-e2e/output/story_202605210740`
+- Downloaded artifact directory: `/Users/peter/Downloads/qcut-kpop-asian-ref-e2e-artifacts`
+- Final movie: `/Users/peter/Downloads/qcut-kpop-asian-ref-e2e-artifacts/final_movie.mp4`
+- Reference audit: `/Users/peter/Downloads/qcut-kpop-asian-ref-e2e-artifacts/videos/Shanghai_Neon_Runway/video_reference_audit.json`
+
+## Result
+
+The run completed successfully.
+
+- Scripts: 1
+- Shots: 5
+- Storyboard images: 5
+- Video clips: 5
+- Final video duration: 52.2 seconds
+- Final video size: 50 MB
+- Total provider cost reported by QCut: `$15.888`
+- Summary errors: `[]`
+
+## Reference Usage
+
+The video stage used `storyboard+references` mode.
+
+| Clip | Storyboard image | Portrait reference count | Notes |
+| --- | --- | ---: | --- |
+| `SHOT_001` | yes | 0 | Establishing/environment shot, no character refs |
+| `SHOT_002` | yes | 1 | Single-character reference |
+| `SHOT_003` | yes | 1 | Single-character reference |
+| `SHOT_004` | yes | 2 | Multi-reference: Lin Yue + Park Mina |
+| `SHOT_005` | yes | 2 | Multi-reference: Lin Yue + Park Mina |
+
+This proves the target path works for a single video clip with multiple portrait references:
+
+```text
+storyboard image + Lin Yue portrait + Park Mina portrait
+```
+
+## Step Timing
+
+Times below are from `summary.json`, file mtimes, and the live command log. They are approximate because the CLI does not yet persist per-stage timestamps.
+
+| Stage | Evidence | Approx time | Parallel? | Notes |
+| --- | --- | ---: | --- | --- |
+| Setup / novel save | `summary.started_at` 00:40:24, `novel.txt` 00:40:24 | <1s | no | Local file setup only |
+| Character extraction | `characters.json` 00:40:28 | ~4s | no | One LLM call |
+| Portrait generation | portrait files 00:41:06 and 00:41:07 | ~39s | yes | Two character portraits ran concurrently; outputs landed 1s apart |
+| Script segmentation | `scripts/chunk_001.json` 00:41:12 | ~5s | no | One LLM segmentation step |
+| Storyboard generation | first storyboard 00:41:54, last storyboard 00:42:30 | ~78s | yes | Five image tasks ran with concurrency 5 |
+| Video `SHOT_001` | video file 00:47:59 | ~5m29s | no | Video generation is awaited before starting next clip |
+| Video `SHOT_002` | video file 00:53:10 | ~5m11s | no | Sequential |
+| Video `SHOT_003` | video file 00:57:55 | ~4m45s | no | Sequential |
+| Video `SHOT_004` | video file 01:03:39 | ~5m44s | no | Sequential, uses 2 portrait references |
+| Video `SHOT_005` | video file 01:10:37 | ~6m58s | no | Sequential, uses 2 portrait references |
+| Concatenate final movie | `final_movie.mp4` 01:10:37 | <1s | no | FFmpeg concat is cheap for this run |
+
+Total wall time: 30m13s (`2026-05-21T07:40:24Z` to `2026-05-21T08:10:37Z`).
+
+## Why It Took So Long
+
+The dominant cost is remote Seedance Ref2V video generation. The current `CameraImageGenerator` processes videos sequentially:
+
+```text
+for each shot:
+  await videoAdapter.generate(...)
+```
+
+That means five remote jobs are serialized. The earlier portrait and storyboard stages already use concurrency, but the video stage does not.
+
+## Fixes Made Before This E2E Passed
+
+- `novel2movie` now defaults to `imarouter_seedance_2_0_ref2v`, so the command can consume multiple references without requiring `--video-model`.
+- Video mode defaults to `storyboard+references`.
+- Camera generation writes `video_reference_audit.json` with source image, reference count, and reference URLs per shot.
+- Character portrait registry stores the provider URL when available, so video reference asset creation can avoid stale local upload credentials.
+- Storyboard reference generation falls back to `gpt_image_2_ima` when the main image model does not support reference edits.
+- IMA Router Seedance Ref2V defaults set `metadata.audio=false`, avoiding unrelated audio moderation failures.
+- Video and storyboard failures now propagate into pipeline `errors`; failed video runs should not return a false-success result.
+
+## Follow-Up
+
+If we want this command to be faster for `--max-clips 5`, the next engineering step is bounded video concurrency, likely `--video-concurrency` with a default of 1 and a hard cap such as 2 or 3. That needs provider/cost consideration because concurrent Seedance jobs can spend credits faster and can hit upstream rate limits.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/27-novel2movie-cli-flow-bilingual.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/27-novel2movie-cli-flow-bilingual.md
@@ -1,0 +1,390 @@
+# QCut Novel-to-Movie CLI Flow / 小说到影视 CLI 流程
+
+Date: 2026-05-21
+
+This document explains the intended command sequence for QCut's novel-to-movie workflow in both Chinese and English. It is a usage guide, not an implementation note.
+
+本文档用中英文说明 QCut 从小说到影视生成的 CLI 顺序。它是使用说明，不是代码实现说明。
+
+## Overview / 总览
+
+Full one-shot command:
+
+完整一键命令：
+
+```bash
+qcut flow novel2movie --novel story.txt --max-scenes 20 --max-clips 5
+```
+
+中文：从小说文件开始，自动抽人物、生成角色图、切场景和镜头、生成 storyboard 图片、生成 video clips，最后合成 final movie。
+
+English: Start from a novel file, automatically extract characters, generate portraits, segment scenes and shots, generate storyboard images, generate video clips, then concatenate the final movie.
+
+Recommended model defaults:
+
+推荐默认模型：
+
+- LLM: `google/gemini-3.5-flash` or the configured Gemini Flash model
+- Image: `gpt_image_2_ima`
+- Video: `imarouter_seedance_2_0_ref2v`
+- Video reference mode: `storyboard+references`
+
+## Step 1: Novel Input / 小说输入
+
+Use this when you only want script chunks, with no image or video generation:
+
+如果只想把小说拆成影视脚本，不生图、不生视频：
+
+```bash
+qcut flow novel2movie --novel story.txt --scripts-only
+```
+
+中文：读取小说，只生成 `scripts/chunk_*.json`。适合先验证小说切分和脚本结构。
+
+English: Read the novel and only generate `scripts/chunk_*.json`. This is useful for validating segmentation and screenplay structure first.
+
+More explicit decomposed command:
+
+更拆分的命令：
+
+```bash
+qcut flow novel2script --novel story.txt --project my-story --max-scenes 20
+```
+
+中文：把小说拆成项目里的影视脚本、场景、镜头结构。
+
+English: Convert the novel into project screenplay chunks with scenes and shots.
+
+## Step 2: Extract Characters / 抽取角色
+
+Standalone character extraction:
+
+单独抽人物：
+
+```bash
+qcut flow characters \
+  --novel /tmp/qcut-input/novel.txt \
+  --llm-model google/gemini-3.5-flash \
+  -o /tmp/qcut-output \
+  --json
+```
+
+中文：从小说文本中抽出角色名字、外貌、性格、身份、服装、人物关系等信息，输出 `characters.json`。
+
+English: Extract character names, appearance, personality, identity, clothing, and relationships from the novel, then write `characters.json`.
+
+Alternative lightweight model example:
+
+轻量模型示例：
+
+```bash
+qcut flow characters \
+  --novel /tmp/qcut-input/novel.txt \
+  --llm-model gemini-3.1-flash-lite \
+  -o /tmp/qcut-output \
+  --json
+```
+
+## Step 3: Generate Character Portraits / 生成人物 Portraits
+
+Generate front-view portraits from `characters.json`:
+
+从 `characters.json` 生成正面人物图：
+
+```bash
+qcut flow portraits \
+  --input /tmp/qcut-output/characters.json \
+  --max-characters 3 \
+  --views front \
+  --image-model gpt_image_2_ima \
+  -o /tmp/qcut-output/portraits \
+  --json
+```
+
+中文：为角色生成正面人物图，并输出 portrait 图片和 registry。后续 storyboard 和 video 可以用这些图片作为角色 reference。
+
+English: Generate front-view character portraits plus a portrait registry. Later storyboard and video steps can use these images as character references.
+
+Multiple views:
+
+多视角：
+
+```bash
+qcut flow portraits \
+  --input /tmp/qcut-output/characters.json \
+  --max-characters 3 \
+  --views front,side,back \
+  --image-model gpt_image_2_ima \
+  -o /tmp/qcut-output/portraits \
+  --json
+```
+
+中文：如果后续镜头角度比较多，可以生成 front、side、back 多视角，提高角色一致性。
+
+English: If later shots need multiple camera angles, generate front, side, and back views to improve character consistency.
+
+## Step 4: Extract Scenes and Shots / 抽取场景和镜头
+
+Scene extraction command:
+
+场景抽取命令：
+
+```bash
+qcut flow scenes \
+  --novel /tmp/qcut-input/novel.txt \
+  --llm-model google/gemini-3.5-flash \
+  -o /tmp/qcut-output/scenes \
+  --json
+```
+
+中文：把小说拆成 scenes，每个 scene 里包含 shots、人物、地点、动作、时间等信息。
+
+English: Split the novel into scenes. Each scene contains shots, characters, location, action, time, and related metadata.
+
+In the full pipeline, this step is usually handled automatically by:
+
+完整流程中，这一步通常由下面的命令自动完成：
+
+```bash
+qcut flow novel2movie --novel story.txt
+```
+
+or:
+
+或者：
+
+```bash
+qcut flow novel2script --novel story.txt --project my-story
+```
+
+## Step 5: Generate Storyboard Images / 生成 Storyboard 图片
+
+Generate storyboard images from script, with portraits as references:
+
+从 script 生成 storyboard 图片，并使用 portraits 做人物参考：
+
+```bash
+qcut flow storyboard \
+  --script /tmp/qcut-output/scripts/chunk_001.json \
+  --portraits /tmp/qcut-output/portraits/registry.json \
+  --image-model gpt_image_2_ima \
+  --style "cinematic Chinese fashion drama, K-pop lighting" \
+  -o /tmp/qcut-output/storyboard \
+  --json
+```
+
+中文：把每个 shot 变成 storyboard image，并尽量使用 portraits 保持人物一致。
+
+English: Turn each shot into a storyboard image while using portraits to keep characters visually consistent.
+
+Preview mode with limited images:
+
+只生成少量图的 preview 模式：
+
+```bash
+qcut flow novel2movie --novel story.txt --max-images 5
+```
+
+中文：最多生成 5 张 storyboard 图片，不生视频。适合省钱快速检查视觉方向。
+
+English: Generate at most 5 storyboard images and no videos. This is good for quickly checking visual direction with lower cost.
+
+Storyboard-only mode:
+
+只生成全部 storyboard，不生视频：
+
+```bash
+qcut flow novel2movie --novel story.txt --storyboard-only
+```
+
+中文：生成全部 storyboard images，但停止在视频之前。
+
+English: Generate all storyboard images, then stop before video generation.
+
+## Step 6: Provide Extra Reference Images / 上传或传入额外 Reference 图片
+
+Use extra reference images when you want to guide the video model with real people, costumes, style frames, or other visual references.
+
+如果想用真人图、服装图、风格图、角色图等额外 reference 来影响视频模型，可以传入：
+
+```bash
+qcut flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 5 \
+  --video-reference-images /Users/peter/Downloads/ref1.png \
+  --video-reference-images /Users/peter/Downloads/ref2.png
+```
+
+中文：这些图片会作为额外 video reference，和 storyboard image、portrait references 一起传给视频模型。
+
+English: These images are passed as extra video references together with the storyboard image and portrait references.
+
+Video reference modes:
+
+视频 reference 模式：
+
+```bash
+--video-reference-mode storyboard
+--video-reference-mode references
+--video-reference-mode storyboard+references
+```
+
+Chinese meaning:
+
+中文含义：
+
+- `storyboard`: 只使用 storyboard 图
+- `references`: 只使用 portrait / extra reference，不使用 storyboard 作为 source image
+- `storyboard+references`: 使用 storyboard + portraits + extra references，通常是默认推荐
+
+English meaning:
+
+英文含义：
+
+- `storyboard`: only use the storyboard image
+- `references`: only use portrait / extra references, without storyboard as the source image
+- `storyboard+references`: use storyboard plus portraits plus extra references, usually the recommended default
+
+## Step 7: Generate Video Clips / 生成视频 Clips
+
+Full video generation:
+
+完整视频生成：
+
+```bash
+qcut flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 5 \
+  --video-model imarouter_seedance_2_0_ref2v \
+  --video-reference-mode storyboard+references
+```
+
+中文：选择最多 5 个 shot 生成 video clips，然后合成 final movie。当前逻辑会优先选择较短的 clips，以控制时间和成本。
+
+English: Select up to 5 shots, generate video clips, then concatenate the final movie. The current logic favors shorter clips to control time and cost.
+
+Parallel video trial:
+
+视频并发测试：
+
+```bash
+qcut flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 5 \
+  --video-concurrency 2
+```
+
+中文：同时跑最多 2 个 video clips。默认是 `1`，更稳；最高 hard cap 是 `6`。并发可以更快提交任务，但 provider 仍可能排队，成本和限流风险也更高。
+
+English: Run up to 2 video clips in parallel. The default is `1` for stability, and the hard cap is `6`. Parallelism can submit jobs faster, but the provider may still queue jobs, and cost/rate-limit risk is higher.
+
+## Recommended Test Order / 推荐测试顺序
+
+Use this sequence when validating the pipeline step by step:
+
+建议按这个顺序一步一步验证：
+
+### 1. Characters / 先抽人物
+
+```bash
+qcut flow characters \
+  --novel story.txt \
+  --llm-model google/gemini-3.5-flash \
+  -o /tmp/qcut-output \
+  --json
+```
+
+中文：确认小说能被 LLM 正确理解，人物能抽出来。
+
+English: Confirm the LLM can understand the novel and extract characters correctly.
+
+### 2. Portraits / 再生人物图
+
+```bash
+qcut flow portraits \
+  --input /tmp/qcut-output/characters.json \
+  --max-characters 3 \
+  --views front \
+  --image-model gpt_image_2_ima \
+  -o /tmp/qcut-output/portraits \
+  --json
+```
+
+中文：确认角色图能生成，并且 registry 可用于后续 reference。
+
+English: Confirm portraits can be generated and the registry is ready for later references.
+
+### 3. Storyboard Preview / 小量 Storyboard 预览
+
+```bash
+qcut flow novel2movie --novel story.txt --max-images 5
+```
+
+中文：低成本检查视觉方向，不生成视频。
+
+English: Check visual direction at lower cost, without generating video.
+
+### 4. Small Video E2E / 小规模视频端到端测试
+
+```bash
+qcut flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 2 \
+  --video-concurrency 2
+```
+
+中文：只跑 2 个 clips，验证 storyboard + portraits + video references + final concat 全链路是否好使。
+
+English: Generate only 2 clips to validate the full chain: storyboard, portraits, video references, and final concatenation.
+
+### 5. Larger Video Run / 扩大视频生成规模
+
+```bash
+qcut flow novel2movie \
+  --novel story.txt \
+  --max-scenes 20 \
+  --max-clips 5 \
+  --video-concurrency 2
+```
+
+中文：确认小规模成功后，再扩大到 5 个 clips。真实 provider 可能排队，所以耗时不一定线性下降。
+
+English: After the small run succeeds, expand to 5 clips. Real providers may queue jobs, so total time may not decrease linearly.
+
+## Output Expectations / 输出产物
+
+Typical output files:
+
+常见输出文件：
+
+- `characters.json`: extracted character profiles / 抽取出来的人物信息
+- `portrait_registry.json`: portrait reference registry / 人物图 reference 注册表
+- `portraits/<character>/front.png`: generated portrait image / 角色正面图
+- `scripts/chunk_*.json`: screenplay chunks / 影视脚本分块
+- `storyboard/.../*.png`: storyboard images / 分镜图片
+- `videos/<title>/SHOT_*.mp4`: video clips / 分镜视频片段
+- `videos/<title>/video_reference_audit.json`: video reference audit / 视频 reference 使用记录
+- `final_movie.mp4`: final concatenated movie / 最终合成视频
+- `summary.json`: run summary, cost, errors, and timing boundaries / 运行摘要、成本、错误和起止时间
+
+## Practical Notes / 实用注意点
+
+中文：
+
+- 先跑 `--scripts-only` 或 `--max-images 5`，不要一开始就全量生视频。
+- 需要角色一致性时，优先生成 portraits，并用 `storyboard+references`。
+- `--video-concurrency 2` 可以测试并发，但默认 `1` 更稳。
+- `video_reference_audit.json` 是确认 reference 是否真正传入视频模型的关键证据。
+- 如果某个 provider 排队很久，不一定是本地 CLI 卡住，可能是远端视频生成任务还在处理。
+
+English:
+
+- Start with `--scripts-only` or `--max-images 5`; do not start with full video generation.
+- For character consistency, generate portraits first and use `storyboard+references`.
+- `--video-concurrency 2` is useful for testing parallel submission, but default `1` is safer.
+- `video_reference_audit.json` is the key evidence for confirming which references were sent to the video model.
+- If a provider takes a long time, the local CLI may not be stuck; the remote video job may still be processing.

--- a/qcut/docs/task/daytona-supabase-agent/implementation/27-novel2movie-cli-flow-bilingual.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/27-novel2movie-cli-flow-bilingual.md
@@ -362,7 +362,7 @@ Typical output files:
 常见输出文件：
 
 - `characters.json`: extracted character profiles / 抽取出来的人物信息
-- `portrait_registry.json`: portrait reference registry / 人物图 reference 注册表
+- `portraits/registry.json`: portrait reference registry / 人物图 reference 注册表
 - `portraits/<character>/front.png`: generated portrait image / 角色正面图
 - `scripts/chunk_*.json`: screenplay chunks / 影视脚本分块
 - `storyboard/.../*.png`: storyboard images / 分镜图片

--- a/qcut/docs/task/daytona-supabase-agent/implementation/28-upload-files-artifacts-e2e.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/28-upload-files-artifacts-e2e.md
@@ -1,0 +1,107 @@
+# Upload Files to Artifacts E2E
+
+Date: 2026-05-21
+
+Goal: verify that uploaded image, text, and video files can appear in the Chat Agent `Sandbox files` / artifacts panel.
+
+## Result
+
+Passed on the production page:
+
+```text
+https://quriosity.com.au/chat-agent.html
+```
+
+The page connected to a real Daytona terminal session and uploaded three local test files through the website upload UI.
+
+## Test Files
+
+Run id:
+
+```text
+1779389330
+```
+
+Local input files:
+
+```text
+output/playwright/upload-artifacts-e2e-1779389330/input/upload-text-1779389330.txt
+output/playwright/upload-artifacts-e2e-1779389330/input/upload-image-1779389330.png
+output/playwright/upload-artifacts-e2e-1779389330/input/upload-video-1779389330.mp4
+```
+
+## Real UI Steps
+
+1. Opened `https://quriosity.com.au/chat-agent.html`.
+2. Confirmed terminal starts as `disconnected`.
+3. Clicked `Connect`.
+4. Waited until the Daytona terminal status became `connected`.
+5. Used the page upload input with:
+   - `upload-text-1779389330.txt`
+   - `upload-image-1779389330.png`
+   - `upload-video-1779389330.mp4`
+6. Clicked `Upload selected files`.
+7. Waited for the `Sandbox files` panel to show all three uploaded filenames.
+8. Verified each tile's DOM kind and path.
+
+## Evidence
+
+Upload status from the page:
+
+```text
+Uploaded to /tmp/qcut-output: upload-text-1779389330.txt, upload-image-1779389330.png, upload-video-1779389330.mp4
+```
+
+Artifacts panel text:
+
+```text
+upload-image-1779389330.png
+76 bytes
+upload-text-1779389330.txt
+42 bytes
+upload-video-1779389330.mp4
+5.7 KB
+```
+
+DOM verification:
+
+```json
+[
+  {
+    "name": "upload-text-1779389330.txt",
+    "kind": "log",
+    "path": "/tmp/qcut-output/upload-text-1779389330.txt"
+  },
+  {
+    "name": "upload-image-1779389330.png",
+    "kind": "image",
+    "path": "/tmp/qcut-output/upload-image-1779389330.png"
+  },
+  {
+    "name": "upload-video-1779389330.mp4",
+    "kind": "video",
+    "path": "/tmp/qcut-output/upload-video-1779389330.mp4"
+  }
+]
+```
+
+Screenshot evidence:
+
+```text
+output/playwright/upload-artifacts-e2e-1779389330/06-uploaded-artifacts.png
+```
+
+Machine-readable result:
+
+```text
+output/playwright/upload-artifacts-e2e-1779389330/result.json
+```
+
+## Notes
+
+- The upload target was the current sandbox path, which defaults to `/tmp/qcut-output`.
+- Uploaded text files are classified as `log`; this is expected because the artifact kind enum uses `log` for text-like files.
+- Uploaded images are classified as `image`.
+- Uploaded videos are classified as `video`.
+- No code fix was needed for this goal.
+

--- a/qcut/docs/task/daytona-supabase-agent/implementation/29-video-analyze-e2e.md
+++ b/qcut/docs/task/daytona-supabase-agent/implementation/29-video-analyze-e2e.md
@@ -1,0 +1,365 @@
+# QCut CLI Video Analyze Real E2E
+
+Date: 2026-05-21
+
+## Scope
+
+Verify `qcut analyze video` / `analyze-video` on a short real video and record the result.
+
+Update after correction:
+
+- Default video analysis model is now `openrouter_gemini_3_5_flash_video`.
+- Provider is direct OpenRouter.
+- Underlying model ID is `google/gemini-3.5-flash`.
+- OpenRouter video input uses `/api/v1/chat/completions` with `video_url` content.
+
+Reference:
+
+- https://openrouter.ai/google/gemini-3.5-flash/api
+- https://openrouter.ai/docs/guides/overview/multimodal/videos
+
+## Initial Failure
+
+Command:
+
+```bash
+bun electron/native-pipeline/cli/cli.ts analyze video \
+  -i /Users/peter/Desktop/code/qcut/qcut/output/playwright/upload-artifacts-e2e-1779389330/input/upload-video-1779389330.mp4 \
+  --analysis-type description \
+  -o /tmp/qcut-video-analyze-e2e-1779392218 \
+  --json
+```
+
+Result:
+
+```json
+{
+  "status": "error",
+  "error": "FAL upload error: Upload URL request failed (401): {\"error\":\"Invalid token\"}",
+  "code": "analyze-video:failed"
+}
+```
+
+Cause found:
+
+- `fal_video_qa` correctly uses the FAL backend.
+- Doubao/Volcengine and Gemini image-understanding models did not explicitly set `providerBackend`.
+- Registry normalization defaulted missing `providerBackend` to `fal`.
+- As a result, `doubao_video_understanding` was routed through the FAL caller instead of Volcengine.
+
+## Fix
+
+Files changed:
+
+- `electron/native-pipeline/infra/registry.ts`
+  - Extended `ProviderBackend` to include the direct execution backends already used by API routing: `google`, `openrouter`, `volcengine`, `gmi-llm`, and `runway`.
+- `electron/native-pipeline/registry-data/image-understanding.ts`
+  - Added `openrouter_gemini_3_5_flash_video` for Gemini 3.5 Flash via OpenRouter.
+  - Added `providerBackend: "google"` for Gemini image-understanding models.
+  - Added `providerBackend: "volcengine"` for Doubao video/image-understanding models.
+- `electron/native-pipeline/execution/step-executors.ts`
+  - Added OpenRouter media-understanding payload shaping for `chat/completions`.
+  - Local videos are encoded as base64 data URLs before submit.
+- `electron/native-pipeline/cli/cli-handlers-media.ts`
+  - Changed `analyze video` and `query video` defaults to `openrouter_gemini_3_5_flash_video`.
+- `electron/native-pipeline/cli/command-registry.ts`
+  - Updated help/default metadata for `analyze-video` and `query-video`.
+- `electron/native-pipeline/registry-data/__tests__/image-understanding.test.ts`
+  - Added coverage so OpenRouter, Gemini, and Doubao understanding models cannot silently fall back to FAL.
+- `electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts`
+  - Added payload-shape coverage for remote URLs and local base64 video inputs.
+
+Registry verification:
+
+```text
+openrouter_gemini_3_5_flash_video: provider=OpenRouter backend=openrouter endpoint=chat/completions model=google/gemini-3.5-flash
+fal_video_qa: provider=fal backend=fal endpoint=openrouter/router/video/enterprise
+doubao_video_understanding: provider=Volcengine backend=volcengine endpoint=volcengine/chat/completions
+doubao_seed_2_lite: provider=Volcengine backend=volcengine endpoint=volcengine/responses
+gemini_describe: provider=Google backend=google endpoint=google/gemini/describe
+```
+
+## Real E2E Success — OpenRouter Default
+
+Input video:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/upload-artifacts-e2e-1779389330/input/upload-video-1779389330.mp4
+```
+
+Command, intentionally no `--model`:
+
+```bash
+set -a
+source /Users/peter/.qcut/.env
+set +a
+
+OUT="/tmp/qcut-video-analyze-openrouter-default-1779393130"
+VIDEO="/Users/peter/Desktop/code/qcut/qcut/output/playwright/upload-artifacts-e2e-1779389330/input/upload-video-1779389330.mp4"
+
+bun /Users/peter/Desktop/code/qcut/qcut/electron/native-pipeline/cli/cli.ts analyze video \
+  -i "$VIDEO" \
+  --analysis-type description \
+  -o "$OUT" \
+  --json
+```
+
+Result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "schema_version": "1",
+    "command": "analyze-video",
+    "outputPath": "/tmp/qcut-video-analyze-openrouter-default-1779393130/upload-video-1779389330.json",
+    "data": {
+      "type": "description",
+      "video": "upload-video-1779389330.mp4",
+      "model": "openrouter_gemini_3_5_flash_video",
+      "duration": 8.331,
+      "content": "This video features a young woman with curly auburn hair in a cozy, softly lit bedroom..."
+    },
+    "duration": 8.331
+  },
+  "duration_ms": 8333
+}
+```
+
+Output artifact:
+
+```text
+/tmp/qcut-video-analyze-openrouter-default-1779393130/upload-video-1779389330.json
+```
+
+Confirmed:
+
+- Default selected `openrouter_gemini_3_5_flash_video`.
+- The provider route was OpenRouter.
+- The model returned a correct description of the test clip.
+
+Note:
+
+- The proxy path first returned `401 Invalid token`, then the CLI fell back to local `OPENROUTER_API_KEY` and succeeded.
+
+## Legacy Doubao E2E Success
+
+Input video:
+
+```text
+https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4
+```
+
+Command:
+
+```bash
+set -a
+source /Users/peter/.qcut/.env
+set +a
+
+OUT="/tmp/qcut-video-analyze-doubao-1779392716"
+VIDEO_URL="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+
+bun /Users/peter/Desktop/code/qcut/qcut/electron/native-pipeline/cli/cli.ts analyze video \
+  -i "$VIDEO_URL" \
+  --model doubao_video_understanding \
+  --analysis-type description \
+  -o "$OUT" \
+  --json
+```
+
+Result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "schema_version": "1",
+    "command": "analyze-video",
+    "outputPath": "/tmp/qcut-video-analyze-doubao-1779392716/flower.json",
+    "data": {
+      "type": "description",
+      "video": "flower.mp4",
+      "model": "doubao_video_understanding",
+      "duration": 17.769,
+      "content": "The video captures a close-up, time-lapse view of a red flower bud blooming..."
+    },
+    "duration": 17.769
+  },
+  "duration_ms": 17772
+}
+```
+
+Output artifact:
+
+```text
+/tmp/qcut-video-analyze-doubao-1779392716/flower.json
+```
+
+Confirmed content:
+
+- The returned description correctly identifies a red flower bud blooming.
+- The output JSON was written successfully.
+- The CLI path reports `command: "analyze-video"`.
+
+Note:
+
+- The proxy path first returned `401 Invalid token`, then the CLI fell back to the local `ARK_API_KEY` and succeeded through Volcengine.
+- The default `fal_video_qa` route is still dependent on a valid FAL/proxy key for local-file upload.
+
+## Verification
+
+```bash
+bunx vitest run \
+  electron/native-pipeline/registry-data/__tests__/image-understanding.test.ts \
+  electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts
+cd electron && bun x tsc --noEmit
+```
+
+Results:
+
+- Targeted tests: passed, 6 tests.
+- TypeScript: passed.
+
+## AutoClip Dry-Run E2E
+
+Command under test:
+
+```bash
+qcut edit autoclip \
+  -i video.mp4 \
+  --srt-file subs.srt \
+  --min-score 0.8 \
+  --dry-run
+```
+
+Real command before changing the default:
+
+```bash
+set -a
+source /Users/peter/.qcut/.env
+set +a
+
+TMP="/tmp/qcut-autoclip-e2e-1779396996"
+
+bun /Users/peter/Desktop/code/qcut/qcut/electron/native-pipeline/cli/cli.ts edit autoclip \
+  -i "$TMP/video.mp4" \
+  --srt-file "$TMP/subs.srt" \
+  --min-score 0.8 \
+  --model google/gemini-3.5-flash \
+  --dry-run \
+  -o "$TMP/out" \
+  --json
+```
+
+Result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "schema_version": "1",
+    "command": "autoclip",
+    "data": {
+      "dryRun": true,
+      "topics": 2,
+      "segments": 1,
+      "highScore": 1,
+      "threshold": 0.8,
+      "metadataDir": "/tmp/qcut-autoclip-e2e-1779396996/out/autoclip-metadata"
+    }
+  },
+  "duration_ms": 19895
+}
+```
+
+Evidence files:
+
+```text
+/tmp/qcut-autoclip-e2e-1779396996/out/autoclip-metadata/step1_outline.json
+/tmp/qcut-autoclip-e2e-1779396996/out/autoclip-metadata/step2_timeline.json
+/tmp/qcut-autoclip-e2e-1779396996/out/autoclip-metadata/step3_all_scores.json
+/tmp/qcut-autoclip-e2e-1779396996/out/autoclip-metadata/step3_high_scores.json
+```
+
+High-score output:
+
+```json
+{
+  "id": "1",
+  "outline": "Morning Routine Setup, Playful Reveal and Wrap-up",
+  "startTime": "00:00:00,000",
+  "endTime": "00:02:05,000",
+  "finalScore": 0.82,
+  "recommendReason": "Strong visual hooks and clear structure make this lifestyle routine highly engaging. The before-and-after transition offers great viral potential for social media platforms."
+}
+```
+
+Default model update:
+
+- `electron/native-pipeline/autoclip/steps/step-outline.ts`
+- `electron/native-pipeline/autoclip/steps/step-timeline.ts`
+- `electron/native-pipeline/autoclip/steps/step-scoring.ts`
+- `electron/native-pipeline/cli/command-registry.ts`
+
+The autoclip default is now:
+
+```text
+google/gemini-3.5-flash
+```
+
+Default-model E2E command, intentionally no `--model`:
+
+```bash
+TMP="/tmp/qcut-autoclip-default-35-e2e-1779398240"
+
+bun /Users/peter/Desktop/code/qcut/qcut/electron/native-pipeline/cli/cli.ts edit autoclip \
+  -i "$TMP/video.mp4" \
+  --srt-file "$TMP/subs.srt" \
+  --min-score 0.8 \
+  --dry-run \
+  -o "$TMP/out" \
+  --json
+```
+
+Result:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "schema_version": "1",
+    "command": "autoclip",
+    "data": {
+      "dryRun": true,
+      "topics": 2,
+      "segments": 1,
+      "highScore": 1,
+      "threshold": 0.8,
+      "metadataDir": "/tmp/qcut-autoclip-default-35-e2e-1779398240/out/autoclip-metadata"
+    }
+  },
+  "duration_ms": 19803
+}
+```
+
+Default high-score output:
+
+```json
+{
+  "id": "1",
+  "outline": "Morning Routine Setup, Playful Reveal, and Wrap-up",
+  "startTime": "00:00:00,000",
+  "endTime": "00:02:05,000",
+  "finalScore": 0.8,
+  "recommendReason": "Strong aesthetic appeal with a clear visual hook and a satisfying before-and-after reveal, making it highly shareable for lifestyle and wellness audiences."
+}
+```
+
+Conclusion:
+
+- `qcut edit autoclip --dry-run` works end-to-end with a supplied SRT.
+- It produced one highlight above `--min-score 0.8`.
+- It did not cut a file because `--dry-run` was intentionally enabled.
+- This path is subtitle/text driven. It does not inspect video pixels directly.
+- Default autoclip model is now `google/gemini-3.5-flash`, verified by CLI help and a no-`--model` dry-run E2E.

--- a/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/01-current-state.md
+++ b/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/01-current-state.md
@@ -1,0 +1,265 @@
+# Current State: QCut Daytona Outputs and WZRD Asset Reference
+
+Date: 2026-05-22
+
+## QCut Web/Daytona Flow Today
+
+The QCut website Chat Agent has two related artifact paths:
+
+1. Interactive Daytona session files.
+2. Headless agent job artifacts.
+
+### Interactive Daytona Session Files
+
+The current web UI treats the sandbox as the live workspace:
+
+- uploaded user files go to `/tmp/qcut-input`;
+- generated outputs should go to `/tmp/qcut-output`;
+- temporary tools can live under `/tmp/qcut-tools`;
+- the file browser lists active sandbox paths;
+- users can navigate folders, preview images/text/JSON/Markdown, copy paths, download files, and download folders.
+
+Important existing files:
+
+- `packages/nexusai-website/js/agent-chat/01-runtime-api.js`
+- `packages/nexusai-website/js/agent-chat/02-ui-files.js`
+- `packages/license-server/src/routes/agent-parts/files.ts`
+
+Existing docs:
+
+- `docs/task/daytona-supabase-agent/implementation/16-chat-agent-file-browser-stack.md`
+- `docs/task/daytona-supabase-agent/implementation/25-chat-agent-file-preview.md`
+- `docs/task/daytona-supabase-agent/implementation/28-upload-files-artifacts-e2e.md`
+
+The live file browser is good for "what is in the current sandbox right now". It is not yet an asset library.
+
+### Headless Agent Job Artifacts
+
+For queued jobs, QCut already persists output files to Supabase Storage:
+
+- worker walks the output directory;
+- uploads files to the `artifacts` bucket;
+- inserts `agent_artifacts` rows;
+- license-server routes can list/download artifact rows.
+
+Important existing files:
+
+- `packages/agent-worker/src/upload-artifacts.ts`
+- `packages/db/src/schema.ts`
+- `packages/license-server/src/routes/agent-parts/jobs.ts`
+
+Current schema shape:
+
+```text
+agent_jobs
+agent_events
+agent_artifacts
+agent_sessions
+```
+
+`agent_artifacts` is job-scoped. It stores kind, storage path, bytes, metadata, and job/user ownership. That is useful, but it is still not a user-facing reusable asset library.
+
+## What QCut Has Already Solved
+
+- Real cloud sandbox execution with Daytona.
+- A known input/output convention: `/tmp/qcut-input` and `/tmp/qcut-output`.
+- Browser-side upload to sandbox.
+- Browser-side artifact navigation and file preview.
+- Download routes that understand sandbox paths and session ownership.
+- Job artifact persistence for headless runs.
+- File kind classification for common media and text outputs.
+
+These pieces reduce the migration difficulty a lot. The live workspace does not need to be invented again.
+
+## What QCut Has Not Solved Yet
+
+- Durable asset identity independent of a sandbox path or job id.
+- Asset search/filtering across many runs.
+- Collections/folders/tags as a user organization model.
+- Reuse tracking: "this video used these portrait images and this storyboard frame".
+- Generated metadata: prompt, model, provider, command, seed, parent assets, scene id, character id.
+- Thumbnail/proxy generation for large video/audio.
+- Signed URL strategy for private storage.
+- Storage quotas and cleanup/archival policy.
+- A clean web affordance for selecting assets as references for the next QCut command.
+
+## WZRD Reference System
+
+The `wzrdagentstudio-main` repo already has a Supabase-style asset management design:
+
+- `src/components/assets/AssetUploader.tsx`
+- `src/components/assets/AssetLibrary.tsx`
+- `src/hooks/useAssets.ts`
+- `src/services/assetService.ts`
+- `src/types/assets.ts`
+- `supabase/functions/asset-upload/index.ts`
+- `supabase/functions/asset-processor/index.ts`
+- `supabase/migrations/20251116210000_create_asset_management_system.sql`
+- `supabase/migrations/20251116210200_storage_buckets_setup.sql`
+
+Useful ideas to reuse:
+
+- `project_assets` as durable metadata.
+- `asset_usage` for dependency tracking.
+- `asset_collections` and `asset_collection_items`.
+- `project-assets`, `asset-thumbnails`, and `asset-previews` buckets.
+- path convention like `{userId}/{projectId}/{assetType}/{filename}`;
+- private primary bucket, public/signed thumbnail and preview strategy;
+- processing queue for thumbnails, video previews, metadata extraction.
+
+## Direct Reuse Caveat
+
+The QCut website is currently mostly static HTML/JS around `chat-agent.html`. WZRD is React/Vite/Supabase with TanStack Query and shadcn UI.
+
+So the best reuse is architectural:
+
+- reuse schema ideas;
+- reuse upload/processing concepts;
+- reuse asset metadata vocabulary;
+- maybe copy small service patterns later if QCut moves to a React page.
+
+Direct component copy/paste is low value unless the QCut web surface is also migrated to a React app.
+
+## Current-State Conclusion
+
+QCut has a working live sandbox workspace. WZRD has a working asset-library pattern. The migration should connect these two ideas:
+
+```text
+QCut live output files -> durable Supabase assets -> selectable references -> future QCut runs
+```
+
+The first milestone should persist outputs without disturbing the current file browser.
+
+---
+
+# 现状：QCut Daytona Outputs 与 WZRD Asset Reference
+
+日期：2026-05-22
+
+## 今天的 QCut Web/Daytona 流程
+
+QCut 网站 Chat Agent 现在有两条相关的 artifact 路径：
+
+1. 交互式 Daytona session files。
+2. Headless agent job artifacts。
+
+### 交互式 Daytona Session Files
+
+当前网页 UI 把 sandbox 当成 live workspace：
+
+- 用户上传文件进入 `/tmp/qcut-input`；
+- 生成产物应该写到 `/tmp/qcut-output`；
+- 临时工具可以放在 `/tmp/qcut-tools`；
+- file browser 可以列出 active sandbox paths；
+- 用户可以进入文件夹、预览图片/文本/JSON/Markdown、复制路径、下载文件、下载文件夹。
+
+重要文件：
+
+- `packages/nexusai-website/js/agent-chat/01-runtime-api.js`
+- `packages/nexusai-website/js/agent-chat/02-ui-files.js`
+- `packages/license-server/src/routes/agent-parts/files.ts`
+
+已有文档：
+
+- `docs/task/daytona-supabase-agent/implementation/16-chat-agent-file-browser-stack.md`
+- `docs/task/daytona-supabase-agent/implementation/25-chat-agent-file-preview.md`
+- `docs/task/daytona-supabase-agent/implementation/28-upload-files-artifacts-e2e.md`
+
+live file browser 很适合回答“当前 sandbox 里现在有什么”。但它还不是资产库。
+
+### Headless Agent Job Artifacts
+
+对于 queued jobs，QCut 已经会把 output files 持久化到 Supabase Storage：
+
+- worker 遍历 output directory；
+- 上传文件到 `artifacts` bucket；
+- 插入 `agent_artifacts` rows；
+- license-server routes 可以列出/下载 artifact rows。
+
+重要文件：
+
+- `packages/agent-worker/src/upload-artifacts.ts`
+- `packages/db/src/schema.ts`
+- `packages/license-server/src/routes/agent-parts/jobs.ts`
+
+当前 schema 形状：
+
+```text
+agent_jobs
+agent_events
+agent_artifacts
+agent_sessions
+```
+
+`agent_artifacts` 是 job-scoped。它存 kind、storage path、bytes、metadata 和 job/user ownership。这个很有用，但它仍然不是面向用户的 reusable asset library。
+
+## QCut 已经解决的部分
+
+- 真实云端 Daytona sandbox 执行。
+- 明确的 input/output convention：`/tmp/qcut-input` 和 `/tmp/qcut-output`。
+- 浏览器上传到 sandbox。
+- 浏览器里 artifact navigation 和 file preview。
+- download routes 能理解 sandbox paths 和 session ownership。
+- headless runs 的 job artifact persistence。
+- 常见 media/text outputs 的 file kind classification。
+
+这些都显著降低了迁移难度。live workspace 不需要重新发明。
+
+## QCut 还没有解决的部分
+
+- 脱离 sandbox path 或 job id 的 durable asset identity。
+- 跨多次生成 run 的 asset search/filtering。
+- 用户组织模型：collections/folders/tags。
+- reuse tracking：比如“这个视频用了哪些 portrait images 和 storyboard frame”。
+- 生成 metadata：prompt、model、provider、command、seed、parent assets、scene id、character id。
+- 大视频/音频的 thumbnail/proxy generation。
+- private storage 的 signed URL 策略。
+- storage quota 和 cleanup/archival policy。
+- 一个清晰的网页交互，让用户选择 assets 作为下一次 QCut command 的 references。
+
+## WZRD 参考系统
+
+`wzrdagentstudio-main` 已经有一套 Supabase 风格资产管理设计：
+
+- `src/components/assets/AssetUploader.tsx`
+- `src/components/assets/AssetLibrary.tsx`
+- `src/hooks/useAssets.ts`
+- `src/services/assetService.ts`
+- `src/types/assets.ts`
+- `supabase/functions/asset-upload/index.ts`
+- `supabase/functions/asset-processor/index.ts`
+- `supabase/migrations/20251116210000_create_asset_management_system.sql`
+- `supabase/migrations/20251116210200_storage_buckets_setup.sql`
+
+值得复用的思想：
+
+- `project_assets` 作为 durable metadata。
+- `asset_usage` 做依赖/使用追踪。
+- `asset_collections` 和 `asset_collection_items`。
+- `project-assets`、`asset-thumbnails`、`asset-previews` buckets。
+- 类似 `{userId}/{projectId}/{assetType}/{filename}` 的路径约定。
+- primary bucket private，thumbnail/preview 用 public 或 signed URL。
+- processing queue 做 thumbnail、video preview、metadata extraction。
+
+## 直接复用的注意点
+
+QCut 网站现在主要是 `chat-agent.html` 周围的 static HTML/JS。WZRD 是 React/Vite/Supabase，使用 TanStack Query 和 shadcn UI。
+
+所以最值得复用的是 architecture：
+
+- 复用 schema ideas；
+- 复用 upload/processing concepts；
+- 复用 asset metadata vocabulary；
+- 如果 QCut 以后迁到 React 页面，再考虑复用小的 service/UI patterns。
+
+直接 copy/paste WZRD components 的价值不高，除非 QCut web surface 也迁移到 React app。
+
+## 现状结论
+
+QCut 有 working live sandbox workspace。WZRD 有 working asset-library pattern。迁移应该连接这两个东西：
+
+```text
+QCut live output files -> durable Supabase assets -> selectable references -> future QCut runs
+```
+
+第一个 milestone 应该是在不打扰当前 file browser 的情况下，把 outputs 持久化下来。

--- a/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/02-target-architecture.md
+++ b/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/02-target-architecture.md
@@ -1,0 +1,483 @@
+# Target Architecture: Durable QCut Assets on Supabase
+
+Date: 2026-05-22
+
+## Product Model
+
+The web product should expose two different surfaces:
+
+| Surface | Purpose | Lifetime |
+| --- | --- | --- |
+| Sandbox files | Live Daytona filesystem, debugging, immediate preview/download | Session-scoped |
+| Asset library | Durable generated/uploaded media, reusable references, searchable history | User/project-scoped |
+
+This separation matters. The sandbox is a workspace. The asset library is a memory.
+
+## Target Flow
+
+```text
+1. User uploads inputs
+   -> /tmp/qcut-input
+
+2. User runs QCut command in Daytona
+   -> qcut flow portraits/storyboard/novel2movie/etc.
+   -> outputs under /tmp/qcut-output
+
+3. Web app ingests selected/all outputs
+   -> Supabase Storage
+   -> durable asset metadata rows
+   -> thumbnails/previews if needed
+
+4. User browses asset library
+   -> preview images/text/video
+   -> search/filter by type, command, model, prompt, run, character, scene
+   -> organize into collections
+
+5. User reuses assets
+   -> selected assets are copied into /tmp/qcut-input
+   -> or passed as signed URLs / asset ids to QCut
+   -> usage links are recorded
+```
+
+## Storage Layout
+
+Recommended buckets:
+
+| Bucket | Privacy | Contents |
+| --- | --- | --- |
+| `qcut-assets` or `project-assets` | private | original uploaded/generated files |
+| `qcut-thumbnails` or `asset-thumbnails` | public or signed | image thumbnails and poster frames |
+| `qcut-previews` or `asset-previews` | public or signed | low-res video/audio preview proxies |
+
+If QCut shares the same Supabase project as WZRD, prefer reusing `project-assets`, `asset-thumbnails`, and `asset-previews` rather than creating parallel buckets. If QCut remains a separate product/backend, use QCut-specific bucket names.
+
+Recommended storage path:
+
+```text
+{userId}/{projectIdOrDefault}/qcut/{runId}/{assetType}/{safeFileName}
+```
+
+For interactive sandbox outputs with no project id:
+
+```text
+{userId}/personal/qcut/{sessionId}/{timestamp}/{assetType}/{safeFileName}
+```
+
+## Metadata Model
+
+There are two reasonable options.
+
+### Option A: Extend `agent_artifacts`
+
+Add enough columns to make job artifacts reusable.
+
+Pros:
+
+- smaller migration from current QCut worker;
+- existing job detail/download APIs stay useful;
+- fast MVP.
+
+Cons:
+
+- `agent_artifacts` is job-scoped, not library-scoped;
+- weak support for collections, usage tracking, search, thumbnails, and user organization;
+- likely becomes cramped as the product grows.
+
+### Option B: Add/Reuse a Real Asset Table
+
+Create `qcut_assets`, or reuse WZRD's `project_assets`.
+
+Recommended durable fields:
+
+```text
+id
+user_id
+project_id
+source_kind              -- upload | qcut_generated | imported
+source_session_id
+source_job_id
+source_sandbox_path
+source_command
+asset_type               -- image | video | audio | document | json | text | other
+mime_type
+file_size_bytes
+storage_bucket
+storage_path
+thumbnail_bucket
+thumbnail_path
+preview_bucket
+preview_path
+original_file_name
+display_name
+visibility
+processing_status
+generation_metadata      -- prompt, model, provider, seed, scene_id, character_id, command args
+created_at
+updated_at
+last_accessed_at
+```
+
+Recommended related tables:
+
+```text
+qcut_asset_usage
+qcut_asset_collections
+qcut_asset_collection_items
+qcut_asset_derivations
+```
+
+`qcut_asset_derivations` is useful because QCut workflows are graph-like:
+
+```text
+portrait image -> storyboard frame -> video clip -> final edit
+```
+
+It should record parent-child asset relationships.
+
+## Reuse Contract
+
+Asset reuse should support both local-file and URL-based providers.
+
+### Local File Reuse
+
+For CLI commands that expect file paths:
+
+```text
+selected asset
+  -> license-server creates signed download/read
+  -> copies file into Daytona /tmp/qcut-input/assets/{assetId}-{filename}
+  -> prompt/command uses local path
+```
+
+This is the most reliable path because many CLI flows already work with local files.
+
+### URL Reuse
+
+For providers that accept remote URLs:
+
+```text
+selected asset
+  -> create short-lived signed URL
+  -> pass URL to CLI/provider
+```
+
+This avoids copying large files but requires provider support and careful URL expiry handling.
+
+### Multi-Reference Reuse
+
+QCut video/image flows should support multiple references:
+
+```text
+--reference /tmp/qcut-input/assets/ref-1.png
+--reference /tmp/qcut-input/assets/ref-2.png
+--reference /tmp/qcut-input/assets/ref-3.mp4
+```
+
+or, where the CLI supports it:
+
+```text
+--references /tmp/qcut-input/references.json
+```
+
+The JSON shape is cleaner for complex flows:
+
+```json
+{
+  "references": [
+    {
+      "assetId": "asset_1",
+      "path": "/tmp/qcut-input/assets/asset_1.png",
+      "role": "character_portrait",
+      "weight": 0.8
+    },
+    {
+      "assetId": "asset_2",
+      "path": "/tmp/qcut-input/assets/asset_2.png",
+      "role": "style_reference",
+      "weight": 0.4
+    }
+  ]
+}
+```
+
+## Web UI Shape
+
+Minimum useful UI:
+
+- live sandbox files panel remains as-is;
+- asset library panel/page shows durable assets;
+- filters: all, images, video, audio, text/json, generated, uploaded;
+- preview modal/new tab;
+- right-click: preview, download, copy asset id, copy storage path, copy sandbox import command, use as reference;
+- action: "Save selected sandbox outputs to Assets";
+- action: "Use selected assets in next QCut run";
+- detail drawer: prompt/model/provider/source command/parent assets.
+
+## Security Model
+
+Prefer private original assets with signed URLs.
+
+Rules:
+
+- user can only list/read/write assets under their own user id;
+- project assets require membership check once project/team support exists;
+- service role can ingest from worker/server;
+- preview and thumbnail buckets can be public only if they contain no sensitive originals;
+- large original video download should avoid proxying when signed URL is safe enough.
+
+## Target Architecture Conclusion
+
+The clean architecture is:
+
+```text
+Daytona = live workspace
+Supabase Storage = durable binary store
+Asset table = product memory and search index
+Usage/derivation tables = reuse/provenance graph
+QCut CLI = generation engine
+```
+
+This keeps QCut's CLI power while making the web app feel like a real creative asset workspace.
+
+---
+
+# 目标架构：Supabase 上的 Durable QCut Assets
+
+日期：2026-05-22
+
+## 产品模型
+
+网页端应该暴露两个不同 surface：
+
+| Surface | 目的 | 生命周期 |
+| --- | --- | --- |
+| Sandbox files | 真实 Daytona filesystem、debug、即时预览/下载 | Session-scoped |
+| Asset library | 持久 generated/uploaded media、可复用 references、可搜索历史 | User/project-scoped |
+
+这个区分很重要。Sandbox 是工作区，Asset library 是记忆。
+
+## 目标流程
+
+```text
+1. 用户上传 inputs
+   -> /tmp/qcut-input
+
+2. 用户在 Daytona 里运行 QCut command
+   -> qcut flow portraits/storyboard/novel2movie/etc.
+   -> outputs under /tmp/qcut-output
+
+3. Web app ingest selected/all outputs
+   -> Supabase Storage
+   -> durable asset metadata rows
+   -> thumbnails/previews if needed
+
+4. 用户浏览 asset library
+   -> preview images/text/video
+   -> 按 type、command、model、prompt、run、character、scene 搜索/过滤
+   -> organize into collections
+
+5. 用户复用 assets
+   -> selected assets are copied into /tmp/qcut-input
+   -> or passed as signed URLs / asset ids to QCut
+   -> usage links are recorded
+```
+
+## Storage Layout
+
+推荐 buckets：
+
+| Bucket | 隐私 | 内容 |
+| --- | --- | --- |
+| `qcut-assets` 或 `project-assets` | private | 原始上传/生成文件 |
+| `qcut-thumbnails` 或 `asset-thumbnails` | public 或 signed | image thumbnails 和 poster frames |
+| `qcut-previews` 或 `asset-previews` | public 或 signed | low-res video/audio preview proxies |
+
+如果 QCut 和 WZRD 共用同一个 Supabase project，优先复用 `project-assets`、`asset-thumbnails`、`asset-previews`，不要再造一套平行 bucket。如果 QCut 保持独立 backend，则使用 QCut-specific bucket names。
+
+推荐 storage path：
+
+```text
+{userId}/{projectIdOrDefault}/qcut/{runId}/{assetType}/{safeFileName}
+```
+
+对于没有 project id 的 interactive sandbox outputs：
+
+```text
+{userId}/personal/qcut/{sessionId}/{timestamp}/{assetType}/{safeFileName}
+```
+
+## Metadata Model
+
+有两个合理选择。
+
+### 方案 A：扩展 `agent_artifacts`
+
+给现有 job artifacts 增加足够字段，让它可以复用。
+
+优点：
+
+- 从当前 QCut worker 迁移成本更小；
+- 现有 job detail/download APIs 继续可用；
+- MVP 快。
+
+缺点：
+
+- `agent_artifacts` 是 job-scoped，不是 library-scoped；
+- 对 collection、usage tracking、search、thumbnail、用户组织支持弱；
+- 产品一复杂就会变挤。
+
+### 方案 B：新增/复用真正的 Asset Table
+
+创建 `qcut_assets`，或复用 WZRD 的 `project_assets`。
+
+推荐 durable fields：
+
+```text
+id
+user_id
+project_id
+source_kind              -- upload | qcut_generated | imported
+source_session_id
+source_job_id
+source_sandbox_path
+source_command
+asset_type               -- image | video | audio | document | json | text | other
+mime_type
+file_size_bytes
+storage_bucket
+storage_path
+thumbnail_bucket
+thumbnail_path
+preview_bucket
+preview_path
+original_file_name
+display_name
+visibility
+processing_status
+generation_metadata      -- prompt, model, provider, seed, scene_id, character_id, command args
+created_at
+updated_at
+last_accessed_at
+```
+
+推荐相关表：
+
+```text
+qcut_asset_usage
+qcut_asset_collections
+qcut_asset_collection_items
+qcut_asset_derivations
+```
+
+`qcut_asset_derivations` 很有用，因为 QCut workflows 是 graph-like：
+
+```text
+portrait image -> storyboard frame -> video clip -> final edit
+```
+
+它应该记录 parent-child asset relationships。
+
+## Reuse Contract
+
+资产复用应该同时支持 local-file 和 URL-based providers。
+
+### Local File Reuse
+
+对于期待 file paths 的 CLI commands：
+
+```text
+selected asset
+  -> license-server creates signed download/read
+  -> copies file into Daytona /tmp/qcut-input/assets/{assetId}-{filename}
+  -> prompt/command uses local path
+```
+
+这是最可靠的路径，因为很多 CLI flows 已经支持 local files。
+
+### URL Reuse
+
+对于接受 remote URLs 的 providers：
+
+```text
+selected asset
+  -> create short-lived signed URL
+  -> pass URL to CLI/provider
+```
+
+这能避免复制大文件，但需要 provider 支持，并且要谨慎处理 URL expiry。
+
+### Multi-Reference Reuse
+
+QCut video/image flows 应该支持 multiple references：
+
+```text
+--reference /tmp/qcut-input/assets/ref-1.png
+--reference /tmp/qcut-input/assets/ref-2.png
+--reference /tmp/qcut-input/assets/ref-3.mp4
+```
+
+或者在 CLI 支持时：
+
+```text
+--references /tmp/qcut-input/references.json
+```
+
+复杂 flows 用 JSON shape 更干净：
+
+```json
+{
+  "references": [
+    {
+      "assetId": "asset_1",
+      "path": "/tmp/qcut-input/assets/asset_1.png",
+      "role": "character_portrait",
+      "weight": 0.8
+    },
+    {
+      "assetId": "asset_2",
+      "path": "/tmp/qcut-input/assets/asset_2.png",
+      "role": "style_reference",
+      "weight": 0.4
+    }
+  ]
+}
+```
+
+## Web UI 形态
+
+最小可用 UI：
+
+- live sandbox files panel 保持现状；
+- asset library panel/page 展示 durable assets；
+- filters：all、images、video、audio、text/json、generated、uploaded；
+- preview modal/new tab；
+- 右键：preview、download、copy asset id、copy storage path、copy sandbox import command、use as reference；
+- action：`Save selected sandbox outputs to Assets`；
+- action：`Use selected assets in next QCut run`；
+- detail drawer：prompt/model/provider/source command/parent assets。
+
+## Security Model
+
+推荐 private original assets + signed URLs。
+
+规则：
+
+- user 只能 list/read/write 自己 user id 下的 assets；
+- 一旦有 project/team 支持，project assets 需要 membership check；
+- service role 可以从 worker/server ingest；
+- preview 和 thumbnail buckets 可以 public，但前提是里面没有敏感 original；
+- 大视频下载能用 signed URL 就不要走 proxy。
+
+## 目标架构结论
+
+清晰的架构是：
+
+```text
+Daytona = live workspace
+Supabase Storage = durable binary store
+Asset table = product memory and search index
+Usage/derivation tables = reuse/provenance graph
+QCut CLI = generation engine
+```
+
+这样既保留 QCut CLI 的能力，又让网页端体验像一个真正的 creative asset workspace。

--- a/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/03-implementation-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/03-implementation-plan.md
@@ -1,0 +1,535 @@
+# Implementation Plan: QCut Outputs to Reusable Web Assets
+
+Date: 2026-05-22
+
+## Phase 0: Define the Contract
+
+Goal: make the vocabulary stable before changing code.
+
+Decisions:
+
+- Use WZRD `project_assets` style or create QCut-specific `qcut_assets`.
+- Decide whether project id is required or optional.
+- Decide whether `agent_artifacts` remains job history only, or becomes linked to durable assets.
+- Decide storage bucket names.
+- Define supported asset types: image, video, audio, document, json, text, folder/archive, other.
+- Define reference injection mode: local copy, signed URL, or both.
+
+Suggested decision:
+
+- Keep `agent_artifacts` as job/session history.
+- Add a durable asset table or reuse `project_assets`.
+- Add a linking field/table: `agent_artifact_id -> asset_id`.
+
+Deliverables:
+
+- schema plan;
+- API contract;
+- UI copy for "Sandbox files" vs "Assets".
+
+Estimated effort: 1-2 days.
+
+## Phase 1: Persist QCut Outputs as Assets
+
+Goal: from the current sandbox output list, save selected/all files into durable storage.
+
+Backend work:
+
+- Add an ingest route:
+
+```text
+POST /api/agent/sessions/:sessionId/assets/ingest
+```
+
+Request:
+
+```json
+{
+  "paths": ["/tmp/qcut-output/frame-001.png"],
+  "projectId": null,
+  "collectionId": null,
+  "mode": "selected"
+}
+```
+
+Response:
+
+```json
+{
+  "assets": [
+    {
+      "id": "asset_id",
+      "assetType": "image",
+      "storagePath": "user/project/qcut/run/image/frame-001.png"
+    }
+  ]
+}
+```
+
+Implementation notes:
+
+- reuse existing Daytona file download/read path;
+- stream files to Supabase Storage;
+- insert asset rows in one transaction when possible;
+- best-effort rollback storage if metadata insert fails;
+- preserve original sandbox path in metadata;
+- record source session id, command/job if known, file bytes, MIME type.
+
+Frontend work:
+
+- add "Save to Assets" action to file context menu;
+- add "Save folder to Assets" for folders;
+- add status and error reporting;
+- keep download/preview behavior unchanged.
+
+Testing:
+
+- unit tests for path validation and file classification;
+- integration test for ingest route with mocked Daytona FS and mocked storage;
+- Playwright E2E: create image/json/text files in `/tmp/qcut-output`, save to assets, verify library list.
+
+Estimated effort: 5-8 days.
+
+## Phase 2: Asset Library UI
+
+Goal: users can browse durable QCut assets without needing the sandbox alive.
+
+UI options:
+
+1. Add an asset tab/page to current static `chat-agent.html`.
+2. Build a React page and gradually move Chat Agent UI into React.
+3. Integrate QCut into WZRD and use WZRD's existing AssetLibrary patterns.
+
+Recommended MVP:
+
+- keep current static UI;
+- add a lightweight assets panel using plain JS and license-server APIs;
+- do not block on a React migration.
+
+Library features:
+
+- list assets;
+- filter by type;
+- preview image/text/json/video;
+- download;
+- copy asset id/path;
+- show source command/session;
+- delete/archive;
+- select assets for reuse.
+
+Backend routes:
+
+```text
+GET    /api/assets
+GET    /api/assets/:assetId
+GET    /api/assets/:assetId/download
+POST   /api/assets/:assetId/signed-url
+PATCH  /api/assets/:assetId
+DELETE /api/assets/:assetId
+```
+
+Testing:
+
+- route authorization tests;
+- UI tests for preview/download/copy path;
+- user isolation test.
+
+Estimated effort: 1-2 weeks.
+
+## Phase 3: Reuse Assets in QCut Runs
+
+Goal: selected assets become inputs/references for new QCut commands.
+
+Backend work:
+
+- add route to import assets into current Daytona sandbox:
+
+```text
+POST /api/agent/sessions/:sessionId/assets/import
+```
+
+Request:
+
+```json
+{
+  "assetIds": ["asset_1", "asset_2"],
+  "targetFolder": "/tmp/qcut-input/assets",
+  "writeReferencesJson": true
+}
+```
+
+Response:
+
+```json
+{
+  "files": [
+    {
+      "assetId": "asset_1",
+      "path": "/tmp/qcut-input/assets/asset_1.png"
+    }
+  ],
+  "referencesPath": "/tmp/qcut-input/references.json"
+}
+```
+
+Frontend work:
+
+- asset selection mode;
+- "Use in next prompt" or "Import to sandbox";
+- display generated local paths;
+- optionally inject a suggested command snippet into Codex input.
+
+QCut CLI consideration:
+
+- existing commands can already accept normal file paths in many cases;
+- for complex multi-reference workflows, a `--references` JSON option would be cleaner than many repeated flags;
+- this can be added incrementally per command, starting with image/video reference flows.
+
+Testing:
+
+- import image asset into sandbox;
+- run a real QCut image/video command using imported reference;
+- verify `asset_usage` or equivalent records the reuse.
+
+Estimated effort: 1-2 weeks depending on how much CLI reference normalization is required.
+
+## Phase 4: Processing, Provenance, and Hardening
+
+Goal: make it production-grade.
+
+Processing:
+
+- thumbnail for images;
+- poster frame and low-res preview for video;
+- waveform or duration metadata for audio;
+- text/json previews with size caps;
+- EXIF/media metadata extraction where useful.
+
+Provenance:
+
+- source command;
+- prompt;
+- model;
+- provider;
+- seed;
+- runtime duration;
+- parent asset ids;
+- QCut flow stage: characters, portraits, storyboard, video, final export.
+
+Security:
+
+- private originals;
+- signed URLs;
+- user/project RLS;
+- path normalization;
+- no arbitrary sandbox path ingestion outside allowed roots.
+
+Operations:
+
+- storage quota;
+- cleanup orphan rows/files;
+- retry failed processing;
+- clear error states;
+- admin audit view.
+
+Testing:
+
+- RLS/user isolation;
+- large video ingest/download;
+- signed URL expiry;
+- thumbnail generation failure path;
+- retry and cleanup jobs.
+
+Estimated effort: 2-3 additional weeks.
+
+## Migration Sequence
+
+Recommended order:
+
+1. Do not remove current sandbox file browser.
+2. Add durable asset schema and storage bucket.
+3. Add server-side ingest from `/tmp/qcut-output`.
+4. Add "Save to Assets" from file/folder context menu.
+5. Add asset library list/preview/download.
+6. Add import selected assets back into `/tmp/qcut-input`.
+7. Add usage/derivation tracking.
+8. Add thumbnails/previews and cleanup jobs.
+
+## Implementation Plan Conclusion
+
+The smallest valuable version is:
+
+```text
+Generate in QCut -> save selected outputs to Assets -> preview/download later -> import selected assets into next QCut run
+```
+
+That can be built without rewriting the whole web app.
+
+---
+
+# 实施计划：QCut Outputs 到可复用 Web Assets
+
+日期：2026-05-22
+
+## Phase 0：定义 Contract
+
+目标：在改代码前先稳定词汇和边界。
+
+需要决策：
+
+- 使用 WZRD `project_assets` 风格，还是创建 QCut-specific `qcut_assets`。
+- project id 是必需还是可选。
+- `agent_artifacts` 只保留 job history，还是和 durable assets 建立链接。
+- storage bucket names。
+- 支持的 asset types：image、video、audio、document、json、text、folder/archive、other。
+- reference injection mode：local copy、signed URL，或两者都支持。
+
+推荐决策：
+
+- `agent_artifacts` 保持 job/session history。
+- 新增 durable asset table，或复用 `project_assets`。
+- 加一个 linking field/table：`agent_artifact_id -> asset_id`。
+
+交付物：
+
+- schema plan；
+- API contract；
+- UI 文案：`Sandbox files` vs `Assets`。
+
+预计工作量：1-2 天。
+
+## Phase 1：把 QCut Outputs 持久化成 Assets
+
+目标：从当前 sandbox output list 里，把 selected/all files 保存到 durable storage。
+
+Backend work：
+
+- 新增 ingest route：
+
+```text
+POST /api/agent/sessions/:sessionId/assets/ingest
+```
+
+Request：
+
+```json
+{
+  "paths": ["/tmp/qcut-output/frame-001.png"],
+  "projectId": null,
+  "collectionId": null,
+  "mode": "selected"
+}
+```
+
+Response：
+
+```json
+{
+  "assets": [
+    {
+      "id": "asset_id",
+      "assetType": "image",
+      "storagePath": "user/project/qcut/run/image/frame-001.png"
+    }
+  ]
+}
+```
+
+实现注意：
+
+- 复用现有 Daytona file download/read path；
+- stream files 到 Supabase Storage；
+- 尽可能用 transaction 插入 asset rows；
+- metadata insert 失败时 best-effort rollback storage；
+- 保留 original sandbox path；
+- 记录 source session id、command/job、file bytes、MIME type。
+
+Frontend work：
+
+- file context menu 加 `Save to Assets`；
+- folder context menu 加 `Save folder to Assets`；
+- 加 status 和 error reporting；
+- 保持现有 download/preview behavior 不变。
+
+Testing：
+
+- path validation 和 file classification 的 unit tests；
+- mocked Daytona FS + mocked storage 的 ingest route integration test；
+- Playwright E2E：在 `/tmp/qcut-output` 创建 image/json/text files，save to assets，验证 library list。
+
+预计工作量：5-8 天。
+
+## Phase 2：Asset Library UI
+
+目标：用户不需要 sandbox 还活着，也能浏览 durable QCut assets。
+
+UI options：
+
+1. 给当前 static `chat-agent.html` 加 asset tab/page。
+2. 建一个 React page，并逐步把 Chat Agent UI 迁过去。
+3. 把 QCut 整合进 WZRD，使用 WZRD 现有 AssetLibrary patterns。
+
+推荐 MVP：
+
+- 保持当前 static UI；
+- 用 plain JS + license-server APIs 加一个 lightweight assets panel；
+- 不要让 React migration 卡住 MVP。
+
+Library features：
+
+- list assets；
+- filter by type；
+- preview image/text/json/video；
+- download；
+- copy asset id/path；
+- show source command/session；
+- delete/archive；
+- select assets for reuse。
+
+Backend routes：
+
+```text
+GET    /api/assets
+GET    /api/assets/:assetId
+GET    /api/assets/:assetId/download
+POST   /api/assets/:assetId/signed-url
+PATCH  /api/assets/:assetId
+DELETE /api/assets/:assetId
+```
+
+Testing：
+
+- route authorization tests；
+- preview/download/copy path 的 UI tests；
+- user isolation test。
+
+预计工作量：1-2 周。
+
+## Phase 3：在 QCut Runs 中复用 Assets
+
+目标：被选中的 assets 能成为新 QCut commands 的 inputs/references。
+
+Backend work：
+
+- 新增 route，把 assets import 到当前 Daytona sandbox：
+
+```text
+POST /api/agent/sessions/:sessionId/assets/import
+```
+
+Request：
+
+```json
+{
+  "assetIds": ["asset_1", "asset_2"],
+  "targetFolder": "/tmp/qcut-input/assets",
+  "writeReferencesJson": true
+}
+```
+
+Response：
+
+```json
+{
+  "files": [
+    {
+      "assetId": "asset_1",
+      "path": "/tmp/qcut-input/assets/asset_1.png"
+    }
+  ],
+  "referencesPath": "/tmp/qcut-input/references.json"
+}
+```
+
+Frontend work：
+
+- asset selection mode；
+- `Use in next prompt` 或 `Import to sandbox`；
+- 展示生成的 local paths；
+- 可选：把推荐 command snippet 注入 Codex input。
+
+QCut CLI consideration：
+
+- 许多现有 commands 已经能接受普通 file paths；
+- 对复杂 multi-reference workflows，`--references` JSON option 会比很多重复 flags 更清晰；
+- 可以按 command 逐步添加，先从 image/video reference flows 开始。
+
+Testing：
+
+- import image asset into sandbox；
+- run real QCut image/video command using imported reference；
+- 验证 `asset_usage` 或同等记录写入 reuse。
+
+预计工作量：1-2 周，取决于 CLI reference normalization 的范围。
+
+## Phase 4：Processing、Provenance、Hardening
+
+目标：达到生产级。
+
+Processing：
+
+- image thumbnails；
+- video poster frame 和 low-res preview；
+- audio waveform 或 duration metadata；
+- text/json previews with size caps；
+- 必要时提取 EXIF/media metadata。
+
+Provenance：
+
+- source command；
+- prompt；
+- model；
+- provider；
+- seed；
+- runtime duration；
+- parent asset ids；
+- QCut flow stage：characters、portraits、storyboard、video、final export。
+
+Security：
+
+- private originals；
+- signed URLs；
+- user/project RLS；
+- path normalization；
+- 禁止 ingest allowed roots 以外的 arbitrary sandbox path。
+
+Operations：
+
+- storage quota；
+- cleanup orphan rows/files；
+- retry failed processing；
+- clear error states；
+- admin audit view。
+
+Testing：
+
+- RLS/user isolation；
+- large video ingest/download；
+- signed URL expiry；
+- thumbnail generation failure path；
+- retry and cleanup jobs。
+
+预计工作量：额外 2-3 周。
+
+## 迁移顺序
+
+推荐顺序：
+
+1. 不移除当前 sandbox file browser。
+2. 添加 durable asset schema 和 storage bucket。
+3. 添加从 `/tmp/qcut-output` ingest 的 server route。
+4. 给 file/folder context menu 加 `Save to Assets`。
+5. 添加 asset library list/preview/download。
+6. 把 selected assets import 回 `/tmp/qcut-input`。
+7. 添加 usage/derivation tracking。
+8. 添加 thumbnails/previews 和 cleanup jobs。
+
+## 实施计划结论
+
+最小有价值版本是：
+
+```text
+Generate in QCut -> save selected outputs to Assets -> preview/download later -> import selected assets into next QCut run
+```
+
+这个版本不需要重写整个 web app。

--- a/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/04-effort-risk-testing.md
+++ b/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/04-effort-risk-testing.md
@@ -1,0 +1,407 @@
+# Effort, Risks, and Testing
+
+Date: 2026-05-22
+
+## Work Estimate
+
+| Area | MVP effort | Production effort | Notes |
+| --- | ---: | ---: | --- |
+| Schema and storage buckets | 1-2 days | 3-5 days | More if sharing WZRD tables requires migration compatibility |
+| Ingest sandbox outputs to assets | 3-5 days | 1-2 weeks | Streaming, rollback, folders, large videos, MIME detection |
+| Asset library list/preview/download | 4-7 days | 2-3 weeks | Current preview code helps, but durable routes/auth are new |
+| Asset reuse into Daytona input | 3-6 days | 1-2 weeks | Local copy is easier than provider URL support |
+| Usage/provenance tracking | 2-4 days | 1-2 weeks | Important for generated media chains |
+| Thumbnails/proxy previews | 3-5 days | 1-2 weeks | Video proxies are the expensive part |
+| E2E and security tests | 3-5 days | 1-2 weeks | Must cover user isolation and large files |
+
+## Total Estimate
+
+### MVP
+
+Roughly 2-3 weeks for one engineer.
+
+MVP definition:
+
+- save selected QCut `/tmp/qcut-output` files to durable Supabase assets;
+- list and preview durable assets;
+- download durable assets;
+- import selected assets into `/tmp/qcut-input`;
+- prove one real reuse flow E2E.
+
+### Production-Ready
+
+Roughly 4-6 weeks.
+
+Production definition:
+
+- robust private storage and signed URLs;
+- thumbnails/previews;
+- folder ingest;
+- large video handling;
+- asset usage and derivation graph;
+- cleanup/retry;
+- broad tests;
+- usable UI polish.
+
+### Full WZRD-Level Media System
+
+Roughly 6-10 weeks.
+
+This includes collections, advanced search, quotas, processing queue, CDN/R2 migration path, team/project permissions, billing-aware storage, and a richer React-style asset management surface.
+
+## Main Risks
+
+### 1. Confusing Sandbox Files with Assets
+
+Risk: users may not understand why a file appears in `/tmp/qcut-output` but is not in the library.
+
+Mitigation:
+
+- keep labels explicit: "Sandbox files" and "Saved assets";
+- add one action: "Save to Assets";
+- show saved state on sandbox files when possible.
+
+### 2. Large Video Files
+
+Risk: large videos can break base64 uploads, browser memory, worker memory, and proxy downloads.
+
+Mitigation:
+
+- stream server-side from Daytona to Storage;
+- do not base64 video payloads;
+- use signed URLs for download where possible;
+- cap preview text and proxy video sizes;
+- keep `bytes` as bigint-compatible, as QCut already started doing for artifacts.
+
+### 3. Permissions and Storage Paths
+
+Risk: path-based storage security can become accidental public access.
+
+Mitigation:
+
+- originals should be private;
+- storage path starts with user id;
+- all list/download/import routes verify user ownership;
+- signed URLs expire quickly;
+- RLS policies mirror the user/project model.
+
+### 4. Provider Reference Compatibility
+
+Risk: not every image/video provider accepts the same reference format.
+
+Mitigation:
+
+- first support local file references in Daytona;
+- later add provider-specific URL/reference adapters;
+- store references in a normalized JSON file for complex workflows.
+
+### 5. Metadata Drift
+
+Risk: QCut commands produce different metadata shapes, making search/provenance inconsistent.
+
+Mitigation:
+
+- define a small stable metadata core: prompt, model, provider, command, stage, parent assets;
+- allow extra command-specific JSON in `generation_metadata`;
+- add tests for each flow that should emit metadata.
+
+### 6. UI Framework Split
+
+Risk: WZRD uses React, QCut website is static JS. Copying components directly can create a half-migrated UI.
+
+Mitigation:
+
+- use WZRD as schema/service inspiration;
+- build a small static-JS asset panel first;
+- only migrate to React when there is a wider product reason.
+
+## Testing Plan
+
+### Unit Tests
+
+Cover:
+
+- safe storage path generation;
+- sandbox path allowlist: `/tmp/qcut-output`, `/tmp/qcut-input` where appropriate;
+- MIME/kind detection;
+- asset metadata normalization;
+- signed URL expiry handling;
+- command/reference JSON generation.
+
+### Integration Tests
+
+Cover:
+
+- ingest one image file from mocked Daytona FS to mocked Supabase Storage;
+- ingest folder with image/json/text/video files;
+- failed DB insert rolls back uploaded object;
+- failed upload leaves no asset row;
+- user A cannot ingest/list/download user B assets;
+- import selected assets back into sandbox.
+
+### E2E Tests
+
+Minimum real Daytona E2E:
+
+```text
+1. Open production chat-agent page with local branch override if needed.
+2. Connect to real Daytona sandbox.
+3. Generate or create small image/json/text outputs in /tmp/qcut-output.
+4. Save selected outputs to Assets.
+5. Refresh or start a new session.
+6. Confirm assets still appear without relying on the old sandbox.
+7. Preview image and text/json.
+8. Download one asset locally.
+9. Import one image asset into /tmp/qcut-input/assets.
+10. Run a small QCut command using that imported file as a reference.
+11. Confirm usage/provenance links exist.
+```
+
+Large-file E2E:
+
+```text
+1. Generate or upload a short video.
+2. Save video to Assets.
+3. Confirm no base64 path is used.
+4. Download through signed URL or authenticated route.
+5. Generate preview/poster if enabled.
+```
+
+Security E2E:
+
+```text
+1. User A saves asset.
+2. User B attempts list/download/import by id/path.
+3. All access fails.
+```
+
+## Decision Matrix
+
+| Decision | Recommendation |
+| --- | --- |
+| Replace sandbox file browser? | No, keep it as live workspace |
+| Build durable assets? | Yes, separate layer |
+| Reuse WZRD code directly? | Mostly no, reuse architecture first |
+| Use private originals? | Yes |
+| Store generated QCut metadata? | Yes, from day one |
+| Support asset reuse? | Yes, via local copy first |
+| Add React migration now? | Not required for MVP |
+
+## Final Assessment
+
+This is a medium-high complexity project because it touches product UX, storage, security, worker/runtime paths, and QCut CLI reference semantics.
+
+But it is a good project structurally. QCut already has a strong live-generation base, and WZRD already demonstrates the asset-library pattern. The right implementation is incremental:
+
+```text
+Live sandbox files stay live.
+Saved assets become durable.
+Durable assets become references for future QCut generation.
+```
+
+That is the bridge from "downloads in a temporary workspace" to "a real web creative asset system".
+
+---
+
+# 工作量、风险与测试
+
+日期：2026-05-22
+
+## 工作量估算
+
+| Area | MVP 工作量 | 生产级工作量 | 说明 |
+| --- | ---: | ---: | --- |
+| Schema and storage buckets | 1-2 天 | 3-5 天 | 如果要兼容 WZRD tables，migration 会更复杂 |
+| Ingest sandbox outputs to assets | 3-5 天 | 1-2 周 | Streaming、rollback、folders、大视频、MIME detection |
+| Asset library list/preview/download | 4-7 天 | 2-3 周 | 现有 preview code 有帮助，但 durable routes/auth 是新的 |
+| Asset reuse into Daytona input | 3-6 天 | 1-2 周 | Local copy 比 provider URL support 更容易 |
+| Usage/provenance tracking | 2-4 天 | 1-2 周 | 对 generated media chain 很重要 |
+| Thumbnails/proxy previews | 3-5 天 | 1-2 周 | Video proxy 是最花时间的部分 |
+| E2E and security tests | 3-5 天 | 1-2 周 | 必须覆盖 user isolation 和 large files |
+
+## 总估算
+
+### MVP
+
+一个工程师大约 2-3 周。
+
+MVP 定义：
+
+- 保存 selected QCut `/tmp/qcut-output` files 到 durable Supabase assets；
+- list 和 preview durable assets；
+- download durable assets；
+- import selected assets 到 `/tmp/qcut-input`；
+- 用一次真实 E2E 证明 reuse flow。
+
+### Production-Ready
+
+大约 4-6 周。
+
+生产可用定义：
+
+- robust private storage 和 signed URLs；
+- thumbnails/previews；
+- folder ingest；
+- large video handling；
+- asset usage 和 derivation graph；
+- cleanup/retry；
+- broad tests；
+- UI polish。
+
+### Full WZRD-Level Media System
+
+大约 6-10 周。
+
+包括 collections、advanced search、quotas、processing queue、CDN/R2 migration path、team/project permissions、billing-aware storage，以及更丰富的 React-style asset management surface。
+
+## 主要风险
+
+### 1. 混淆 Sandbox Files 和 Assets
+
+风险：用户可能不理解为什么文件出现在 `/tmp/qcut-output`，但没有出现在 library。
+
+缓解：
+
+- 明确 label：`Sandbox files` 和 `Saved assets`；
+- 提供一个清晰 action：`Save to Assets`；
+- 可能的话，在 sandbox files 上显示 saved state。
+
+### 2. 大视频文件
+
+风险：大视频会打爆 base64 uploads、browser memory、worker memory、proxy downloads。
+
+缓解：
+
+- server-side stream from Daytona to Storage；
+- 不要把视频走 base64 payload；
+- 尽可能用 signed URLs download；
+- preview text 和 proxy video 都加 size cap；
+- `bytes` 保持 bigint-compatible，QCut artifacts 已经朝这个方向走了。
+
+### 3. 权限和 Storage Paths
+
+风险：path-based storage security 容易变成意外 public access。
+
+缓解：
+
+- originals 应该 private；
+- storage path 以 user id 开头；
+- 所有 list/download/import routes 校验 user ownership；
+- signed URLs 短期过期；
+- RLS policies 对齐 user/project model。
+
+### 4. Provider Reference Compatibility
+
+风险：不是所有 image/video provider 都接受同一种 reference format。
+
+缓解：
+
+- 先支持 Daytona local file references；
+- 之后再加 provider-specific URL/reference adapters；
+- 复杂 workflows 用 normalized JSON file 存 references。
+
+### 5. Metadata Drift
+
+风险：QCut commands 产出的 metadata shape 不统一，会导致 search/provenance 混乱。
+
+缓解：
+
+- 定义小而稳定的 metadata core：prompt、model、provider、command、stage、parent assets；
+- command-specific JSON 放进 `generation_metadata`；
+- 对每个应该 emit metadata 的 flow 加 tests。
+
+### 6. UI Framework Split
+
+风险：WZRD 使用 React，QCut website 是 static JS。直接 copy components 容易变成半迁移 UI。
+
+缓解：
+
+- WZRD 主要作为 schema/service inspiration；
+- MVP 先做小的 static-JS asset panel；
+- 只有在更大产品原因出现时，再迁 React。
+
+## 测试计划
+
+### Unit Tests
+
+覆盖：
+
+- safe storage path generation；
+- sandbox path allowlist：`/tmp/qcut-output`、必要时 `/tmp/qcut-input`；
+- MIME/kind detection；
+- asset metadata normalization；
+- signed URL expiry handling；
+- command/reference JSON generation。
+
+### Integration Tests
+
+覆盖：
+
+- 从 mocked Daytona FS ingest 一张 image 到 mocked Supabase Storage；
+- ingest folder with image/json/text/video files；
+- DB insert 失败时 rollback uploaded object；
+- upload 失败时不留下 asset row；
+- user A 不能 ingest/list/download user B assets；
+- import selected assets back into sandbox。
+
+### E2E Tests
+
+最小 real Daytona E2E：
+
+```text
+1. 打开 production chat-agent page，必要时用 local branch override。
+2. 连接真实 Daytona sandbox。
+3. 在 /tmp/qcut-output 生成或创建小 image/json/text outputs。
+4. Save selected outputs to Assets。
+5. Refresh 或 start new session。
+6. 确认 assets 不依赖旧 sandbox 仍然出现。
+7. Preview image 和 text/json。
+8. Download one asset locally。
+9. Import one image asset into /tmp/qcut-input/assets。
+10. Run a small QCut command using that imported file as a reference。
+11. 确认 usage/provenance links 存在。
+```
+
+Large-file E2E：
+
+```text
+1. 生成或上传短视频。
+2. Save video to Assets。
+3. 确认没有使用 base64 path。
+4. 通过 signed URL 或 authenticated route 下载。
+5. 如启用，生成 preview/poster。
+```
+
+Security E2E：
+
+```text
+1. User A 保存 asset。
+2. User B 尝试通过 id/path list/download/import。
+3. 所有访问都失败。
+```
+
+## 决策矩阵
+
+| Decision | Recommendation |
+| --- | --- |
+| Replace sandbox file browser? | No，保留为 live workspace |
+| Build durable assets? | Yes，作为单独一层 |
+| Reuse WZRD code directly? | Mostly no，先复用 architecture |
+| Use private originals? | Yes |
+| Store generated QCut metadata? | Yes，从第一天开始 |
+| Support asset reuse? | Yes，先走 local copy |
+| Add React migration now? | MVP 不需要 |
+
+## 最终评估
+
+这是一个中高复杂度项目，因为它同时触碰 product UX、storage、security、worker/runtime paths、QCut CLI reference semantics。
+
+但结构上这是个值得做的项目。QCut 已经有很强的 live-generation base，WZRD 已经证明了 asset-library pattern。正确实现方式是 incremental：
+
+```text
+Live sandbox files stay live.
+Saved assets become durable.
+Durable assets become references for future QCut generation.
+```
+
+这就是从“临时 workspace 里的下载文件”走向“真正 web creative asset system”的桥。

--- a/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/README.md
+++ b/qcut/docs/task/daytona-supabase-agent/qcut-supabase-assets/README.md
@@ -1,0 +1,141 @@
+# QCut Supabase Asset Library Migration
+
+Date: 2026-05-22
+
+## Question
+
+If we want to turn the current QCut Daytona generation flow into a web-first experience with a reusable asset library backed by Supabase Storage, how hard is it?
+
+This analysis is about QCut:
+
+- QCut CLI generation in Daytona sandboxes.
+- Files produced under `/tmp/qcut-output`.
+- The current website Chat Agent artifact/file browser.
+- A future durable asset library where generated images, videos, audio, JSON, Markdown, and text can be reused as references for later QCut runs.
+
+It uses `wzrdagentstudio-main` as the reference implementation for Supabase-style asset storage, not as code to copy wholesale.
+
+## Short Answer
+
+The work is feasible, but it is not just a storage upload task.
+
+The current QCut web path already has the hard first piece: a real Daytona sandbox, `/tmp/qcut-input` uploads, `/tmp/qcut-output` artifacts, preview, right-click download, folder download, and job artifacts persisted to the `artifacts` bucket for headless jobs.
+
+What is missing is the durable product layer:
+
+- asset records that survive beyond the current sandbox/session;
+- thumbnails/previews and metadata extraction;
+- a library UI for browsing, searching, selecting, grouping, and reusing assets;
+- a reference contract so selected assets can be injected back into `/tmp/qcut-input` or passed to QCut CLI as URLs/local files;
+- provenance from QCut command, model, prompt, provider, source files, and parent assets;
+- RLS/private storage and signed download/preview URLs.
+
+## Difficulty
+
+| Scope | Difficulty | Rough effort |
+| --- | --- | --- |
+| Persist current QCut outputs into a Supabase asset table and bucket | Medium | 5-8 engineer-days |
+| Usable web asset library for generated QCut artifacts, preview/download/reuse | Medium-high | 2-3 weeks |
+| Production-grade library with signed URLs, thumbnails, quotas, cleanup, usage tracking, and robust E2E | High | 4-6 weeks |
+| Full WZRD-like media OS with collections, advanced processing, billing-aware storage, CDN/R2 migration path, and multi-project collaboration | High+ | 6-10 weeks |
+
+Best practical path: ship this in phases. Start by ingesting QCut outputs into a durable asset table while keeping the existing Daytona file browser. Then add the library and reuse flow.
+
+## Recommended Document Order
+
+1. [Current State](01-current-state.md)
+2. [Target Architecture](02-target-architecture.md)
+3. [Implementation Plan](03-implementation-plan.md)
+4. [Effort, Risks, and Testing](04-effort-risk-testing.md)
+
+## Key Recommendation
+
+Do not replace the current Daytona file browser first. Keep it as the live workspace view. Add a separate durable "Assets" layer beside it:
+
+```text
+Daytona sandbox filesystem
+  /tmp/qcut-input
+  /tmp/qcut-output
+        |
+        | ingest selected/all generated files
+        v
+Supabase Storage + asset metadata
+        |
+        | browse/select/reuse
+        v
+next QCut run references
+```
+
+That keeps live debugging simple while giving users a cleaner, reusable asset library.
+
+---
+
+# QCut Supabase 资产库迁移
+
+日期：2026-05-22
+
+## 问题
+
+如果我们想把现在 QCut Daytona 生成流程改成一个网页端优先、并且由 Supabase Storage 支撑的可复用资产库，难度有多大？
+
+这里分析的是 QCut：
+
+- QCut CLI 在 Daytona sandbox 里生成内容。
+- 产物默认写到 `/tmp/qcut-output`。
+- 当前网站 Chat Agent 里的 artifacts/file browser。
+- 未来的持久资产库：生成出来的图片、视频、音频、JSON、Markdown、文本，都可以作为后续 QCut 运行的 reference 再次使用。
+
+`wzrdagentstudio-main` 在这里是 Supabase 风格资产系统的参考，不代表要直接照搬 UI 代码。
+
+## 简短结论
+
+这件事可行，但它不只是“上传到 Storage”这么简单。
+
+QCut 现在已经有一个很重要的基础：真实 Daytona sandbox、`/tmp/qcut-input` 上传、`/tmp/qcut-output` 生成产物、预览、右键下载、文件夹下载，以及 headless job artifact 持久化到 `artifacts` bucket。
+
+缺的是产品层的 durable asset library：
+
+- 资产记录要脱离当前 sandbox/session 长期存在；
+- 缩略图、预览、metadata 抽取；
+- 用于浏览、搜索、选择、分组、复用的 library UI；
+- 一套 reference contract，让选中的资产可以被拷回 `/tmp/qcut-input`，或以 URL/local file 形式传给 QCut CLI；
+- provenance：QCut command、model、prompt、provider、source files、parent assets；
+- RLS/private storage 和 signed download/preview URL。
+
+## 难度
+
+| 范围 | 难度 | 粗略工作量 |
+| --- | --- | --- |
+| 把当前 QCut outputs 持久化到 Supabase asset table 和 bucket | 中等 | 5-8 个工程日 |
+| 可用的网页资产库：generated artifacts 可预览/下载/复用 | 中高 | 2-3 周 |
+| 生产级资产库：signed URL、thumbnail、quota、cleanup、usage tracking、完整 E2E | 高 | 4-6 周 |
+| 完整 WZRD 风格 media OS：collection、高级处理、计费、CDN/R2、协作权限 | 更高 | 6-10 周 |
+
+最实际的路线是分阶段做：先把 QCut outputs ingest 成 durable assets，同时保留现有 Daytona file browser；然后再加资产库和复用流程。
+
+## 推荐阅读顺序
+
+1. [现状 / Current State](01-current-state.md)
+2. [目标架构 / Target Architecture](02-target-architecture.md)
+3. [实施计划 / Implementation Plan](03-implementation-plan.md)
+4. [工作量、风险、测试 / Effort, Risks, and Testing](04-effort-risk-testing.md)
+
+## 核心建议
+
+不要第一步就替换当前 Daytona file browser。它应该继续作为 live workspace。旁边增加一个 durable "Assets" 层：
+
+```text
+Daytona sandbox filesystem
+  /tmp/qcut-input
+  /tmp/qcut-output
+        |
+        | ingest selected/all generated files
+        v
+Supabase Storage + asset metadata
+        |
+        | browse/select/reuse
+        v
+next QCut run references
+```
+
+这样既保留了 live debug 的简单性，又给用户一个更清晰、可复用的资产库。

--- a/qcut/electron/native-pipeline/autoclip/steps/step-outline.ts
+++ b/qcut/electron/native-pipeline/autoclip/steps/step-outline.ts
@@ -27,7 +27,7 @@ interface OutlineOptions {
 	signal?: AbortSignal;
 }
 
-const DEFAULT_MODEL = "google/gemini-3-flash-preview";
+const DEFAULT_MODEL = "google/gemini-3.5-flash";
 
 /**
  * Parse the LLM outline response into structured topics.

--- a/qcut/electron/native-pipeline/autoclip/steps/step-scoring.ts
+++ b/qcut/electron/native-pipeline/autoclip/steps/step-scoring.ts
@@ -27,7 +27,7 @@ interface ScoringOptions {
 	signal?: AbortSignal;
 }
 
-const DEFAULT_MODEL = "google/gemini-3-flash-preview";
+const DEFAULT_MODEL = "google/gemini-3.5-flash";
 const DEFAULT_MIN_SCORE = 0.7;
 
 /**

--- a/qcut/electron/native-pipeline/autoclip/steps/step-timeline.ts
+++ b/qcut/electron/native-pipeline/autoclip/steps/step-timeline.ts
@@ -32,7 +32,7 @@ interface TimelineOptions {
 	signal?: AbortSignal;
 }
 
-const DEFAULT_MODEL = "google/gemini-3-flash-preview";
+const DEFAULT_MODEL = "google/gemini-3.5-flash";
 const TIME_FORMAT_RE = /^\d{2}:\d{2}:\d{2},\d{3}$/;
 
 /** Validate SRT time format. */

--- a/qcut/electron/native-pipeline/cli/cli-handlers-media.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-media.ts
@@ -17,6 +17,8 @@ import type { PipelineExecutor } from "../execution/executor.js";
 import { resolveOutputDir } from "../output/output-utils.js";
 import { createEditorClient } from "../editor/editor-api-client.js";
 
+const DEFAULT_VIDEO_ANALYSIS_MODEL = "openrouter_gemini_3_5_flash_video";
+
 function isUrl(input: string): boolean {
 	return /^https?:\/\//i.test(input);
 }
@@ -70,7 +72,7 @@ export async function handleAnalyzeVideo(
 		return { success: false, error: "Missing --input/-i (video path/URL)" };
 	}
 
-	const model = options.model || "fal_video_qa";
+	const model = options.model || DEFAULT_VIDEO_ANALYSIS_MODEL;
 	if (!ModelRegistry.has(model)) {
 		return { success: false, error: `Unknown model '${model}'` };
 	}
@@ -350,7 +352,7 @@ export async function handleQueryVideo(
 		};
 	}
 
-	const model = options.model || "fal_video_qa";
+	const model = options.model || DEFAULT_VIDEO_ANALYSIS_MODEL;
 	if (!ModelRegistry.has(model)) {
 		return { success: false, error: `Unknown model '${model}'` };
 	}

--- a/qcut/electron/native-pipeline/cli/cli-runner/types.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/types.ts
@@ -93,6 +93,8 @@ export interface CLIRunOptions {
 	llmModel?: string;
 	imageModel?: string;
 	videoModel?: string;
+	videoReferenceMode?: string;
+	videoReferenceImages?: string[];
 	image?: string;
 	stream?: boolean;
 	configDir?: string;

--- a/qcut/electron/native-pipeline/cli/cli-runner/types.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/types.ts
@@ -95,6 +95,7 @@ export interface CLIRunOptions {
 	videoModel?: string;
 	videoReferenceMode?: string;
 	videoReferenceImages?: string[];
+	videoConcurrency?: number;
 	image?: string;
 	stream?: boolean;
 	configDir?: string;

--- a/qcut/electron/native-pipeline/cli/cli.ts
+++ b/qcut/electron/native-pipeline/cli/cli.ts
@@ -186,6 +186,7 @@ export function parseCliArgs(argv: string[]): CLIRunOptions {
 			"video-model": { type: "string" },
 			"video-reference-mode": { type: "string" },
 			"video-reference-images": { type: "string", multiple: true },
+			"video-concurrency": { type: "string" },
 			image: { type: "string" },
 			stream: { type: "boolean", default: false },
 			"config-dir": { type: "string" },
@@ -516,6 +517,11 @@ export function parseCliArgs(argv: string[]): CLIRunOptions {
 		videoReferenceImages: values["video-reference-images"] as
 			| string[]
 			| undefined,
+		videoConcurrency: values["video-concurrency"]
+			? Number.isNaN(parseInt(values["video-concurrency"] as string, 10))
+				? undefined
+				: parseInt(values["video-concurrency"] as string, 10)
+			: undefined,
 		image: values.image as string | undefined,
 		stream: (values.stream as boolean) ?? false,
 		configDir: values["config-dir"] as string | undefined,

--- a/qcut/electron/native-pipeline/cli/cli.ts
+++ b/qcut/electron/native-pipeline/cli/cli.ts
@@ -184,6 +184,8 @@ export function parseCliArgs(argv: string[]): CLIRunOptions {
 			"llm-model": { type: "string" },
 			"image-model": { type: "string" },
 			"video-model": { type: "string" },
+			"video-reference-mode": { type: "string" },
+			"video-reference-images": { type: "string", multiple: true },
 			image: { type: "string" },
 			stream: { type: "boolean", default: false },
 			"config-dir": { type: "string" },
@@ -510,6 +512,10 @@ export function parseCliArgs(argv: string[]): CLIRunOptions {
 		llmModel: values["llm-model"] as string | undefined,
 		imageModel: values["image-model"] as string | undefined,
 		videoModel: values["video-model"] as string | undefined,
+		videoReferenceMode: values["video-reference-mode"] as string | undefined,
+		videoReferenceImages: values["video-reference-images"] as
+			| string[]
+			| undefined,
 		image: values.image as string | undefined,
 		stream: (values.stream as boolean) ?? false,
 		configDir: values["config-dir"] as string | undefined,

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -1468,6 +1468,16 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			f("--llm-model", "string", "LLM model"),
 			f("--image-model", "string", "Image generation model"),
 			f("--video-model", "string", "Video generation model"),
+			f(
+				"--video-reference-mode",
+				"string",
+				"Video inputs: storyboard, references, or storyboard+references"
+			),
+			f(
+				"--video-reference-images",
+				"string[]",
+				"Extra video reference images (repeatable)"
+			),
 		],
 		examples: [
 			"qcut-pipeline vimax:novel2movie --novel story.txt --max-scenes 10",

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -553,7 +553,7 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			}),
 			f("--model", "string", "Model key", {
 				short: "-m",
-				default: "fal_video_qa",
+				default: "openrouter_gemini_3_5_flash_video",
 			}),
 			f("--analysis-type", "string", "Analysis type", {
 				enum: ["timeline", "summary", "description", "transcript"],
@@ -575,7 +575,10 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			}),
 			f("--prompt", "string", "Custom query prompt"),
 			f("--text", "string", "Query text (alias)", { short: "-t" }),
-			f("--model", "string", "Model key", { short: "-m" }),
+			f("--model", "string", "Model key", {
+				short: "-m",
+				default: "openrouter_gemini_3_5_flash_video",
+			}),
 		],
 		examples: [
 			"qcut-pipeline query-video -i video.mp4 --prompt 'Find all action scenes'",
@@ -631,14 +634,10 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 				}
 			),
 			f("--output", "string", "Output directory", { short: "-o" }),
-			f(
-				"--model",
-				"string",
-				"LLM model (default: google/gemini-3-flash-preview)",
-				{
-					short: "-m",
-				}
-			),
+			f("--model", "string", "LLM model (default: google/gemini-3.5-flash)", {
+				short: "-m",
+				default: "google/gemini-3.5-flash",
+			}),
 			f("--min-score", "number", "Minimum score threshold 0-1 (default: 0.7)"),
 			f("--step", "number", "Run only a specific step (1-4)"),
 			f(

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -1469,6 +1469,11 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			f("--image-model", "string", "Image generation model"),
 			f("--video-model", "string", "Video generation model"),
 			f(
+				"--video-concurrency",
+				"number",
+				"Parallel video clips in flight (default 1, max 6)"
+			),
+			f(
 				"--video-reference-mode",
 				"string",
 				"Video inputs: storyboard, references, or storyboard+references"
@@ -1484,6 +1489,7 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 			"qcut-pipeline vimax:novel2movie --scripts-only",
 			"qcut-pipeline vimax:novel2movie --max-images 5",
 			"qcut-pipeline vimax:novel2movie --max-scenes 20 --max-clips 5",
+			"qcut-pipeline vimax:novel2movie --max-clips 2 --video-concurrency 2",
 		],
 	},
 	"vimax:novel2script": {

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
@@ -18,11 +18,9 @@ type ProgressFn = (progress: {
 	model?: string;
 }) => void;
 
-function resolveVideoReferenceMode(mode?: string):
-	| "storyboard"
-	| "references"
-	| "storyboard+references"
-	| undefined {
+function resolveVideoReferenceMode(
+	mode?: string
+): "storyboard" | "references" | "storyboard+references" | undefined {
 	if (!mode) return;
 	if (
 		mode === "storyboard" ||
@@ -324,7 +322,7 @@ export async function handleVimaxNovel2Movie(
 			...(options.videoReferenceImages
 				? { video_reference_images: options.videoReferenceImages }
 				: {}),
-			...(options.videoConcurrency ?? options.concurrency
+			...((options.videoConcurrency ?? options.concurrency)
 				? { video_concurrency: options.videoConcurrency ?? options.concurrency }
 				: {}),
 		};

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
@@ -322,9 +322,10 @@ export async function handleVimaxNovel2Movie(
 			...(options.videoReferenceImages
 				? { video_reference_images: options.videoReferenceImages }
 				: {}),
-			...((options.videoConcurrency ?? options.concurrency)
-				? { video_concurrency: options.videoConcurrency ?? options.concurrency }
-				: {}),
+			...(() => {
+				const vc = options.videoConcurrency ?? options.concurrency;
+				return vc !== undefined ? { video_concurrency: vc } : {};
+			})(),
 		};
 		if (options.videoModel) pipelineConfig.video_model = options.videoModel;
 		if (options.imageModel) pipelineConfig.image_model = options.imageModel;

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
@@ -324,6 +324,9 @@ export async function handleVimaxNovel2Movie(
 			...(options.videoReferenceImages
 				? { video_reference_images: options.videoReferenceImages }
 				: {}),
+			...(options.videoConcurrency ?? options.concurrency
+				? { video_concurrency: options.videoConcurrency ?? options.concurrency }
+				: {}),
 		};
 		if (options.videoModel) pipelineConfig.video_model = options.videoModel;
 		if (options.imageModel) pipelineConfig.image_model = options.imageModel;

--- a/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
+++ b/qcut/electron/native-pipeline/cli/vimax-cli-handlers/pipeline-handlers.ts
@@ -18,6 +18,24 @@ type ProgressFn = (progress: {
 	model?: string;
 }) => void;
 
+function resolveVideoReferenceMode(mode?: string):
+	| "storyboard"
+	| "references"
+	| "storyboard+references"
+	| undefined {
+	if (!mode) return;
+	if (
+		mode === "storyboard" ||
+		mode === "references" ||
+		mode === "storyboard+references"
+	) {
+		return mode;
+	}
+	throw new Error(
+		`Invalid --video-reference-mode "${mode}". Use storyboard, references, or storyboard+references.`
+	);
+}
+
 /** vimax:idea2video — Full pipeline from idea to video. */
 export async function handleVimaxIdea2Video(
 	options: CLIRunOptions,
@@ -296,6 +314,16 @@ export async function handleVimaxNovel2Movie(
 			...(options.maxScenes != null ? { max_scenes: options.maxScenes } : {}),
 			...(options.maxClips != null ? { max_clips: options.maxClips } : {}),
 			...(resolvedStyle ? { visual_style: resolvedStyle } : {}),
+			...(options.videoReferenceMode
+				? {
+						video_reference_mode: resolveVideoReferenceMode(
+							options.videoReferenceMode
+						),
+					}
+				: {}),
+			...(options.videoReferenceImages
+				? { video_reference_images: options.videoReferenceImages }
+				: {}),
 		};
 		if (options.videoModel) pipelineConfig.video_model = options.videoModel;
 		if (options.imageModel) pipelineConfig.image_model = options.imageModel;

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts
@@ -70,7 +70,7 @@ describe("executeImageUnderstanding — OpenRouter video", () => {
 		expect(content[0]).toEqual({ type: "text", text: "Describe the clip" });
 		expect(content[1]).toEqual({
 			type: "video_url",
-			videoUrl: { url: "https://example.com/clip.mp4" },
+			video_url: { url: "https://example.com/clip.mp4" },
 		});
 	});
 
@@ -91,7 +91,7 @@ describe("executeImageUnderstanding — OpenRouter video", () => {
 		const content = getContentItems({ payload: call.payload });
 		expect(content[1]).toEqual({
 			type: "video_url",
-			videoUrl: { url: "data:video/mp4;base64,ZmFrZS12aWRlbw==" },
+			video_url: { url: "data:video/mp4;base64,ZmFrZS12aWRlbw==" },
 		});
 	});
 });

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-openrouter-video.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infra/api-caller.js", async () => {
+	return {
+		callModelApi: vi.fn(),
+		downloadOutput: vi.fn(async (_url: string, dest: string) => dest),
+		uploadToFalStorage: vi.fn(),
+	};
+});
+
+import { callModelApi } from "../../infra/api-caller.js";
+import { ModelRegistry } from "../../infra/registry.js";
+import { registerImageUnderstandingModels } from "../../registry-data/image-understanding.js";
+import { executeStep } from "../step-executors.js";
+
+type ApiCall = {
+	provider?: string;
+	endpoint?: string;
+	payload: Record<string, unknown>;
+};
+
+const mockedCallModelApi = callModelApi as unknown as {
+	mockResolvedValue: (value: unknown) => void;
+	mock: { calls: Array<[ApiCall]> };
+};
+
+function getContentItems({
+	payload,
+}: {
+	payload: Record<string, unknown>;
+}): Array<Record<string, unknown>> {
+	const messages = payload.messages as Array<Record<string, unknown>>;
+	return messages[0].content as Array<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+	if (!ModelRegistry.has("openrouter_gemini_3_5_flash_video")) {
+		registerImageUnderstandingModels();
+	}
+	vi.clearAllMocks();
+	mockedCallModelApi.mockResolvedValue({
+		success: true,
+		duration: 1,
+		data: {
+			choices: [{ message: { content: "short video description" } }],
+		},
+	});
+});
+
+describe("executeImageUnderstanding — OpenRouter video", () => {
+	it("sends remote video input as OpenRouter chat-completions video content", async () => {
+		const model = ModelRegistry.get("openrouter_gemini_3_5_flash_video");
+
+		const result = await executeStep(
+			model,
+			{ videoUrl: "https://example.com/clip.mp4" },
+			{ prompt: "Describe the clip" },
+			{}
+		);
+
+		expect(result.text).toBe("short video description");
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("openrouter");
+		expect(call.endpoint).toBe("chat/completions");
+		expect(call.payload.model).toBe("google/gemini-3.5-flash");
+		const content = getContentItems({ payload: call.payload });
+		expect(content[0]).toEqual({ type: "text", text: "Describe the clip" });
+		expect(content[1]).toEqual({
+			type: "video_url",
+			videoUrl: { url: "https://example.com/clip.mp4" },
+		});
+	});
+
+	it("encodes local video input as a base64 data URL for OpenRouter", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "qcut-openrouter-video-"));
+		const videoPath = join(dir, "clip.mp4");
+		writeFileSync(videoPath, "fake-video");
+		const model = ModelRegistry.get("openrouter_gemini_3_5_flash_video");
+
+		await executeStep(
+			model,
+			{ videoUrl: videoPath },
+			{ prompt: "Describe the local clip" },
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		const content = getContentItems({ payload: call.payload });
+		expect(content[1]).toEqual({
+			type: "video_url",
+			videoUrl: { url: "data:video/mp4;base64,ZmFrZS12aWRlbw==" },
+		});
+	});
+});

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -1111,7 +1111,7 @@ async function executeOpenRouterMediaUnderstanding(
 		input.videoUrl !== undefined
 			? [
 					{ type: "text", text: prompt },
-					{ type: "video_url", videoUrl: { url: mediaUrl } },
+					{ type: "video_url", video_url: { url: mediaUrl } },
 				]
 			: [
 					{ type: "text", text: prompt },

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -7,6 +7,7 @@
  */
 
 import * as path from "path";
+import { readFileSync } from "node:fs";
 import type { ModelCategory, ModelDefinition } from "../infra/registry.js";
 import {
 	callElevenLabsSpeechToText,
@@ -104,6 +105,33 @@ function getProviderForEndpoint(endpoint: string): ProviderName {
 
 function isRemoteUrl(url: string): boolean {
 	return /^https?:\/\//i.test(url);
+}
+
+function getMediaMimeType({ input }: { input: string }): string {
+	switch (path.extname(input).toLowerCase()) {
+		case ".mov":
+			return "video/quicktime";
+		case ".webm":
+			return "video/webm";
+		case ".mpeg":
+		case ".mpg":
+			return "video/mpeg";
+		case ".png":
+			return "image/png";
+		case ".jpg":
+		case ".jpeg":
+			return "image/jpeg";
+		case ".webp":
+			return "image/webp";
+		default:
+			return "video/mp4";
+	}
+}
+
+function toOpenRouterMediaUrl({ input }: { input: string }): string {
+	if (isRemoteUrl(input) || input.startsWith("data:")) return input;
+	const media = readFileSync(input);
+	return `data:${getMediaMimeType({ input })};base64,${media.toString("base64")}`;
 }
 
 function collectReferenceImages({
@@ -999,6 +1027,10 @@ async function executeImageUnderstanding(
 		signal?: AbortSignal;
 	}
 ): Promise<StepOutput> {
+	if (provider === "openrouter") {
+		return executeOpenRouterMediaUnderstanding(model, input, payload, options);
+	}
+
 	// Volcengine Ark uses OpenAI-compatible Chat Completions format
 	if (provider === "volcengine") {
 		return executeVolcengineVideoUnderstanding(model, input, payload, options);
@@ -1032,6 +1064,82 @@ async function executeImageUnderstanding(
 		onProgress: options.onProgress,
 		signal: options.signal,
 	});
+	if (result.success) {
+		const text = extractTextFromResult(result.data);
+		return {
+			success: true,
+			text,
+			data: result.data,
+			duration: result.duration,
+		};
+	}
+	return { success: false, error: result.error, duration: result.duration };
+}
+
+async function executeOpenRouterMediaUnderstanding(
+	model: ModelDefinition,
+	input: StepInput,
+	payload: Record<string, unknown>,
+	options: {
+		outputDir?: string;
+		onProgress?: (p: number, m: string) => void;
+		signal?: AbortSignal;
+	}
+): Promise<StepOutput> {
+	const mediaInput = input.videoUrl || input.imageUrl;
+	if (!mediaInput) {
+		return {
+			success: false,
+			error: "OpenRouter understanding requires a video or image URL",
+			duration: 0,
+		};
+	}
+
+	let mediaUrl: string;
+	try {
+		mediaUrl = toOpenRouterMediaUrl({ input: mediaInput });
+	} catch (error) {
+		return {
+			success: false,
+			error: `Failed to read media for OpenRouter: ${error instanceof Error ? error.message : String(error)}`,
+			duration: 0,
+		};
+	}
+
+	const prompt = (payload.prompt as string) || "Describe this media in detail";
+	const content =
+		input.videoUrl !== undefined
+			? [
+					{ type: "text", text: prompt },
+					{ type: "video_url", videoUrl: { url: mediaUrl } },
+				]
+			: [
+					{ type: "text", text: prompt },
+					{ type: "image_url", image_url: { url: mediaUrl } },
+				];
+	const apiPayload: Record<string, unknown> = {
+		model: payload.model || model.defaults.model,
+		messages: [{ role: "user", content }],
+		stream: false,
+	};
+
+	if (payload.max_tokens !== undefined) {
+		apiPayload.max_tokens = payload.max_tokens;
+	}
+	if (payload.temperature !== undefined) {
+		apiPayload.temperature = payload.temperature;
+	}
+
+	const result = await callModelApi({
+		endpoint: model.endpoint,
+		modelKey: model.key,
+		payload: apiPayload,
+		provider: "openrouter",
+		async: false,
+		onProgress: options.onProgress,
+		signal: options.signal,
+	});
+
 	if (result.success) {
 		const text = extractTextFromResult(result.data);
 		return {

--- a/qcut/electron/native-pipeline/infra/registry.ts
+++ b/qcut/electron/native-pipeline/infra/registry.ts
@@ -8,7 +8,16 @@
  */
 
 /** Supported provider backends for model execution. */
-export type ProviderBackend = "fal" | "gmi" | "imarouter" | "elevenlabs";
+export type ProviderBackend =
+	| "fal"
+	| "elevenlabs"
+	| "google"
+	| "openrouter"
+	| "volcengine"
+	| "gmi"
+	| "gmi-llm"
+	| "runway"
+	| "imarouter";
 
 export type ModelCategory =
 	| "text_to_image"

--- a/qcut/electron/native-pipeline/output/upload-helper.ts
+++ b/qcut/electron/native-pipeline/output/upload-helper.ts
@@ -118,6 +118,17 @@ function getFalApiKey(): string | undefined {
 	return process.env.FAL_KEY || process.env.FAL_API_KEY || undefined;
 }
 
+async function getUploadAuthToken({
+	authToken,
+}: {
+	authToken?: string;
+}): Promise<string> {
+	if (authToken !== undefined) return authToken.trim();
+	const sessionToken = (await getSessionToken()).trim();
+	if (sessionToken) return sessionToken;
+	return process.env.QCUT_AUTH_TOKEN?.trim() ?? "";
+}
+
 /**
  * Vend a signed upload URL via the license-server proxy.
  *
@@ -259,7 +270,7 @@ export async function uploadFileForReference(
 	const fileName = path.basename(filePath);
 	const contentType = options.contentType ?? inferContentType(filePath);
 
-	const authToken = options.authToken ?? (await getSessionToken());
+	const authToken = await getUploadAuthToken({ authToken: options.authToken });
 	const falKey = getFalApiKey();
 
 	// ── Step 1: vend signed URL (proxy preferred, direct FAL fallback) ──

--- a/qcut/electron/native-pipeline/registry-data/__tests__/image-understanding.test.ts
+++ b/qcut/electron/native-pipeline/registry-data/__tests__/image-understanding.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { ModelRegistry } from "../../infra/registry.js";
+import { registerImageUnderstandingModels } from "../image-understanding.js";
+
+describe("image-understanding registry", () => {
+	beforeAll(() => {
+		ModelRegistry.clear();
+		registerImageUnderstandingModels();
+	});
+
+	it("keeps FAL video QA on the FAL backend", () => {
+		const model = ModelRegistry.get("fal_video_qa");
+
+		expect(model.providerBackend).toBe("fal");
+		expect(model.endpoint).toBe("openrouter/router/video/enterprise");
+	});
+
+	it("registers OpenRouter Gemini 3.5 Flash video understanding", () => {
+		const model = ModelRegistry.get("openrouter_gemini_3_5_flash_video");
+
+		expect(model.providerBackend).toBe("openrouter");
+		expect(model.endpoint).toBe("chat/completions");
+		expect(model.defaults.model).toBe("google/gemini-3.5-flash");
+	});
+
+	it("routes Gemini image understanding models to the Google backend", () => {
+		for (const key of [
+			"gemini_describe",
+			"gemini_detailed",
+			"gemini_classify",
+			"gemini_objects",
+			"gemini_ocr",
+			"gemini_composition",
+			"gemini_qa",
+		]) {
+			const model = ModelRegistry.get(key);
+			expect(model.providerBackend).toBe("google");
+		}
+	});
+
+	it("routes Doubao video understanding models to the Volcengine backend", () => {
+		for (const key of [
+			"doubao_video_understanding",
+			"doubao_seed_2_pro",
+			"doubao_seed_2_lite",
+		]) {
+			const model = ModelRegistry.get(key);
+			expect(model.providerBackend).toBe("volcengine");
+		}
+	});
+});

--- a/qcut/electron/native-pipeline/registry-data/image-to-video.ts
+++ b/qcut/electron/native-pipeline/registry-data/image-to-video.ts
@@ -1434,6 +1434,12 @@ export function registerImageToVideoModels(): void {
 			resolution: "1080p",
 			aspect_ratio: "16:9",
 			role_mode: "reference",
+			metadata: {
+				audio: false,
+				resolution: "1080p",
+				aspect_ratio: "16:9",
+				role_mode: "reference",
+			},
 		},
 		features: [
 			"multi_reference",
@@ -1547,6 +1553,12 @@ export function registerImageToVideoModels(): void {
 			resolution: "1080p",
 			aspect_ratio: "16:9",
 			role_mode: "reference",
+			metadata: {
+				audio: false,
+				resolution: "1080p",
+				aspect_ratio: "16:9",
+				role_mode: "reference",
+			},
 		},
 		features: ["multi_reference", "native_audio"],
 		maxDuration: 15,

--- a/qcut/electron/native-pipeline/registry-data/image-understanding.ts
+++ b/qcut/electron/native-pipeline/registry-data/image-understanding.ts
@@ -10,6 +10,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_describe",
 		name: "Gemini Describe",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/describe",
 		categories: ["image_understanding"],
 		description: "Basic image description",
@@ -24,6 +25,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_detailed",
 		name: "Gemini Detailed",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/detailed",
 		categories: ["image_understanding"],
 		description: "Detailed image analysis",
@@ -38,6 +40,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_classify",
 		name: "Gemini Classify",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/classify",
 		categories: ["image_understanding"],
 		description: "Image classification and categorization",
@@ -52,6 +55,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_objects",
 		name: "Gemini Objects",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/objects",
 		categories: ["image_understanding"],
 		description: "Object detection and identification",
@@ -66,6 +70,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_ocr",
 		name: "Gemini OCR",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/ocr",
 		categories: ["image_understanding"],
 		description: "Text extraction (OCR)",
@@ -80,6 +85,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_composition",
 		name: "Gemini Composition",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/composition",
 		categories: ["image_understanding"],
 		description: "Artistic and technical composition analysis",
@@ -94,6 +100,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "gemini_qa",
 		name: "Gemini Q&A",
 		provider: "Google",
+		providerBackend: "google",
 		endpoint: "google/gemini/qa",
 		categories: ["image_understanding"],
 		description: "Question and answer system for images",
@@ -102,6 +109,31 @@ export function registerImageUnderstandingModels(): void {
 		features: ["qa", "interactive"],
 		costEstimate: 0.001,
 		processingTime: 4,
+	});
+
+	ModelRegistry.register({
+		key: "openrouter_gemini_3_5_flash_video",
+		name: "OpenRouter Gemini 3.5 Flash Video",
+		provider: "OpenRouter",
+		providerBackend: "openrouter",
+		endpoint: "chat/completions",
+		categories: ["image_understanding"],
+		description:
+			"Video understanding via OpenRouter Gemini 3.5 Flash chat completions",
+		pricing: { per_request: 0.005 },
+		defaults: {
+			model: "google/gemini-3.5-flash",
+			max_tokens: 4096,
+		},
+		features: [
+			"qa",
+			"video_analysis",
+			"interactive",
+			"temporal_awareness",
+			"multimodal",
+		],
+		costEstimate: 0.005,
+		processingTime: 15,
 	});
 
 	ModelRegistry.register({
@@ -123,6 +155,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "doubao_video_understanding",
 		name: "Doubao Video Understanding",
 		provider: "Volcengine",
+		providerBackend: "volcengine",
 		endpoint: "volcengine/chat/completions",
 		categories: ["image_understanding"],
 		description:
@@ -149,6 +182,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "doubao_seed_2_pro",
 		name: "Doubao Seed 2.0 Pro",
 		provider: "Volcengine",
+		providerBackend: "volcengine",
 		endpoint: "volcengine/responses",
 		categories: ["image_understanding"],
 		description:
@@ -176,6 +210,7 @@ export function registerImageUnderstandingModels(): void {
 		key: "doubao_seed_2_lite",
 		name: "Doubao Seed 2.0 Lite",
 		provider: "Volcengine",
+		providerBackend: "volcengine",
 		endpoint: "volcengine/responses",
 		categories: ["image_understanding"],
 		description:

--- a/qcut/electron/native-pipeline/replicate/replicate-analyzer.ts
+++ b/qcut/electron/native-pipeline/replicate/replicate-analyzer.ts
@@ -16,7 +16,7 @@ import {
 import { PipelineExecutor } from "../execution/executor.js";
 import type { PipelineStep } from "../execution/executor.js";
 
-const DEFAULT_MODEL = "fal_video_qa";
+const DEFAULT_MODEL = "openrouter_gemini_3_5_flash_video";
 
 export interface AnalyzerOptions {
 	model?: string;

--- a/qcut/electron/native-pipeline/vimax/adapters/__tests__/video-adapter-gmi-seedance.test.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/__tests__/video-adapter-gmi-seedance.test.ts
@@ -19,7 +19,12 @@ vi.mock("../../../infra/imarouter-assets.js", () => ({
 		groupIdKey: "groupIdOverseas",
 	})),
 	ensureGroup: vi.fn(async () => "asset-group-1"),
-	uploadAsset: vi.fn(async () => "asset://storyboard-asset-1"),
+	uploadAsset: vi.fn(async (url: string) => {
+		if (url.includes("storyboard")) return "asset://storyboard-asset-1";
+		if (url.includes("mara")) return "asset://mara-asset-1";
+		if (url.includes("jon")) return "asset://jon-asset-1";
+		return "asset://image-asset-1";
+	}),
 }));
 
 import { callModelApi } from "../../../infra/api-caller.js";
@@ -108,6 +113,41 @@ describe("VideoGeneratorAdapter — GMI Seedance I2V", () => {
 		).toEqual({ image: "https://cdn.example.com/frame.png" });
 	});
 
+	it("passes multiple images as GMI Seedance Ref2V references", async () => {
+		const adapter = new VideoGeneratorAdapter({
+			model: "gmi_seedance_2_0_fast_260128_ref2v",
+			output_dir: "/tmp/qcut-video",
+		});
+
+		await adapter.generate(
+			"https://cdn.example.com/storyboard.png",
+			"gentle handheld motion",
+			{
+				duration: 5,
+				output_path: "/tmp/qcut-video/gmi-ref2v.mp4",
+				reference_images: [
+					"https://cdn.example.com/mara.png",
+					"https://cdn.example.com/jon.png",
+				],
+			}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("gmi");
+		expect(call.modelKey).toBe("gmi_seedance_2_0_fast_260128_ref2v");
+		expect(call.payload).toMatchObject({
+			prompt: "gentle handheld motion",
+			reference_images: [
+				"https://cdn.example.com/storyboard.png",
+				"https://cdn.example.com/mara.png",
+				"https://cdn.example.com/jon.png",
+			],
+			duration: "5",
+		});
+		expect(call.payload).not.toHaveProperty("image");
+		expect(call.payload).not.toHaveProperty("first_frame");
+	});
+
 	it("resolves IMA Router video models without falling back to FAL", () => {
 		expect(
 			resolveVideoModelSpec("imarouter_seedance_2_0_fast_i2v").providerBackend
@@ -146,5 +186,77 @@ describe("VideoGeneratorAdapter — GMI Seedance I2V", () => {
 			aspect_ratio: "16:9",
 			role_mode: "frame",
 		});
+	});
+
+	it("passes storyboard plus multiple references to IMA Router Ref2V", async () => {
+		const adapter = new VideoGeneratorAdapter({
+			model: "imarouter_seedance_2_0_ref2v",
+			output_dir: "/tmp/qcut-video",
+		});
+
+		await adapter.generate(
+			"https://cdn.example.com/storyboard.png",
+			"slow push toward the table",
+			{
+				duration: 5,
+				output_path: "/tmp/qcut-video/ref2v.mp4",
+				reference_images: [
+					"https://cdn.example.com/mara.png",
+					"https://cdn.example.com/jon.png",
+				],
+			}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(mockedEnsureGroup.mock.calls).toHaveLength(1);
+		expect(mockedUploadAsset.mock.calls.map((args) => args[0])).toEqual([
+			"https://cdn.example.com/storyboard.png",
+			"https://cdn.example.com/mara.png",
+			"https://cdn.example.com/jon.png",
+		]);
+		expect(call.payload).toMatchObject({
+			model: "seedance-2.0",
+			prompt: "slow push toward the table",
+			images: [
+				"asset://storyboard-asset-1",
+				"asset://mara-asset-1",
+				"asset://jon-asset-1",
+			],
+			duration: "5",
+			resolution: "1080p",
+			aspect_ratio: "16:9",
+			role_mode: "reference",
+		});
+	});
+
+	it("can send only reference images when source storyboard is disabled", async () => {
+		const adapter = new VideoGeneratorAdapter({
+			model: "imarouter_seedance_2_0_ref2v",
+			output_dir: "/tmp/qcut-video",
+		});
+
+		await adapter.generate(
+			"https://cdn.example.com/storyboard.png",
+			"animate the two characters talking",
+			{
+				duration: 5,
+				output_path: "/tmp/qcut-video/ref-only.mp4",
+				include_source_image: false,
+				reference_images: [
+					"https://cdn.example.com/mara.png",
+					"https://cdn.example.com/jon.png",
+				],
+			}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(mockedUploadAsset.mock.calls.map((args) => args[0])).toEqual([
+			"https://cdn.example.com/mara.png",
+			"https://cdn.example.com/jon.png",
+		]);
+		expect(call.payload.images).toEqual([
+			"asset://mara-asset-1",
+			"asset://jon-asset-1",
+		]);
 	});
 });

--- a/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
@@ -32,6 +32,7 @@ import {
 	uploadAsset,
 } from "../../infra/imarouter-assets.js";
 import { ModelRegistry } from "../../infra/registry.js";
+import { uploadFileForReference } from "../../output/upload-helper.js";
 import type { VideoOutput, ImageOutput } from "../types/output.js";
 import { createVideoOutput } from "../types/output.js";
 
@@ -67,6 +68,14 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
 };
 
 type VideoProviderBackend = "fal" | "gmi" | "imarouter";
+
+export interface VideoGenerateOptions {
+	model?: string;
+	duration?: number;
+	output_path?: string;
+	reference_images?: string[];
+	include_source_image?: boolean;
+}
 
 interface ResolvedModelSpec {
 	/** The canonical registry key (after alias resolution). */
@@ -234,22 +243,102 @@ export function buildImageField({
 	};
 }
 
+function isRemoteImageRef(imagePath: string): boolean {
+	return /^https?:/i.test(imagePath);
+}
+
+function isDataUriImageRef(imagePath: string): boolean {
+	return imagePath.startsWith("data:");
+}
+
+function isAssetImageRef(imagePath: string): boolean {
+	return imagePath.startsWith("asset://");
+}
+
+function uniqueImageRefs(imageRefs: string[]): string[] {
+	const seen = new Set<string>();
+	const unique: string[] = [];
+	for (const imageRef of imageRefs) {
+		const trimmed = imageRef.trim();
+		if (!trimmed || seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		unique.push(trimmed);
+	}
+	return unique;
+}
+
+async function resolveImaRouterAssetRef({
+	imagePath,
+	modelKey,
+	apiKey,
+	groupId,
+}: {
+	imagePath: string;
+	modelKey: string;
+	apiKey: string;
+	groupId: string;
+}): Promise<string> {
+	if (isAssetImageRef(imagePath) || isDataUriImageRef(imagePath)) {
+		return imagePath;
+	}
+	const channel = channelFor(modelKey);
+	const imageUrl = isRemoteImageRef(imagePath)
+		? imagePath
+		: (await uploadFileForReference({ filePath: imagePath })).url;
+	return uploadAsset(imageUrl, channel, groupId, { apiKey });
+}
+
+async function resolveFetchableImageRef(imagePath: string): Promise<string> {
+	if (
+		isRemoteImageRef(imagePath) ||
+		isDataUriImageRef(imagePath) ||
+		isAssetImageRef(imagePath)
+	) {
+		return imagePath;
+	}
+	return (await uploadFileForReference({ filePath: imagePath })).url;
+}
+
 async function buildProviderImageField({
 	imagePath,
 	provider,
 	modelKey,
+	referenceImages = [],
+	includeSourceImage = true,
 }: {
 	imagePath: string;
 	provider: VideoProviderBackend;
 	modelKey: string;
+	referenceImages?: string[];
+	includeSourceImage?: boolean;
 }): Promise<Record<string, unknown>> {
+	const imageRefs = uniqueImageRefs([
+		...(includeSourceImage ? [imagePath] : []),
+		...referenceImages,
+	]).slice(0, 14);
+
+	if (provider === "gmi" && isGmiSeedanceRef2vModel({ modelKey })) {
+		const resolvedRefs: string[] = [];
+		for (const imageRef of imageRefs) {
+			resolvedRefs.push(await resolveFetchableImageRef(imageRef));
+		}
+		return { reference_images: resolvedRefs };
+	}
+
+	if (provider === "fal" && isFalSeedanceRef2vModel({ modelKey })) {
+		const resolvedRefs: string[] = [];
+		for (const imageRef of imageRefs.slice(0, 9)) {
+			resolvedRefs.push(await resolveFetchableImageRef(imageRef));
+		}
+		return { image_urls: resolvedRefs };
+	}
+
 	if (provider !== "imarouter") {
 		return buildImageField({ imagePath, provider, modelKey });
 	}
 
-	const isRemote = /^https?:/i.test(imagePath);
-	if (!isRemote) {
-		return buildImageField({ imagePath, provider, modelKey });
+	if (imageRefs.length === 0) {
+		throw new Error("IMA Router video generation requires at least one image");
 	}
 
 	const apiKey = await envApiKeyProvider("imarouter");
@@ -258,12 +347,29 @@ async function buildProviderImageField({
 	}
 	const channel = channelFor(modelKey);
 	const groupId = await ensureGroup(channel, { apiKey });
-	const assetUrl = await uploadAsset(imagePath, channel, groupId, { apiKey });
-	return { images: [assetUrl] };
+	const images: string[] = [];
+	for (const imageRef of imageRefs) {
+		const assetRef = await resolveImaRouterAssetRef({
+			imagePath: imageRef,
+			modelKey,
+			apiKey,
+			groupId,
+		});
+		images.push(assetRef);
+	}
+	return { images };
 }
 
 function isGmiSeedanceI2vModel({ modelKey }: { modelKey: string }): boolean {
 	return /^gmi_seedance_2_0(?:_fast)?_260128_i2v$/.test(modelKey);
+}
+
+function isGmiSeedanceRef2vModel({ modelKey }: { modelKey: string }): boolean {
+	return /^gmi_seedance_2_0(?:_fast)?_260128_ref2v$/.test(modelKey);
+}
+
+function isFalSeedanceRef2vModel({ modelKey }: { modelKey: string }): boolean {
+	return modelKey === "seedance_2_0_ref2v";
 }
 
 function buildDurationField({
@@ -364,11 +470,7 @@ export class VideoGeneratorAdapter extends BaseAdapter<
 	async generate(
 		imagePath: string,
 		prompt: string,
-		options?: {
-			model?: string;
-			duration?: number;
-			output_path?: string;
-		}
+		options?: VideoGenerateOptions
 	): Promise<VideoOutput> {
 		await this.ensureInitialized();
 
@@ -399,6 +501,8 @@ export class VideoGeneratorAdapter extends BaseAdapter<
 			imagePath,
 			provider: spec.providerBackend,
 			modelKey: spec.canonicalKey,
+			referenceImages: options?.reference_images,
+			includeSourceImage: options?.include_source_image,
 		});
 		const payload: Record<string, unknown> = {
 			...spec.defaults,
@@ -575,6 +679,8 @@ export async function generateVideo(
 		model?: string;
 		duration?: number;
 		output_path?: string;
+		reference_images?: string[];
+		include_source_image?: boolean;
 	}
 ): Promise<VideoOutput> {
 	const adapter = new VideoGeneratorAdapter({ model: options?.model });

--- a/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
@@ -318,6 +318,11 @@ async function buildProviderImageField({
 	]).slice(0, 14);
 
 	if (provider === "gmi" && isGmiSeedanceRef2vModel({ modelKey })) {
+		if (imageRefs.length === 0) {
+			throw new Error(
+				"GMI Seedance Ref2V requires at least one reference image"
+			);
+		}
 		const resolvedRefs = await Promise.all(
 			imageRefs.map((imageRef) => resolveFetchableImageRef(imageRef))
 		);
@@ -325,6 +330,11 @@ async function buildProviderImageField({
 	}
 
 	if (provider === "fal" && isFalSeedanceRef2vModel({ modelKey })) {
+		if (imageRefs.length === 0) {
+			throw new Error(
+				"FAL Seedance Ref2V requires at least one reference image"
+			);
+		}
 		const resolvedRefs = await Promise.all(
 			imageRefs
 				.slice(0, 9)

--- a/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
+++ b/qcut/electron/native-pipeline/vimax/adapters/video-adapter.ts
@@ -318,18 +318,18 @@ async function buildProviderImageField({
 	]).slice(0, 14);
 
 	if (provider === "gmi" && isGmiSeedanceRef2vModel({ modelKey })) {
-		const resolvedRefs: string[] = [];
-		for (const imageRef of imageRefs) {
-			resolvedRefs.push(await resolveFetchableImageRef(imageRef));
-		}
+		const resolvedRefs = await Promise.all(
+			imageRefs.map((imageRef) => resolveFetchableImageRef(imageRef))
+		);
 		return { reference_images: resolvedRefs };
 	}
 
 	if (provider === "fal" && isFalSeedanceRef2vModel({ modelKey })) {
-		const resolvedRefs: string[] = [];
-		for (const imageRef of imageRefs.slice(0, 9)) {
-			resolvedRefs.push(await resolveFetchableImageRef(imageRef));
-		}
+		const resolvedRefs = await Promise.all(
+			imageRefs
+				.slice(0, 9)
+				.map((imageRef) => resolveFetchableImageRef(imageRef))
+		);
 		return { image_urls: resolvedRefs };
 	}
 
@@ -347,16 +347,16 @@ async function buildProviderImageField({
 	}
 	const channel = channelFor(modelKey);
 	const groupId = await ensureGroup(channel, { apiKey });
-	const images: string[] = [];
-	for (const imageRef of imageRefs) {
-		const assetRef = await resolveImaRouterAssetRef({
-			imagePath: imageRef,
-			modelKey,
-			apiKey,
-			groupId,
-		});
-		images.push(assetRef);
-	}
+	const images = await Promise.all(
+		imageRefs.map((imageRef) =>
+			resolveImaRouterAssetRef({
+				imagePath: imageRef,
+				modelKey,
+				apiKey,
+				groupId,
+			})
+		)
+	);
 	return { images };
 }
 

--- a/qcut/electron/native-pipeline/vimax/agents/__tests__/camera-generator-references.test.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/__tests__/camera-generator-references.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { collectVideoReferenceImages } from "../camera-generator.js";
+import {
+	CharacterPortraitRegistry,
+	createCharacterPortrait,
+} from "../../types/character.js";
+import { createShotDescription } from "../../types/shot.js";
+
+describe("collectVideoReferenceImages", () => {
+	it("combines shot, registry, and explicit references without duplicates", () => {
+		const registry = new CharacterPortraitRegistry("project-1");
+		registry.addPortrait(
+			createCharacterPortrait({
+				character_name: "Mara",
+				front_view: "/tmp/portraits/mara-front.png",
+				side_view: "/tmp/portraits/mara-side.png",
+			})
+		);
+		registry.addPortrait(
+			createCharacterPortrait({
+				character_name: "Jon",
+				front_view: "/tmp/portraits/jon-front.png",
+			})
+		);
+		const shot = createShotDescription({
+			shot_id: "s1",
+			description: "Mara and Jon study a map",
+			camera_angle: "front",
+			characters: ["Mara", "Jon"],
+			character_references: {
+				Mara: "/tmp/portraits/mara-front.png",
+				Jon: "/tmp/portraits/jon-front.png",
+			},
+			primary_reference_image: "/tmp/portraits/mara-front.png",
+		});
+
+		const references = collectVideoReferenceImages({
+			shot,
+			portraitRegistry: registry,
+			extraReferenceImages: [
+				"/tmp/style/reference.png",
+				"/tmp/portraits/jon-front.png",
+			],
+			maxReferences: 3,
+		});
+
+		expect(references).toEqual([
+			"/tmp/portraits/mara-front.png",
+			"/tmp/portraits/jon-front.png",
+			"/tmp/style/reference.png",
+		]);
+	});
+});

--- a/qcut/electron/native-pipeline/vimax/agents/__tests__/camera-generator-references.test.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/__tests__/camera-generator-references.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { collectVideoReferenceImages } from "../camera-generator.js";
+import {
+	CameraImageGenerator,
+	collectVideoReferenceImages,
+} from "../camera-generator.js";
 import {
 	CharacterPortraitRegistry,
 	createCharacterPortrait,
 } from "../../types/character.js";
-import { createShotDescription } from "../../types/shot.js";
+import { createScene, createShotDescription } from "../../types/shot.js";
+import { createImageOutput, createVideoOutput } from "../../types/output.js";
+import type { StoryboardResult } from "../storyboard-artist.js";
 
 describe("collectVideoReferenceImages", () => {
 	it("combines shot, registry, and explicit references without duplicates", () => {
@@ -49,6 +54,106 @@ describe("collectVideoReferenceImages", () => {
 			"/tmp/portraits/mara-front.png",
 			"/tmp/portraits/jon-front.png",
 			"/tmp/style/reference.png",
+		]);
+	});
+});
+
+describe("CameraImageGenerator video concurrency", () => {
+	it("runs video tasks concurrently without reordering successful clips", async () => {
+		const generator = new CameraImageGenerator({
+			output_dir: "/tmp/qcut-camera-concurrency-test",
+			video_concurrency: 2,
+		});
+		const events: string[] = [];
+		let inFlight = 0;
+		let maxInFlight = 0;
+
+		const fakeAdapter = {
+			generate: async (
+				sourceImage: string,
+				prompt: string,
+				options: {
+					duration: number;
+					output_path: string;
+					reference_images: string[];
+					include_source_image: boolean;
+				}
+			) => {
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				events.push(`start:${sourceImage}`);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				events.push(`end:${sourceImage}`);
+				inFlight--;
+
+				return createVideoOutput({
+					video_path: options.output_path,
+					source_image: sourceImage,
+					prompt,
+					model: "mock-video",
+					duration: options.duration,
+				});
+			},
+			concatenateVideos: async (
+				videos: Array<{ duration: number }>,
+				finalPath: string
+			) =>
+				createVideoOutput({
+					video_path: finalPath,
+					model: "mock-video",
+					duration: videos.reduce((sum, video) => sum + video.duration, 0),
+				}),
+		};
+		(
+			generator as unknown as {
+				_videoAdapter: typeof fakeAdapter;
+			}
+		)._videoAdapter = fakeAdapter;
+
+		const storyboard: StoryboardResult = {
+			title: "Parallel Clip Test",
+			description: "",
+			total_cost: 0,
+			scenes: [
+				createScene({
+					scene_id: "scene-1",
+					shots: [
+						createShotDescription({
+							shot_id: "shot-1",
+							description: "first shot",
+						}),
+						createShotDescription({
+							shot_id: "shot-2",
+							description: "second shot",
+						}),
+						createShotDescription({
+							shot_id: "shot-3",
+							description: "third shot",
+						}),
+					],
+				}),
+			],
+			images: [1, 2, 3].map((index) =>
+				createImageOutput({
+					image_path: `/tmp/source-${index}.png`,
+					prompt: `source ${index}`,
+					model: "mock-image",
+				})
+			),
+		};
+
+		const result = await generator.process(storyboard);
+
+		expect(result.success).toBe(true);
+		expect(maxInFlight).toBe(2);
+		expect(events.slice(0, 2)).toEqual([
+			"start:/tmp/source-1.png",
+			"start:/tmp/source-2.png",
+		]);
+		expect(result.result?.videos.map((video) => video.video_path)).toEqual([
+			"/tmp/qcut-camera-concurrency-test/Parallel_Clip_Test/shot-1.mp4",
+			"/tmp/qcut-camera-concurrency-test/Parallel_Clip_Test/shot-2.mp4",
+			"/tmp/qcut-camera-concurrency-test/Parallel_Clip_Test/shot-3.mp4",
 		]);
 	});
 });

--- a/qcut/electron/native-pipeline/vimax/agents/camera-generator.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/camera-generator.ts
@@ -40,6 +40,7 @@ export interface CameraGeneratorConfig extends AgentConfig {
 	video_reference_mode: VideoReferenceMode;
 	video_reference_images: string[];
 	max_video_references: number;
+	video_concurrency: number;
 }
 
 export function createCameraGeneratorConfig(
@@ -53,6 +54,7 @@ export function createCameraGeneratorConfig(
 		video_reference_mode: "storyboard+references",
 		video_reference_images: [],
 		max_video_references: 14,
+		video_concurrency: 1,
 		...partial,
 	};
 }
@@ -76,6 +78,29 @@ interface VideoReferenceAuditEntry {
 	reference_image_count: number;
 	reference_images: string[];
 	error?: string;
+}
+
+interface VideoGenerationTask {
+	shot: ShotDescription;
+	sourceImage: string;
+	motionPrompt: string;
+	outputPath: string;
+	includeSourceImage: boolean;
+	referenceImages: string[];
+}
+
+const MAX_VIDEO_CONCURRENCY = 6;
+
+function normalizeVideoConcurrency({
+	concurrency,
+	itemCount,
+}: {
+	concurrency: number;
+	itemCount: number;
+}): number {
+	if (itemCount === 0) return 0;
+	const normalized = Number.isFinite(concurrency) ? Math.trunc(concurrency) : 1;
+	return Math.max(1, Math.min(normalized, itemCount, MAX_VIDEO_CONCURRENCY));
 }
 
 function uniqueReferences(references: Array<string | undefined>): string[] {
@@ -154,6 +179,54 @@ export class CameraImageGenerator extends BaseAgent<
 		return parts.join(", ");
 	}
 
+	private _buildVideoTasks({
+		storyboard,
+		portraitRegistry,
+		outputDir,
+	}: {
+		storyboard: StoryboardResult;
+		portraitRegistry?: CharacterPortraitRegistry;
+		outputDir: string;
+	}): VideoGenerationTask[] {
+		const tasks: VideoGenerationTask[] = [];
+		let imageIndex = 0;
+
+		for (const scene of storyboard.scenes) {
+			for (const shot of scene.shots) {
+				if (imageIndex >= storyboard.images.length) break;
+
+				const image = storyboard.images[imageIndex];
+				imageIndex++;
+
+				const sourceImage = image.image_url ?? image.image_path;
+				const referenceImages = collectVideoReferenceImages({
+					shot,
+					portraitRegistry,
+					extraReferenceImages: this.config.video_reference_images,
+					maxReferences: this.config.max_video_references,
+				});
+				const includeSourceImage =
+					this.config.video_reference_mode !== "references" ||
+					referenceImages.length === 0;
+				const videoReferenceImages =
+					this.config.video_reference_mode === "storyboard"
+						? []
+						: referenceImages;
+
+				tasks.push({
+					shot,
+					sourceImage,
+					motionPrompt: this._getMotionPrompt(shot),
+					outputPath: path.join(outputDir, `${shot.shot_id}.mp4`),
+					includeSourceImage,
+					referenceImages: videoReferenceImages,
+				});
+			}
+		}
+
+		return tasks;
+	}
+
 	async process(
 		storyboard: StoryboardResult,
 		portraitRegistry?: CharacterPortraitRegistry
@@ -175,79 +248,90 @@ export class CameraImageGenerator extends BaseAgent<
 			}
 
 			const referenceAudit: VideoReferenceAuditEntry[] = [];
-			// Match images with shots
-			let imageIndex = 0;
-			for (const scene of storyboard.scenes) {
-				for (const shot of scene.shots) {
-					if (imageIndex >= storyboard.images.length) break;
+			const tasks = this._buildVideoTasks({
+				storyboard,
+				portraitRegistry,
+				outputDir,
+			});
+			const videos = new Array<VideoOutput | undefined>(tasks.length);
+			const auditEntries = new Array<VideoReferenceAuditEntry>(tasks.length);
+			const concurrency = normalizeVideoConcurrency({
+				concurrency: this.config.video_concurrency,
+				itemCount: tasks.length,
+			});
+			if (tasks.length > 0) {
+				console.log(
+					`[camera_gen] Running ${tasks.length} video task(s) with concurrency ${concurrency}`
+				);
+			}
 
-					const image = storyboard.images[imageIndex];
-					imageIndex++;
+			let nextIndex = 0;
+			const runNext = async (): Promise<void> => {
+				const index = nextIndex++;
+				if (index >= tasks.length) return;
 
-					const motionPrompt = this._getMotionPrompt(shot);
-					const outputPath = path.join(outputDir, `${shot.shot_id}.mp4`);
-					const sourceImage = image.image_url ?? image.image_path;
-					const referenceImages = collectVideoReferenceImages({
-						shot,
-						portraitRegistry,
-						extraReferenceImages: this.config.video_reference_images,
-						maxReferences: this.config.max_video_references,
-					});
-					const includeSourceImage =
-						this.config.video_reference_mode !== "references" ||
-						referenceImages.length === 0;
-					const videoReferenceImages =
-						this.config.video_reference_mode === "storyboard"
-							? []
-							: referenceImages;
-					console.log(
-						`[camera_gen] ${shot.shot_id}: video refs=${videoReferenceImages.length}, storyboard=${includeSourceImage ? "yes" : "no"}`
+				const task = tasks[index];
+				console.log(
+					`[camera_gen] ${task.shot.shot_id}: video refs=${task.referenceImages.length}, storyboard=${task.includeSourceImage ? "yes" : "no"}`
+				);
+
+				try {
+					const video = await this._videoAdapter!.generate(
+						task.sourceImage,
+						task.motionPrompt,
+						{
+							duration:
+								task.shot.duration_seconds || this.config.default_duration,
+							output_path: task.outputPath,
+							reference_images: task.referenceImages,
+							include_source_image: task.includeSourceImage,
+						}
 					);
-
-					try {
-						const video = await this._videoAdapter!.generate(
-							sourceImage,
-							motionPrompt,
-							{
-								duration: shot.duration_seconds || this.config.default_duration,
-								output_path: outputPath,
-								reference_images: videoReferenceImages,
-								include_source_image: includeSourceImage,
-							}
-						);
-						video.metadata = {
-							...video.metadata,
-							video_reference_mode: this.config.video_reference_mode,
-							include_source_image: includeSourceImage,
-							reference_image_count: videoReferenceImages.length,
-							reference_images: videoReferenceImages,
-						};
-						referenceAudit.push({
-							shot_id: shot.shot_id,
-							video_path: video.video_path,
-							source_image: sourceImage,
-							video_reference_mode: this.config.video_reference_mode,
-							include_source_image: includeSourceImage,
-							reference_image_count: videoReferenceImages.length,
-							reference_images: videoReferenceImages,
-						});
-						addVideoToOutput(output, video);
-					} catch (err) {
-						const msg = err instanceof Error ? err.message : String(err);
-						const shotError = `${shot.shot_id}: ${msg}`;
-						console.error(`[camera_gen] Shot failed: ${shotError}`);
-						output.errors.push(shotError);
-						referenceAudit.push({
-							shot_id: shot.shot_id,
-							source_image: sourceImage,
-							video_reference_mode: this.config.video_reference_mode,
-							include_source_image: includeSourceImage,
-							reference_image_count: videoReferenceImages.length,
-							reference_images: videoReferenceImages,
-							error: msg,
-						});
-					}
+					video.metadata = {
+						...video.metadata,
+						video_reference_mode: this.config.video_reference_mode,
+						include_source_image: task.includeSourceImage,
+						reference_image_count: task.referenceImages.length,
+						reference_images: task.referenceImages,
+					};
+					videos[index] = video;
+					auditEntries[index] = {
+						shot_id: task.shot.shot_id,
+						video_path: video.video_path,
+						source_image: task.sourceImage,
+						video_reference_mode: this.config.video_reference_mode,
+						include_source_image: task.includeSourceImage,
+						reference_image_count: task.referenceImages.length,
+						reference_images: task.referenceImages,
+					};
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					const shotError = `${task.shot.shot_id}: ${msg}`;
+					console.error(`[camera_gen] Shot failed: ${shotError}`);
+					output.errors.push(shotError);
+					auditEntries[index] = {
+						shot_id: task.shot.shot_id,
+						source_image: task.sourceImage,
+						video_reference_mode: this.config.video_reference_mode,
+						include_source_image: task.includeSourceImage,
+						reference_image_count: task.referenceImages.length,
+						reference_images: task.referenceImages,
+						error: msg,
+					};
 				}
+
+				return runNext();
+			};
+
+			const workers = Array.from({ length: concurrency }, () => runNext());
+			await Promise.all(workers);
+
+			for (let index = 0; index < tasks.length; index++) {
+				const auditEntry = auditEntries[index];
+				if (auditEntry) referenceAudit.push(auditEntry);
+
+				const video = videos[index];
+				if (video) addVideoToOutput(output, video);
 			}
 
 			fs.writeFileSync(

--- a/qcut/electron/native-pipeline/vimax/agents/camera-generator.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/camera-generator.ts
@@ -20,6 +20,7 @@ import {
 import type { StoryboardResult } from "./storyboard-artist.js";
 import { VideoGeneratorAdapter } from "../adapters/video-adapter.js";
 import type { ShotDescription } from "../types/shot.js";
+import type { CharacterPortraitRegistry } from "../types/character.js";
 import type {
 	ImageOutput,
 	VideoOutput,
@@ -27,10 +28,18 @@ import type {
 } from "../types/output.js";
 import { createPipelineOutput, addVideoToOutput } from "../types/output.js";
 
+export type VideoReferenceMode =
+	| "storyboard"
+	| "references"
+	| "storyboard+references";
+
 export interface CameraGeneratorConfig extends AgentConfig {
 	video_model: string;
 	default_duration: number;
 	output_dir: string;
+	video_reference_mode: VideoReferenceMode;
+	video_reference_images: string[];
+	max_video_references: number;
 }
 
 export function createCameraGeneratorConfig(
@@ -41,6 +50,9 @@ export function createCameraGeneratorConfig(
 		video_model: "kling",
 		default_duration: 5.0,
 		output_dir: "media/generated/vimax/videos",
+		video_reference_mode: "storyboard+references",
+		video_reference_images: [],
+		max_video_references: 14,
 		...partial,
 	};
 }
@@ -54,6 +66,54 @@ const MOVEMENT_HINTS: Record<string, string> = {
 	tracking: "camera tracking subject movement",
 	static: "subtle ambient motion, no camera movement",
 };
+
+interface VideoReferenceAuditEntry {
+	shot_id: string;
+	video_path?: string;
+	source_image: string;
+	video_reference_mode: VideoReferenceMode;
+	include_source_image: boolean;
+	reference_image_count: number;
+	reference_images: string[];
+	error?: string;
+}
+
+function uniqueReferences(references: Array<string | undefined>): string[] {
+	const seen = new Set<string>();
+	const unique: string[] = [];
+	for (const reference of references) {
+		const trimmed = reference?.trim();
+		if (!trimmed || seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		unique.push(trimmed);
+	}
+	return unique;
+}
+
+export function collectVideoReferenceImages({
+	shot,
+	portraitRegistry,
+	extraReferenceImages = [],
+	maxReferences = 14,
+}: {
+	shot: ShotDescription;
+	portraitRegistry?: CharacterPortraitRegistry;
+	extraReferenceImages?: string[];
+	maxReferences?: number;
+}): string[] {
+	const registryReferences =
+		portraitRegistry && shot.characters.length > 0
+			? shot.characters.map((character) =>
+					portraitRegistry.getBestView(character, shot.camera_angle)
+				)
+			: [];
+	return uniqueReferences([
+		shot.primary_reference_image,
+		...Object.values(shot.character_references ?? {}),
+		...registryReferences,
+		...extraReferenceImages,
+	]).slice(0, Math.max(0, maxReferences));
+}
 
 export class CameraImageGenerator extends BaseAgent<
 	StoryboardResult,
@@ -95,7 +155,8 @@ export class CameraImageGenerator extends BaseAgent<
 	}
 
 	async process(
-		storyboard: StoryboardResult
+		storyboard: StoryboardResult,
+		portraitRegistry?: CharacterPortraitRegistry
 	): Promise<AgentResult<PipelineOutput>> {
 		await this._ensureAdapter();
 
@@ -113,6 +174,7 @@ export class CameraImageGenerator extends BaseAgent<
 				fs.mkdirSync(outputDir, { recursive: true });
 			}
 
+			const referenceAudit: VideoReferenceAuditEntry[] = [];
 			// Match images with shots
 			let imageIndex = 0;
 			for (const scene of storyboard.scenes) {
@@ -125,19 +187,73 @@ export class CameraImageGenerator extends BaseAgent<
 					const motionPrompt = this._getMotionPrompt(shot);
 					const outputPath = path.join(outputDir, `${shot.shot_id}.mp4`);
 					const sourceImage = image.image_url ?? image.image_path;
-
-					const video = await this._videoAdapter!.generate(
-						sourceImage,
-						motionPrompt,
-						{
-							duration: shot.duration_seconds || this.config.default_duration,
-							output_path: outputPath,
-						}
+					const referenceImages = collectVideoReferenceImages({
+						shot,
+						portraitRegistry,
+						extraReferenceImages: this.config.video_reference_images,
+						maxReferences: this.config.max_video_references,
+					});
+					const includeSourceImage =
+						this.config.video_reference_mode !== "references" ||
+						referenceImages.length === 0;
+					const videoReferenceImages =
+						this.config.video_reference_mode === "storyboard"
+							? []
+							: referenceImages;
+					console.log(
+						`[camera_gen] ${shot.shot_id}: video refs=${videoReferenceImages.length}, storyboard=${includeSourceImage ? "yes" : "no"}`
 					);
 
-					addVideoToOutput(output, video);
+					try {
+						const video = await this._videoAdapter!.generate(
+							sourceImage,
+							motionPrompt,
+							{
+								duration: shot.duration_seconds || this.config.default_duration,
+								output_path: outputPath,
+								reference_images: videoReferenceImages,
+								include_source_image: includeSourceImage,
+							}
+						);
+						video.metadata = {
+							...video.metadata,
+							video_reference_mode: this.config.video_reference_mode,
+							include_source_image: includeSourceImage,
+							reference_image_count: videoReferenceImages.length,
+							reference_images: videoReferenceImages,
+						};
+						referenceAudit.push({
+							shot_id: shot.shot_id,
+							video_path: video.video_path,
+							source_image: sourceImage,
+							video_reference_mode: this.config.video_reference_mode,
+							include_source_image: includeSourceImage,
+							reference_image_count: videoReferenceImages.length,
+							reference_images: videoReferenceImages,
+						});
+						addVideoToOutput(output, video);
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : String(err);
+						const shotError = `${shot.shot_id}: ${msg}`;
+						console.error(`[camera_gen] Shot failed: ${shotError}`);
+						output.errors.push(shotError);
+						referenceAudit.push({
+							shot_id: shot.shot_id,
+							source_image: sourceImage,
+							video_reference_mode: this.config.video_reference_mode,
+							include_source_image: includeSourceImage,
+							reference_image_count: videoReferenceImages.length,
+							reference_images: videoReferenceImages,
+							error: msg,
+						});
+					}
 				}
 			}
+
+			fs.writeFileSync(
+				path.join(outputDir, "video_reference_audit.json"),
+				`${JSON.stringify(referenceAudit, null, 2)}\n`
+			);
 
 			// Concatenate all videos
 			if (output.videos.length > 0) {
@@ -160,6 +276,7 @@ export class CameraImageGenerator extends BaseAgent<
 				video_count: output.videos.length,
 				total_duration: finalDuration,
 				cost: output.total_cost,
+				errors: output.errors,
 			});
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);

--- a/qcut/electron/native-pipeline/vimax/agents/character-portraits.ts
+++ b/qcut/electron/native-pipeline/vimax/agents/character-portraits.ts
@@ -220,11 +220,12 @@ export class CharacterPortraitsGenerator extends BaseAgent<
 
 				totalCost += result.cost;
 
-				if (view === "front") portrait.front_view = result.image_path;
-				else if (view === "side") portrait.side_view = result.image_path;
-				else if (view === "back") portrait.back_view = result.image_path;
+				const referenceImage = result.image_url ?? result.image_path;
+				if (view === "front") portrait.front_view = referenceImage;
+				else if (view === "side") portrait.side_view = referenceImage;
+				else if (view === "back") portrait.back_view = referenceImage;
 				else if (view === "three_quarter")
-					portrait.three_quarter_view = result.image_path;
+					portrait.three_quarter_view = referenceImage;
 			}
 
 			console.log(`[portraits] Generated portraits for ${character.name}`);

--- a/qcut/electron/native-pipeline/vimax/pipelines/__tests__/split-novel-text.test.ts
+++ b/qcut/electron/native-pipeline/vimax/pipelines/__tests__/split-novel-text.test.ts
@@ -148,5 +148,6 @@ describe("novel2movie defaults", () => {
 
 		expect(config.video_model).toBe("imarouter_seedance_2_0_ref2v");
 		expect(config.video_reference_mode).toBe("storyboard+references");
+		expect(config.video_concurrency).toBe(1);
 	});
 });

--- a/qcut/electron/native-pipeline/vimax/pipelines/__tests__/split-novel-text.test.ts
+++ b/qcut/electron/native-pipeline/vimax/pipelines/__tests__/split-novel-text.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+	createNovel2MovieConfig,
 	filterScriptToClipShotKeys,
 	selectShortestClipShotKeys,
 	splitNovelText,
@@ -138,5 +139,14 @@ describe("novel2movie clip selection", () => {
 		expect(
 			secondChunk.scenes[0]?.shots.map((shot) => shot.duration_seconds)
 		).toEqual([2]);
+	});
+});
+
+describe("novel2movie defaults", () => {
+	it("uses Seedance Ref2V so default video generation can consume multiple references", () => {
+		const config = createNovel2MovieConfig();
+
+		expect(config.video_model).toBe("imarouter_seedance_2_0_ref2v");
+		expect(config.video_reference_mode).toBe("storyboard+references");
 	});
 });

--- a/qcut/electron/native-pipeline/vimax/pipelines/novel2movie.ts
+++ b/qcut/electron/native-pipeline/vimax/pipelines/novel2movie.ts
@@ -20,9 +20,11 @@ import {
 	CharacterPortraitsGenerator,
 	StoryboardArtist,
 	CameraImageGenerator,
+	type VideoReferenceMode,
 	NovelSegmenter,
 	buildPromptDescriptions,
 } from "../agents/index.js";
+import { ImageGeneratorAdapter } from "../adapters/image-adapter.js";
 import { VideoGeneratorAdapter } from "../adapters/video-adapter.js";
 import type {
 	CharacterInNovel,
@@ -57,6 +59,12 @@ export interface Novel2MovieConfig {
 	max_scenes: number;
 	/** Cap the number of shot videos generated (0 = unlimited). */
 	max_clips: number;
+	/** Which images the video model should receive as references. */
+	video_reference_mode: VideoReferenceMode;
+	/** Extra video reference images supplied by the CLI/caller. */
+	video_reference_images: string[];
+	/** Hard cap for provider reference image lists. */
+	max_video_references: number;
 }
 
 /** Create a {@link Novel2MovieConfig} with sensible defaults. */
@@ -65,7 +73,7 @@ export function createNovel2MovieConfig(
 ): Novel2MovieConfig {
 	return {
 		output_dir: "media/generated/vimax/novel2movie",
-		video_model: "kling",
+		video_model: "imarouter_seedance_2_0_ref2v",
 		image_model: "gmi_gemini_3_pro_image",
 		llm_model: "google/gemini-3-flash-preview",
 		shot_duration: 15,
@@ -81,6 +89,9 @@ export function createNovel2MovieConfig(
 		max_images: 0,
 		max_scenes: 0,
 		max_clips: 0,
+		video_reference_mode: "storyboard+references",
+		video_reference_images: [],
+		max_video_references: 14,
 		...partial,
 	};
 }
@@ -413,12 +424,20 @@ export class Novel2MoviePipeline {
 
 		this.storyboard_artist = new StoryboardArtist({
 			image_model: this.config.image_model,
+			reference_model: ImageGeneratorAdapter.supportsReferenceImages(
+				this.config.image_model
+			)
+				? this.config.image_model
+				: "gpt_image_2_ima",
 			output_dir: `${base}/storyboard`,
 		});
 
 		this.camera_generator = new CameraImageGenerator({
 			video_model: this.config.video_model,
 			output_dir: `${base}/videos`,
+			video_reference_mode: this.config.video_reference_mode,
+			video_reference_images: this.config.video_reference_images,
+			max_video_references: this.config.max_video_references,
 		});
 	}
 
@@ -751,6 +770,10 @@ export class Novel2MoviePipeline {
 						storyboardCap
 					);
 					if (!storyboardResult.success || !storyboardResult.result) {
+						result.errors.push(
+							storyboardResult.error ??
+								`Storyboard generation failed for chunk ${i + 1}`
+						);
 						continue;
 					}
 					result.total_cost += (storyboardResult.metadata.cost as number) ?? 0;
@@ -761,8 +784,15 @@ export class Novel2MoviePipeline {
 					}
 
 					const videoResult = await this.camera_generator.process(
-						storyboardResult.result
+						storyboardResult.result,
+						result.portrait_registry
 					);
+					if (videoResult.result?.errors?.length) {
+						result.errors.push(...videoResult.result.errors);
+					}
+					if (!videoResult.success && videoResult.error) {
+						result.errors.push(videoResult.error);
+					}
 					if (videoResult.success && videoResult.result?.videos) {
 						allVideos.push(...videoResult.result.videos);
 						result.total_cost += (videoResult.metadata.cost as number) ?? 0;
@@ -806,7 +836,23 @@ export class Novel2MoviePipeline {
 				};
 			}
 
-			result.success = result.scripts.length > 0;
+			if (
+				!this.config.scripts_only &&
+				!this.config.storyboard_only &&
+				!imagesCapped &&
+				allVideos.length === 0 &&
+				result.errors.length === 0
+			) {
+				result.errors.push("No videos generated");
+			}
+
+			result.success =
+				result.scripts.length > 0 &&
+				result.errors.length === 0 &&
+				(this.config.scripts_only ||
+					this.config.storyboard_only ||
+					imagesCapped ||
+					allVideos.length > 0);
 			result.completed_at = new Date().toISOString();
 
 			if (this.config.save_intermediate) {

--- a/qcut/electron/native-pipeline/vimax/pipelines/novel2movie.ts
+++ b/qcut/electron/native-pipeline/vimax/pipelines/novel2movie.ts
@@ -65,6 +65,8 @@ export interface Novel2MovieConfig {
 	video_reference_images: string[];
 	/** Hard cap for provider reference image lists. */
 	max_video_references: number;
+	/** Parallel video clip generations in flight. Capped by CameraImageGenerator. */
+	video_concurrency: number;
 }
 
 /** Create a {@link Novel2MovieConfig} with sensible defaults. */
@@ -92,6 +94,7 @@ export function createNovel2MovieConfig(
 		video_reference_mode: "storyboard+references",
 		video_reference_images: [],
 		max_video_references: 14,
+		video_concurrency: 1,
 		...partial,
 	};
 }
@@ -438,6 +441,7 @@ export class Novel2MoviePipeline {
 			video_reference_mode: this.config.video_reference_mode,
 			video_reference_images: this.config.video_reference_images,
 			max_video_references: this.config.max_video_references,
+			video_concurrency: this.config.video_concurrency,
 		});
 	}
 

--- a/qcut/resources/default-skills/ai-content-pipeline/REFERENCE.md
+++ b/qcut/resources/default-skills/ai-content-pipeline/REFERENCE.md
@@ -339,7 +339,7 @@ QCut's Claude HTTP server (port 8765) exposes video analysis endpoints that acce
 
 | Type | Description | Provider |
 |------|-------------|----------|
-| `timeline` (default) | Detailed second-by-second breakdown | FAL (Gemini via OpenRouter) |
+| `timeline` (default) | Detailed second-by-second breakdown | OpenRouter Gemini 3.5 Flash |
 | `describe` | Video description and summary | Gemini direct |
 | `transcribe` | Audio transcription with timestamps | Gemini direct |
 
@@ -347,7 +347,8 @@ QCut's Claude HTTP server (port 8765) exposes video analysis endpoints that acce
 
 | Key | Provider | Model ID | Notes |
 |-----|----------|----------|-------|
-| `gemini-2.5-flash` (default) | FAL | `google/gemini-2.5-flash` | Fast, cost-effective |
+| `openrouter_gemini_3_5_flash_video` (default) | OpenRouter | `google/gemini-3.5-flash` | Fast multimodal video analysis |
+| `gemini-2.5-flash` | FAL | `google/gemini-2.5-flash` | Legacy FAL route |
 | `gemini-2.5-pro` | FAL | `google/gemini-2.5-pro` | Higher quality |
 | `gemini-3-pro` | FAL | `google/gemini-3-pro-preview` | Highest quality |
 | `gemini-direct` | Gemini | `gemini-2.0-flash-exp` | Requires GEMINI_API_KEY |

--- a/qcut/resources/default-skills/native-cli/references/REFERENCE.md
+++ b/qcut/resources/default-skills/native-cli/references/REFERENCE.md
@@ -115,7 +115,7 @@ Analyze a video with AI vision.
 |------|-------|------|---------|-------------|
 | `--input` | `-i` | string | | Video file or URL (required) |
 | `--video-url` | | string | | Alias for input |
-| `--model` | `-m` | string | `gemini_qa` | Vision model |
+| `--model` | `-m` | string | `openrouter_gemini_3_5_flash_video` | Vision model |
 | `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript` |
 | `--prompt` | | string | | Custom prompt (overrides analysis-type) |
 | `--text` | `-t` | string | | Alias for prompt |
@@ -162,7 +162,7 @@ Extract highlight clips from a video using subtitle-based LLM analysis. Runs a 4
 | `--input` | `-i` | string | | Input video file path (required) |
 | `--srt-file` | `-s` | string | | SRT/VTT subtitle file (auto-detects if omitted) |
 | `--output` | `-o` | string | | Output directory for clips and metadata |
-| `--model` | `-m` | string | `google/gemini-3-flash-preview` | LLM model for analysis |
+| `--model` | `-m` | string | `google/gemini-3.5-flash` | LLM model for analysis |
 | `--min-score` | | number | `0.7` | Minimum score threshold 0–1 |
 | `--step` | | number | | Run only a specific step (1–4) |
 | `--chunk-minutes` | | number | `30` | Subtitle chunk interval in minutes |


### PR DESCRIPTION
## Summary

- Add `storyboard+references` support to `flow novel2movie` video generation.
- Default `novel2movie` video output to IMA Router Seedance Ref2V so portrait references work without extra flags.
- Add `video_reference_audit.json` and CLI flags for video reference mode/images.
- Fix default reference-image paths by storing remote portrait URLs and falling back to `gpt_image_2_ima` for storyboard reference edits.
- Record the Chinese / Asian K-pop supermodel e2e timing and parallelism analysis in the Daytona task docs.

## Why

`qcut flow novel2movie --novel story.txt --max-scenes 20 --max-clips 5` could previously generate videos without actually feeding portrait references into the video model, or fail in default reference paths due to older model/upload assumptions. The video stage also had no durable evidence showing which references were used per clip.

## Validation

- `bunx vitest run electron/native-pipeline/vimax/agents/__tests__/character-portraits.test.ts electron/native-pipeline/vimax/pipelines/__tests__/split-novel-text.test.ts electron/native-pipeline/vimax/adapters/__tests__/video-adapter-gmi-seedance.test.ts electron/native-pipeline/vimax/agents/__tests__/camera-generator-references.test.ts electron/native-pipeline/output/__tests__/upload-helper.test.ts`
- `cd electron && bun x tsc`
- Real e2e: `qcut flow novel2movie --novel story.txt --max-scenes 20 --max-clips 5`
  - Scenario: Chinese / East Asian K-pop supermodel story
  - Generated 5 clips and final movie
  - Audit confirms `SHOT_004` and `SHOT_005` used 2 portrait references plus the storyboard image
  - Artifact: `/Users/peter/Downloads/qcut-kpop-asian-ref-e2e-artifacts`

## Notes

- Video clips are still generated sequentially. The timing doc captures the current step timing and recommends a future bounded `--video-concurrency` option if we want faster multi-clip runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable video reference modes and multi-reference image support for video generation.
  * New --video-concurrency flag to control parallel video processing.

* **Documentation**
  * Added bilingual (English/Chinese) novel-to-movie workflow docs, asset library architecture, implementation plan, effort/risk/testing guidance, and multiple E2E/test reports.

* **Improvements**
  * Updated CLI and pipeline defaults to newer video/LLM models (OpenRouter Gemini 3.5 Flash / Gemini 3.5 Flash).
  * Improved provider routing and media handling for OpenRouter and other backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Quriosity-agent/qcut/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->