### PR TITLE
Fix agent terminal reconnect diagnostics

### DIFF
--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
@@ -799,6 +799,60 @@ After the failing layer is identified, likely fixes are:
 - 增加 relay input audit event。
 - 增加 watchdog：如果浏览器侧 `WebSocket.send(...)` 增加了，但短时间内没有 relay ack/output，显示明确恢复动作。
 
+Implemented fix status:
+
+已实现修复状态：
+
+- Done: explicit `Reconnect` button in `chat-agent.html`.
+- Done: reconnect closes the current browser attachment and then reconnects to the same stored active session id.
+- Done: `Connect` prefers the stored active session id before creating a new session.
+- Done: relay sends `pty_input_ack`, `pty_input_error`, and `pty_input_timeout` server-control messages to the browser.
+- Done: front-end parses those control messages without writing them into xterm output.
+- Done: front-end has a 7-second ack watchdog after `WebSocket.send(...)`.
+- Done: relay audit and browser debug avoid raw input text.
+
+- 已完成：`chat-agent.html` 中加入显式 `Reconnect` 按钮。
+- 已完成：reconnect 会关闭当前 browser attachment，然后重新连接同一个已保存的 active session id。
+- 已完成：`Connect` 会优先使用已保存的 active session id，然后才创建新 session。
+- 已完成：relay 会向浏览器发送 `pty_input_ack`、`pty_input_error` 和 `pty_input_timeout` server-control message。
+- 已完成：前端会解析这些 control message，不会把它们写入 xterm output。
+- 已完成：前端在 `WebSocket.send(...)` 后加入 7 秒 ack watchdog。
+- 已完成：relay audit 和浏览器 debug 都避免记录原始输入文本。
+
+Verification evidence:
+
+验证证据：
+
+```bash
+node --test packages/nexusai-website/js/agent-chat.prompt.test.js
+# 12 passed
+
+cd packages/qcut-relay && bun run test
+# 21 passed
+
+bunx biome check \
+  packages/nexusai-website/js/agent-chat/03-terminal-job.js \
+  packages/nexusai-website/js/agent-chat/04-bootstrap.js \
+  packages/qcut-relay/src/pty-session.ts \
+  packages/qcut-relay/src/pty-session.test.ts \
+  --max-diagnostics=120
+# Checked 4 files. No fixes applied.
+```
+
+What remains for live proof after deploy:
+
+部署后仍需做的 live proof：
+
+- Open the Chat Agent page, connect an existing session, type one character, and confirm the debug line shows both `input #... sent` and `ack #...`.
+- Reproduce or simulate a stale input path and confirm the 7-second watchdog surfaces the missing ack.
+- Click `Reconnect` and confirm the same session id remains visible while a fresh PTY/Codex attachment starts.
+- Submit a second prompt after reconnect and confirm `history.jsonl` gets the prompt.
+
+- 打开 Chat Agent 页面，连接已有 session，输入一个字符，并确认 debug line 同时显示 `input #... sent` 和 `ack #...`。
+- 复现或模拟 stale input path，并确认 7 秒 watchdog 会暴露 missing ack。
+- 点击 `Reconnect`，确认可见 session id 保持不变，同时 fresh PTY/Codex attachment 启动。
+- reconnect 后提交第二条 prompt，并确认 `history.jsonl` 写入该 prompt。
+
 ## Suggested First Implementation Slice / 建议第一步实现范围
 
 Start small:

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
@@ -853,6 +853,26 @@ What remains for live proof after deploy:
 - 点击 `Reconnect`，确认可见 session id 保持不变，同时 fresh PTY/Codex attachment 启动。
 - reconnect 后提交第二条 prompt，并确认 `history.jsonl` 写入该 prompt。
 
+Commit and PR evidence:
+
+Commit / PR 证据：
+
+- Website repo `donghaozhang/nexusai-website`:
+  - branch: `master`
+  - commit: `4998409` (`Fix chat terminal reconnect diagnostics`)
+- Main repo `Quriosity-agent/qcut`:
+  - branch: `image-cli-v11`
+  - commit: `9708913cf` (`Fix agent terminal reconnect diagnostics`)
+  - PR: `https://github.com/Quriosity-agent/qcut/pull/311`
+
+- Website repo `donghaozhang/nexusai-website`：
+  - branch：`master`
+  - commit：`4998409`（`Fix chat terminal reconnect diagnostics`）
+- Main repo `Quriosity-agent/qcut`：
+  - branch：`image-cli-v11`
+  - commit：`9708913cf`（`Fix agent terminal reconnect diagnostics`）
+  - PR：`https://github.com/Quriosity-agent/qcut/pull/311`
+
 ## Suggested First Implementation Slice / 建议第一步实现范围
 
 Start small:

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
@@ -839,19 +839,80 @@ bunx biome check \
 # Checked 4 files. No fixes applied.
 ```
 
-What remains for live proof after deploy:
+Live proof after deploy:
 
-部署后仍需做的 live proof：
+部署后的 live proof：
 
-- Open the Chat Agent page, connect an existing session, type one character, and confirm the debug line shows both `input #... sent` and `ack #...`.
-- Reproduce or simulate a stale input path and confirm the 7-second watchdog surfaces the missing ack.
-- Click `Reconnect` and confirm the same session id remains visible while a fresh PTY/Codex attachment starts.
-- Submit a second prompt after reconnect and confirm `history.jsonl` gets the prompt.
+Production website and relay were both updated before the final live test.
 
-- 打开 Chat Agent 页面，连接已有 session，输入一个字符，并确认 debug line 同时显示 `input #... sent` 和 `ack #...`。
-- 复现或模拟 stale input path，并确认 7 秒 watchdog 会暴露 missing ack。
-- 点击 `Reconnect`，确认可见 session id 保持不变，同时 fresh PTY/Codex attachment 启动。
-- reconnect 后提交第二条 prompt，并确认 `history.jsonl` 写入该 prompt。
+最终 live test 前，生产网站和 relay 都已经更新。
+
+- Website: `https://quriosity.com.au/chat-agent.html`
+- Website repo: `donghaozhang/nexusai-website@25a21d5`
+- GitHub Pages deploy: run `26437358937`, completed successfully.
+- Relay: `https://qcut-relay.zdhpeter.workers.dev`
+- Relay deploy version: `6e430112-10fe-48bc-a00c-b52b97666f9e`
+
+- 网站：`https://quriosity.com.au/chat-agent.html`
+- 网站仓库：`donghaozhang/nexusai-website@25a21d5`
+- GitHub Pages deploy：run `26437358937`，已成功完成。
+- Relay：`https://qcut-relay.zdhpeter.workers.dev`
+- Relay deploy version：`6e430112-10fe-48bc-a00c-b52b97666f9e`
+
+The final production E2E passed:
+
+最终生产 E2E 已通过：
+
+```bash
+bun scripts/agent-chat-e2e.ts \
+  --url https://quriosity.com.au/chat-agent.html \
+  --connect-timeout-ms 300000 \
+  --prompt-timeout-ms 300000 \
+  --artifact-timeout-ms 420000 \
+  --wait-no-auto-connect-ms 3000
+
+# status: passed
+# result: output/playwright/agent-chat-e2e-2026-05-26T07-00-24-883Z/result.json
+```
+
+Important passed steps:
+
+关键通过步骤：
+
+- `manual connect opens Codex`: passed in `12372ms`.
+- `direct terminal qcut image generation creates artifacts`: passed in `112895ms`.
+- `second terminal input works after image generation`: passed in `5748ms`.
+- `terminal-generated image artifacts download from the web UI`: passed in `2246ms`.
+- `reconnect opens Codex again`: passed in `3683ms` with the same session id `3c07f57f-43bd-44ab-85fd-4e2bd24123b3`.
+- `input works after explicit reconnect`: passed in `10883ms`.
+- `disconnect clears terminal state`: passed in `405ms`.
+
+- `manual connect opens Codex`：`12372ms` 通过。
+- `direct terminal qcut image generation creates artifacts`：`112895ms` 通过。
+- `second terminal input works after image generation`：`5748ms` 通过。
+- `terminal-generated image artifacts download from the web UI`：`2246ms` 通过。
+- `reconnect opens Codex again`：`3683ms` 通过，并保持同一个 session id `3c07f57f-43bd-44ab-85fd-4e2bd24123b3`。
+- `input works after explicit reconnect`：`10883ms` 通过。
+- `disconnect clears terminal state`：`405ms` 通过。
+
+The E2E also verified the new debug/ack path:
+
+E2E 同时验证了新的 debug/ack 链路：
+
+```text
+after image prompt:
+socket #2 open · input #465 sent 1 bytes ... · ack #465 1 bytes ...
+
+second input after image generation:
+socket #2 open · input #663 sent 1 bytes ... · ack #663 1 bytes ...
+
+after explicit Reconnect:
+socket #3 open · input #186 sent 1 bytes ... · ack #186 1 bytes ...
+```
+
+The final E2E result contains no `no relay ack` stale-input warning.
+
+最终 E2E 结果中没有 `no relay ack` stale-input 误报。
 
 Commit and PR evidence:
 
@@ -864,7 +925,7 @@ Commit / PR 证据：
   - commit: `25a21d5` (`Reset terminal ack counters on reconnect`)
 - Main repo `Quriosity-agent/qcut`:
   - branch: `image-cli-v11`
-  - commits: `9708913cf` (`Fix agent terminal reconnect diagnostics`), `e153a46d8` (`Document agent terminal fix PR`), plus a follow-up commit addressing the Gemini race-condition review and bumping the website submodule to `25a21d5`.
+  - commits: `9708913cf` (`Fix agent terminal reconnect diagnostics`), `e153a46d8` (`Document agent terminal fix PR`), `f00d15ebb` (`fix(relay): mutate shared audit stats and bring in reconnect fallbacks`), plus this final evidence update.
   - PR: `https://github.com/Quriosity-agent/qcut/pull/311`
 
 - Website repo `donghaozhang/nexusai-website`：
@@ -874,7 +935,7 @@ Commit / PR 证据：
   - commit：`25a21d5`（`Reset terminal ack counters on reconnect`）
 - Main repo `Quriosity-agent/qcut`：
   - branch：`image-cli-v11`
-  - commits：`9708913cf`（`Fix agent terminal reconnect diagnostics`）、`e153a46d8`（`Document agent terminal fix PR`），以及一条处理 Gemini race-condition 评审并把 website submodule pointer 升到 `25a21d5` 的 follow-up commit。
+  - commits：`9708913cf`（`Fix agent terminal reconnect diagnostics`）、`e153a46d8`（`Document agent terminal fix PR`）、`f00d15ebb`（`fix(relay): mutate shared audit stats and bring in reconnect fallbacks`），以及当前最终证据更新。
   - PR：`https://github.com/Quriosity-agent/qcut/pull/311`
 
 ## Suggested First Implementation Slice / 建议第一步实现范围

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/investigation-plan.md
@@ -860,17 +860,21 @@ Commit / PR 证据：
 - Website repo `donghaozhang/nexusai-website`:
   - branch: `master`
   - commit: `4998409` (`Fix chat terminal reconnect diagnostics`)
+  - commit: `0112bb9` (`Fix stale agent session reconnect fallback`)
+  - commit: `25a21d5` (`Reset terminal ack counters on reconnect`)
 - Main repo `Quriosity-agent/qcut`:
   - branch: `image-cli-v11`
-  - commit: `9708913cf` (`Fix agent terminal reconnect diagnostics`)
+  - commits: `9708913cf` (`Fix agent terminal reconnect diagnostics`), `e153a46d8` (`Document agent terminal fix PR`), plus a follow-up commit addressing the Gemini race-condition review and bumping the website submodule to `25a21d5`.
   - PR: `https://github.com/Quriosity-agent/qcut/pull/311`
 
 - Website repo `donghaozhang/nexusai-website`：
   - branch：`master`
   - commit：`4998409`（`Fix chat terminal reconnect diagnostics`）
+  - commit：`0112bb9`（`Fix stale agent session reconnect fallback`）
+  - commit：`25a21d5`（`Reset terminal ack counters on reconnect`）
 - Main repo `Quriosity-agent/qcut`：
   - branch：`image-cli-v11`
-  - commit：`9708913cf`（`Fix agent terminal reconnect diagnostics`）
+  - commits：`9708913cf`（`Fix agent terminal reconnect diagnostics`）、`e153a46d8`（`Document agent terminal fix PR`），以及一条处理 Gemini race-condition 评审并把 website submodule pointer 升到 `25a21d5` 的 follow-up commit。
   - PR：`https://github.com/Quriosity-agent/qcut/pull/311`
 
 ## Suggested First Implementation Slice / 建议第一步实现范围

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
@@ -605,3 +605,19 @@ The implementation now turns the proven recovery path into an explicit product a
 This does not claim to prove the internal Codex TUI root cause. It fixes the user-visible stuck state by detecting the unhealthy input path and providing an explicit same-session recovery action whose effectiveness was already proven live with `Disconnect` + `Connect`.
 
 这并不声称已经证明 Codex TUI 内部根因。它修复的是用户可见的卡住状态：检测不健康的输入链路，并提供明确的同 session 恢复动作；这个恢复动作的有效性已经通过 live `Disconnect` + `Connect` 证明过。
+
+## Follow-up Fixes / 后续修复
+
+Date / 日期: 2026-05-26
+
+After the initial implementation, three additional fixes were applied to keep the recovery path reliable and to address a concurrency review on the relay audit code.
+
+初次实现之后，又应用了三个修复，用来保持恢复路径可靠，并处理 relay audit 代码上的一条并发评审。
+
+- Relay: `sendInputWithAudit` now mutates a shared `PtyInputAuditStats` object synchronously after each `await`, instead of taking a snapshot and writing back via callback. This removes a race in `inputAuditBytes` / `inputAuditMessages` accumulation when multiple terminal input messages were forwarded concurrently. (Gemini PR #311 review.)
+- Website: `shouldCreateFreshTerminalSession` now also treats `session_not_found` as a stale session and falls back to a new session.
+- Website: `connectAgentTerminal` resets `terminalInputSequence` and `terminalLastAckedInputId` on each reconnect so the 7-second ack watchdog does not flag pre-reconnect input ids as stale.
+
+- relay：`sendInputWithAudit` 在每次 `await` 之后会同步修改一个共享的 `PtyInputAuditStats` 对象，而不再使用“快照 + callback 回写”。这消除了多条 terminal input 并发转发时，`inputAuditBytes` / `inputAuditMessages` 累加上的 race。（来自 Gemini 对 PR #311 的评审。）
+- 网站：`shouldCreateFreshTerminalSession` 现在也把 `session_not_found` 视为 stale session，并 fallback 到新建 session。
+- 网站：`connectAgentTerminal` 在每次重连时会重置 `terminalInputSequence` 和 `terminalLastAckedInputId`，避免 7 秒 ack watchdog 把重连前的 input id 误判为 stale。

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
@@ -577,3 +577,31 @@ The user can lose confidence because the UI says connected and ready while the t
 The current safest recovery is to preserve/download needed artifacts first, then use `Disconnect` + `Connect` to create a fresh attachment for the same active session. Starting a new session is not necessary unless reconnect fails. However, that is a workaround, not a fix.
 
 当前最安全的恢复方式是先保留或下载需要的 artifact，然后用 `Disconnect` + `Connect` 为同一个 active session 创建新的 attachment。除非重连失败，否则不需要新建 session。但这只是 workaround，不是根本修复。
+
+## Implemented Fix / 已实现修复
+
+Date / 日期: 2026-05-26
+
+The implementation now turns the proven recovery path into an explicit product action and adds input-path evidence instead of relying on the visual `connected` state.
+
+当前实现已经把有证据证明有效的恢复路径变成明确的产品动作，并且加入输入链路证据，不再只依赖视觉上的 `connected` 状态。
+
+- Added a visible `Reconnect` button next to `Connect` and `Disconnect`.
+- `Reconnect` closes the current browser WebSocket attachment, waits for it to close, and then opens a fresh PTY attachment for the same stored active session.
+- `Connect` now prefers the stored active session id before creating a new session, so reconnect-style recovery preserves the server-side session and files.
+- Relay now sends browser-readable `pty_input_ack`, `pty_input_error`, and `pty_input_timeout` control messages after terminal input is forwarded to `pty.sendInput(...)`.
+- The browser debug line now shows input send state, relay ack state, output state, and stale-input errors.
+- If browser-side input is sent but no relay ack arrives within 7 seconds, the UI reports that the input path is stale and points the user to `Reconnect`.
+- Relay audit still records `pty_input`, `pty_input_error`, and `pty_input_timeout` without logging raw terminal input.
+
+- 新增了可见的 `Reconnect` 按钮，位置在 `Connect` 和 `Disconnect` 旁边。
+- `Reconnect` 会关闭当前 browser WebSocket attachment，等待它关闭，然后为同一个已保存的 active session 打开新的 PTY attachment。
+- `Connect` 现在会优先复用已保存的 active session id，然后才创建新 session，因此 reconnect 式恢复会保留 server-side session 和文件。
+- relay 现在会在 terminal input 转发给 `pty.sendInput(...)` 后，向浏览器发送可识别的 `pty_input_ack`、`pty_input_error` 和 `pty_input_timeout` control message。
+- 浏览器 debug line 现在显示 input send 状态、relay ack 状态、output 状态，以及 stale-input 错误。
+- 如果浏览器侧 input 已发送但 7 秒内没有收到 relay ack，UI 会提示 input path stale，并指向 `Reconnect`。
+- relay audit 仍然记录 `pty_input`、`pty_input_error` 和 `pty_input_timeout`，但不记录原始 terminal input。
+
+This does not claim to prove the internal Codex TUI root cause. It fixes the user-visible stuck state by detecting the unhealthy input path and providing an explicit same-session recovery action whose effectiveness was already proven live with `Disconnect` + `Connect`.
+
+这并不声称已经证明 Codex TUI 内部根因。它修复的是用户可见的卡住状态：检测不健康的输入链路，并提供明确的同 session 恢复动作；这个恢复动作的有效性已经通过 live `Disconnect` + `Connect` 证明过。

--- a/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
+++ b/qcut/docs/task/daytona-supabase-agent/codex-terminal-input-stuck/problem-statement.md
@@ -602,9 +602,9 @@ The implementation now turns the proven recovery path into an explicit product a
 - 如果浏览器侧 input 已发送但 7 秒内没有收到 relay ack，UI 会提示 input path stale，并指向 `Reconnect`。
 - relay audit 仍然记录 `pty_input`、`pty_input_error` 和 `pty_input_timeout`，但不记录原始 terminal input。
 
-This does not claim to prove the internal Codex TUI root cause. It fixes the user-visible stuck state by detecting the unhealthy input path and providing an explicit same-session recovery action whose effectiveness was already proven live with `Disconnect` + `Connect`.
+This does not claim to prove the internal Codex TUI root cause. It fixes the user-visible stuck state by detecting the unhealthy input path and providing an explicit same-session recovery action. Final production E2E also proved that a second terminal input works after real image generation, and that input still works after explicit `Reconnect`.
 
-这并不声称已经证明 Codex TUI 内部根因。它修复的是用户可见的卡住状态：检测不健康的输入链路，并提供明确的同 session 恢复动作；这个恢复动作的有效性已经通过 live `Disconnect` + `Connect` 证明过。
+这并不声称已经证明 Codex TUI 内部根因。它修复的是用户可见的卡住状态：检测不健康的输入链路，并提供明确的同 session 恢复动作。最终生产 E2E 也证明了真实图片生成之后第二次 terminal 输入可以继续工作，并且显式 `Reconnect` 之后输入仍可工作。
 
 ## Follow-up Fixes / 后续修复
 
@@ -617,7 +617,23 @@ After the initial implementation, three additional fixes were applied to keep th
 - Relay: `sendInputWithAudit` now mutates a shared `PtyInputAuditStats` object synchronously after each `await`, instead of taking a snapshot and writing back via callback. This removes a race in `inputAuditBytes` / `inputAuditMessages` accumulation when multiple terminal input messages were forwarded concurrently. (Gemini PR #311 review.)
 - Website: `shouldCreateFreshTerminalSession` now also treats `session_not_found` as a stale session and falls back to a new session.
 - Website: `connectAgentTerminal` resets `terminalInputSequence` and `terminalLastAckedInputId` on each reconnect so the 7-second ack watchdog does not flag pre-reconnect input ids as stale.
+- Production E2E: the final run passed the image-generation workflow, the second input after image generation, explicit same-session `Reconnect`, post-reconnect input, and artifact download.
 
 - relay：`sendInputWithAudit` 在每次 `await` 之后会同步修改一个共享的 `PtyInputAuditStats` 对象，而不再使用“快照 + callback 回写”。这消除了多条 terminal input 并发转发时，`inputAuditBytes` / `inputAuditMessages` 累加上的 race。（来自 Gemini 对 PR #311 的评审。）
 - 网站：`shouldCreateFreshTerminalSession` 现在也把 `session_not_found` 视为 stale session，并 fallback 到新建 session。
 - 网站：`connectAgentTerminal` 在每次重连时会重置 `terminalInputSequence` 和 `terminalLastAckedInputId`，避免 7 秒 ack watchdog 把重连前的 input id 误判为 stale。
+- 生产 E2E：最终运行通过了 image-generation workflow、图片生成后的第二次输入、显式同 session `Reconnect`、reconnect 后输入，以及 artifact download。
+
+Final production evidence:
+
+最终生产证据：
+
+```text
+result: output/playwright/agent-chat-e2e-2026-05-26T07-00-24-883Z/result.json
+status: passed
+image generation: passed in 112895ms
+second input after image: passed in 5748ms
+explicit reconnect: passed in 3683ms, same session id 3c07f57f-43bd-44ab-85fd-4e2bd24123b3
+input after reconnect: passed in 10883ms
+debug ack examples: input #465 / ack #465, input #663 / ack #663, input #186 / ack #186
+```

--- a/qcut/electron/__tests__/vimax-video-adapter.test.ts
+++ b/qcut/electron/__tests__/vimax-video-adapter.test.ts
@@ -182,26 +182,32 @@ describe("buildImageField", () => {
 	});
 
 	it("FAL + remote URL → image_url passthrough", () => {
-		const out = buildImageField("https://cdn.example.com/frame.png", "fal");
+		const out = buildImageField({
+			imagePath: "https://cdn.example.com/frame.png",
+			provider: "fal",
+		});
 		expect(out).toEqual({
 			image_url: "https://cdn.example.com/frame.png",
 		});
 	});
 
 	it("GMI + remote URL → image passthrough (renamed field)", () => {
-		const out = buildImageField("https://cdn.example.com/frame.png", "gmi");
+		const out = buildImageField({
+			imagePath: "https://cdn.example.com/frame.png",
+			provider: "gmi",
+		});
 		expect(out).toEqual({ image: "https://cdn.example.com/frame.png" });
 		expect(out).not.toHaveProperty("image_url");
 	});
 
 	it("FAL + local path → image_url as data URI", () => {
-		const out = buildImageField(localPng, "fal");
+		const out = buildImageField({ imagePath: localPng, provider: "fal" });
 		expect(out.image_url).toMatch(/^data:image\/png;base64,/);
 		expect(out.image_url.length).toBeGreaterThan(50);
 	});
 
 	it("GMI + local path → image as RAW base64 (no data URI prefix)", () => {
-		const out = buildImageField(localPng, "gmi");
+		const out = buildImageField({ imagePath: localPng, provider: "gmi" });
 		expect(out.image).not.toMatch(/^data:/);
 		// Pure base64 — verify it's valid and decodes to the PNG bytes.
 		const decoded = Buffer.from(out.image, "base64");
@@ -210,13 +216,13 @@ describe("buildImageField", () => {
 
 	it("FAL + data URI stays untouched (pass-through)", () => {
 		const dataUri = "data:image/png;base64,iVBORw0KGgo=";
-		const out = buildImageField(dataUri, "fal");
+		const out = buildImageField({ imagePath: dataUri, provider: "fal" });
 		expect(out).toEqual({ image_url: dataUri });
 	});
 
 	it("GMI + data URI stays untouched (caller's responsibility)", () => {
 		const dataUri = "data:image/png;base64,iVBORw0KGgo=";
-		const out = buildImageField(dataUri, "gmi");
+		const out = buildImageField({ imagePath: dataUri, provider: "gmi" });
 		expect(out).toEqual({ image: dataUri });
 	});
 });

--- a/qcut/packages/qcut-relay/src/pty-session.test.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	buildDaytonaPtyId,
 	buildCodexStartupCommand,
+	buildPtyServerControlMessage,
 	parsePtyClientControlMessage,
 } from "./pty-session";
 
@@ -69,6 +70,41 @@ describe("buildDaytonaPtyId", () => {
 				nonce: "safe",
 			})
 		).toBe("qcut-agent-sessionwiths-safe");
+	});
+});
+
+describe("buildPtyServerControlMessage", () => {
+	it("serializes input acknowledgements without raw terminal input", () => {
+		expect(
+			JSON.parse(
+				buildPtyServerControlMessage({
+					kind: "pty_input_ack",
+					messageIndex: 7,
+					bytes: 1,
+					elapsedMs: 4,
+				})
+			)
+		).toEqual({
+			kind: "pty_input_ack",
+			messageIndex: 7,
+			bytes: 1,
+			elapsedMs: 4,
+		});
+	});
+
+	it("limits error control payloads", () => {
+		const message = JSON.parse(
+			buildPtyServerControlMessage({
+				kind: "pty_input_timeout",
+				messageIndex: 3,
+				bytes: 2,
+				error: "x".repeat(300),
+			})
+		);
+
+		expect(message.error).toHaveLength(240);
+		expect(message).not.toHaveProperty("text");
+		expect(message).not.toHaveProperty("data");
 	});
 });
 

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -104,9 +104,11 @@ export class PtySession {
 		let closePty: (() => Promise<void>) | undefined;
 		let closeSandbox: (() => Promise<void>) | undefined;
 		let inputMessageCount = 0;
-		let inputAuditBytes = 0;
-		let inputAuditMessages = 0;
-		let lastInputAudit = Date.now();
+		const inputAuditStats: PtyInputAuditStats = {
+			bytes: 0,
+			messages: 0,
+			lastAudit: Date.now(),
+		};
 
 		try {
 			const pair = new WebSocketPair();
@@ -255,16 +257,7 @@ export class PtySession {
 							data,
 							messageIndex: inputMessageCount,
 							notifyClient: sendControl,
-							stats: {
-								bytes: inputAuditBytes,
-								messages: inputAuditMessages,
-								lastAudit: lastInputAudit,
-							},
-							updateStats: ({ bytes, messages, lastAudit }) => {
-								inputAuditBytes = bytes;
-								inputAuditMessages = messages;
-								lastInputAudit = lastAudit;
-							},
+							stats: inputAuditStats,
 						});
 						return;
 					}
@@ -279,16 +272,7 @@ export class PtySession {
 							data: buf,
 							messageIndex: inputMessageCount,
 							notifyClient: sendControl,
-							stats: {
-								bytes: inputAuditBytes,
-								messages: inputAuditMessages,
-								lastAudit: lastInputAudit,
-							},
-							updateStats: ({ bytes, messages, lastAudit }) => {
-								inputAuditBytes = bytes;
-								inputAuditMessages = messages;
-								lastInputAudit = lastAudit;
-							},
+							stats: inputAuditStats,
 						});
 					} catch (err) {
 						void auditEvent(this.env, claims.session_id, "pty_input_error", {
@@ -428,7 +412,6 @@ async function sendInputWithAudit({
 	messageIndex,
 	notifyClient,
 	stats,
-	updateStats,
 }: {
 	env: Env;
 	sessionId: string;
@@ -444,7 +427,6 @@ async function sendInputWithAudit({
 		error?: string;
 	}) => void;
 	stats: PtyInputAuditStats;
-	updateStats: (stats: PtyInputAuditStats) => void;
 }) {
 	const startedAt = Date.now();
 	const bytes = getInputByteLength({ data });
@@ -478,28 +460,26 @@ async function sendInputWithAudit({
 			bytes,
 			elapsedMs,
 		});
-		const nextStats = {
-			bytes: stats.bytes + bytes,
-			messages: stats.messages + 1,
-			lastAudit: stats.lastAudit,
-		};
+		stats.bytes += bytes;
+		stats.messages += 1;
 		const shouldAudit =
 			messageIndex <= 8 ||
 			Date.now() - stats.lastAudit >= PTY_INPUT_AUDIT_MIN_MS ||
-			nextStats.bytes >= PTY_INPUT_AUDIT_MIN_BYTES;
+			stats.bytes >= PTY_INPUT_AUDIT_MIN_BYTES;
 		if (!shouldAudit) {
-			updateStats(nextStats);
 			return;
 		}
 		void auditEvent(env, sessionId, "pty_input", {
 			provider,
 			payloadType,
 			messageIndex,
-			messages: nextStats.messages,
-			bytes: nextStats.bytes,
+			messages: stats.messages,
+			bytes: stats.bytes,
 			elapsedMs,
 		});
-		updateStats({ bytes: 0, messages: 0, lastAudit: Date.now() });
+		stats.bytes = 0;
+		stats.messages = 0;
+		stats.lastAudit = Date.now();
 	} catch (err) {
 		const elapsedMs = Date.now() - startedAt;
 		const error = err instanceof Error ? err.message : String(err);

--- a/qcut/packages/qcut-relay/src/pty-session.ts
+++ b/qcut/packages/qcut-relay/src/pty-session.ts
@@ -26,6 +26,11 @@ type PtyClientControlMessage = {
 	rows: number;
 };
 
+type PtyServerControlKind =
+	| "pty_input_ack"
+	| "pty_input_error"
+	| "pty_input_timeout";
+
 const PTY_INPUT_TIMEOUT_MS = 5_000;
 const PTY_INPUT_AUDIT_MIN_MS = 2_000;
 const PTY_INPUT_AUDIT_MIN_BYTES = 16;
@@ -117,6 +122,33 @@ export class PtySession {
 					serverRef.send(chunk);
 				} catch {
 					/* socket closed mid-send; ignore */
+				}
+			};
+			const sendControl = ({
+				kind,
+				messageIndex,
+				bytes,
+				elapsedMs,
+				error,
+			}: {
+				kind: PtyServerControlKind;
+				messageIndex: number;
+				bytes: number;
+				elapsedMs?: number;
+				error?: string;
+			}) => {
+				try {
+					serverRef.send(
+						buildPtyServerControlMessage({
+							kind,
+							messageIndex,
+							bytes,
+							elapsedMs,
+							error,
+						})
+					);
+				} catch {
+					/* browser gone; audit already captured the failure */
 				}
 			};
 
@@ -222,6 +254,7 @@ export class PtySession {
 							sendInput,
 							data,
 							messageIndex: inputMessageCount,
+							notifyClient: sendControl,
 							stats: {
 								bytes: inputAuditBytes,
 								messages: inputAuditMessages,
@@ -245,6 +278,7 @@ export class PtySession {
 							sendInput,
 							data: buf,
 							messageIndex: inputMessageCount,
+							notifyClient: sendControl,
 							stats: {
 								bytes: inputAuditBytes,
 								messages: inputAuditMessages,
@@ -361,6 +395,30 @@ type PtyInputAuditStats = {
 	lastAudit: number;
 };
 
+export function buildPtyServerControlMessage({
+	kind,
+	messageIndex,
+	bytes,
+	elapsedMs,
+	error,
+}: {
+	kind: PtyServerControlKind;
+	messageIndex: number;
+	bytes: number;
+	elapsedMs?: number;
+	error?: string;
+}) {
+	return JSON.stringify({
+		kind,
+		messageIndex,
+		bytes,
+		...(typeof elapsedMs === "number" ? { elapsedMs } : {}),
+		...(typeof error === "string" && error.length > 0
+			? { error: error.slice(0, 240) }
+			: {}),
+	});
+}
+
 async function sendInputWithAudit({
 	env,
 	sessionId,
@@ -368,6 +426,7 @@ async function sendInputWithAudit({
 	sendInput,
 	data,
 	messageIndex,
+	notifyClient,
 	stats,
 	updateStats,
 }: {
@@ -377,6 +436,13 @@ async function sendInputWithAudit({
 	sendInput: SendInput | undefined;
 	data: Uint8Array | string;
 	messageIndex: number;
+	notifyClient: (message: {
+		kind: PtyServerControlKind;
+		messageIndex: number;
+		bytes: number;
+		elapsedMs?: number;
+		error?: string;
+	}) => void;
 	stats: PtyInputAuditStats;
 	updateStats: (stats: PtyInputAuditStats) => void;
 }) {
@@ -391,6 +457,12 @@ async function sendInputWithAudit({
 			bytes,
 			error: "missing_send_input",
 		});
+		notifyClient({
+			kind: "pty_input_error",
+			messageIndex,
+			bytes,
+			error: "missing_send_input",
+		});
 		return;
 	}
 	try {
@@ -400,6 +472,12 @@ async function sendInputWithAudit({
 			label: "pty_send_input",
 		});
 		const elapsedMs = Date.now() - startedAt;
+		notifyClient({
+			kind: "pty_input_ack",
+			messageIndex,
+			bytes,
+			elapsedMs,
+		});
 		const nextStats = {
 			bytes: stats.bytes + bytes,
 			messages: stats.messages + 1,
@@ -431,6 +509,13 @@ async function sendInputWithAudit({
 		void auditEvent(env, sessionId, kind, {
 			provider,
 			payloadType,
+			messageIndex,
+			bytes,
+			elapsedMs,
+			error,
+		});
+		notifyClient({
+			kind,
 			messageIndex,
 			bytes,
 			elapsedMs,

--- a/qcut/scripts/agent-chat-e2e.ts
+++ b/qcut/scripts/agent-chat-e2e.ts
@@ -202,6 +202,10 @@ async function readTerminalStatus({ page }: { page: Page }): Promise<string> {
 	).trim();
 }
 
+async function readTerminalDebug({ page }: { page: Page }): Promise<string> {
+	return readText({ page, selector: "#agent-terminal-debug" });
+}
+
 async function runStep({
 	state,
 	name,
@@ -302,6 +306,24 @@ async function waitForCodexReady({
 	);
 }
 
+async function readStoredAgentSessionId({ page }: { page: Page }) {
+	return page.evaluate(
+		() => window.localStorage.getItem("qcut_agent_session_id") || ""
+	);
+}
+
+async function waitForRelayInputAck({ page }: { page: Page }) {
+	await page.waitForFunction(
+		() => {
+			const debugText =
+				document.querySelector("#agent-terminal-debug")?.textContent || "";
+			return /ack #\d+ \d+ bytes/.test(debugText);
+		},
+		null,
+		{ timeout: 15_000 }
+	);
+}
+
 async function resetServerSessionThroughUi({
 	page,
 	timeoutMs,
@@ -359,6 +381,7 @@ async function typePromptIntoTerminal({
 	await page.keyboard.type(prompt, { delay: 1 });
 	await page.waitForTimeout(750);
 	await page.keyboard.press("Enter");
+	await waitForRelayInputAck({ page });
 	if (echoNeedle && echoNeedle.length > 0) {
 		await page.waitForFunction(
 			(needle) => {
@@ -622,14 +645,58 @@ async function main() {
 					namePrefix: imageNamePrefix,
 					timeoutMs: config.artifactTimeoutMs,
 				});
-				return `marker=${artifactFilename}; image=${imageFilename}`;
+				const debugText = await readTerminalDebug({ page });
+				assertCondition({
+					condition: /ack #\d+ \d+ bytes/.test(debugText),
+					message: `expected relay ack after image prompt, got ${debugText}`,
+				});
+				assertCondition({
+					condition: !debugText.includes("no relay ack"),
+					message: `unexpected stale ack warning after image prompt: ${debugText}`,
+				});
+				return `marker=${artifactFilename}; image=${imageFilename}; debug=${debugText}`;
+			},
+		});
+
+		const secondArtifactFilename = `terminal-second-input-e2e-${runId}.txt`;
+		const secondArtifactText = `second input ok ${runId}`;
+		await runStep({
+			state,
+			name: "second terminal input works after image generation",
+			screenshotName: "06-second-input-after-image",
+			action: async () => {
+				await typePromptIntoTerminal({
+					page,
+					prompt: `This is the second input after image generation. Write "${secondArtifactText}" into /tmp/qcut-output/${secondArtifactFilename}, then reply SECOND_INPUT_DONE_${runId}.`,
+					echoNeedle: secondArtifactFilename,
+				});
+				await waitForArtifact({
+					page,
+					filename: secondArtifactFilename,
+					timeoutMs: config.promptTimeoutMs,
+				});
+				const fetchedText = await fetchArtifactTextFromPage({
+					page,
+					filename: secondArtifactFilename,
+					licenseServerUrl: config.licenseServerUrl,
+				});
+				assertCondition({
+					condition: fetchedText.trim() === secondArtifactText,
+					message: `second input artifact mismatch: ${fetchedText.trim()}`,
+				});
+				const debugText = await readTerminalDebug({ page });
+				assertCondition({
+					condition: !debugText.includes("no relay ack"),
+					message: `unexpected stale ack warning after second input: ${debugText}`,
+				});
+				return `second=${secondArtifactFilename}; debug=${debugText}`;
 			},
 		});
 
 		await runStep({
 			state,
 			name: "terminal-generated image artifacts download from the web UI",
-			screenshotName: "06-artifact-download",
+			screenshotName: "07-artifact-download",
 			action: async () => {
 				const downloadedMarkerPath = await downloadArtifactWithButton({
 					page,
@@ -656,8 +723,64 @@ async function main() {
 
 		await runStep({
 			state,
+			name: "reconnect opens Codex again",
+			screenshotName: "08-reconnect-codex-ready",
+			action: async () => {
+				const beforeSessionId = await readStoredAgentSessionId({ page });
+				await page.locator("#agent-terminal-reconnect").click();
+				await waitForCodexReady({
+					page,
+					timeoutMs: config.connectTimeoutMs,
+				});
+				const afterSessionId = await readStoredAgentSessionId({ page });
+				assertCondition({
+					condition:
+						beforeSessionId.length > 0 && beforeSessionId === afterSessionId,
+					message: `reconnect changed session ${beforeSessionId} -> ${afterSessionId}`,
+				});
+				return `sameSession=${afterSessionId}`;
+			},
+		});
+
+		const reconnectArtifactFilename = `terminal-reconnect-e2e-${runId}.txt`;
+		const reconnectArtifactText = `reconnect input ok ${runId}`;
+		await runStep({
+			state,
+			name: "input works after explicit reconnect",
+			screenshotName: "09-input-after-reconnect",
+			action: async () => {
+				await typePromptIntoTerminal({
+					page,
+					prompt: `After explicit Reconnect, write "${reconnectArtifactText}" into /tmp/qcut-output/${reconnectArtifactFilename}, then reply RECONNECT_INPUT_DONE_${runId}.`,
+					echoNeedle: reconnectArtifactFilename,
+				});
+				await waitForArtifact({
+					page,
+					filename: reconnectArtifactFilename,
+					timeoutMs: config.promptTimeoutMs,
+				});
+				const fetchedText = await fetchArtifactTextFromPage({
+					page,
+					filename: reconnectArtifactFilename,
+					licenseServerUrl: config.licenseServerUrl,
+				});
+				assertCondition({
+					condition: fetchedText.trim() === reconnectArtifactText,
+					message: `reconnect artifact mismatch: ${fetchedText.trim()}`,
+				});
+				const debugText = await readTerminalDebug({ page });
+				assertCondition({
+					condition: !debugText.includes("no relay ack"),
+					message: `unexpected stale ack warning after reconnect input: ${debugText}`,
+				});
+				return `reconnect=${reconnectArtifactFilename}; debug=${debugText}`;
+			},
+		});
+
+		await runStep({
+			state,
 			name: "disconnect clears terminal state",
-			screenshotName: "07-disconnected-clean",
+			screenshotName: "10-disconnected-clean",
 			action: async () => {
 				await disconnectTerminal({ page });
 				await page.waitForTimeout(300);
@@ -676,20 +799,6 @@ async function main() {
 					message: "disconnect left stale Codex text in the terminal",
 				});
 				return "terminal reset";
-			},
-		});
-
-		await runStep({
-			state,
-			name: "reconnect opens Codex again",
-			screenshotName: "08-reconnect-codex-ready",
-			action: async () => {
-				await page.locator("#agent-terminal-connect").click();
-				await waitForCodexReady({
-					page,
-					timeoutMs: config.connectTimeoutMs,
-				});
-				return "Codex ready after reconnect";
 			},
 		});
 	} catch (error) {


### PR DESCRIPTION
## Summary
- add visible Chat Agent terminal debug state with input send/relay ack/output status
- add explicit same-session Reconnect recovery for stale terminal attachments
- add relay-side input ack/error/timeout control messages plus audit metadata without logging raw terminal input
- fix stale session fallback after reset and reset ack counters on reconnect
- strengthen production E2E to cover real image generation, second input after image generation, explicit Reconnect, and post-Reconnect input
- update stale Vimax test calls to match the object-parameter `buildImageField` API so CI covers the branch cleanly

## Verification
- node --test packages/nexusai-website/js/agent-chat.prompt.test.js
- cd packages/qcut-relay && bun run test
- bun test electron/__tests__/vimax-video-adapter.test.ts
- bunx biome check packages/nexusai-website/js/agent-chat/03-terminal-job.js packages/nexusai-website/js/agent-chat/04-bootstrap.js packages/nexusai-website/js/agent-chat.prompt.test.js packages/qcut-relay/src/pty-session.ts packages/qcut-relay/src/pty-session.test.ts scripts/agent-chat-e2e.ts electron/__tests__/vimax-video-adapter.test.ts --max-diagnostics=120
- deployed relay: qcut-relay version 6e430112-10fe-48bc-a00c-b52b97666f9e
- deployed website: donghaozhang/nexusai-website@25a21d5 via GitHub Pages run 26437358937
- production E2E passed: output/playwright/agent-chat-e2e-2026-05-26T07-00-24-883Z/result.json

## Production E2E Highlights
- direct terminal qcut image generation creates artifacts: passed in 112895ms
- second terminal input works after image generation: passed in 5748ms
- explicit Reconnect opened Codex again on the same session id: passed in 3683ms
- input works after explicit Reconnect: passed in 10883ms
- debug ack examples matched input/ack ids: #465/#465, #663/#663, #186/#186
- final result contained no `no relay ack` stale-input warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit Reconnect button to restore terminal connection while preserving session state
  * Implemented relay acknowledgment messaging for improved input operation visibility

* **Bug Fixes**
  * Fixed terminal input reliability with stale-input detection and 7-second timeout watchdog
  * Resolved concurrent input race conditions in relay
  * Terminal session now properly persists across reconnections

* **Tests**
  * Production E2E validation confirms input recovery, reconnect behavior, and session persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Quriosity-agent/qcut/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->