### PR TITLE
Fix IMA Router Ref2V reference images

### DIFF
--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/build-deploy-online-e2e-result.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/build-deploy-online-e2e-result.md
@@ -1,0 +1,279 @@
+# Build, Deploy, And Online E2E Result
+
+Date: 2026-05-26
+
+## Branch And Commit
+
+Branch:
+
+```text
+cli-image-v12
+```
+
+Commit used for the published CLI image:
+
+```text
+34378acb9 Fix IMA Router ref2v reference images
+```
+
+## CLI Image
+
+Local build and smoke passed:
+
+```bash
+QCUT_VERSION=cli-image-v12-ref2v-20260526205824 bun run build:cli-image
+```
+
+Published image:
+
+```text
+ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824
+```
+
+GitHub Actions publish run:
+
+```text
+https://github.com/Quriosity-agent/qcut/actions/runs/26475075951
+```
+
+Result:
+
+```text
+build-and-push passed in 11m37s
+Smoke test pushed image passed
+```
+
+Manifest verification:
+
+```text
+linux/amd64 digest sha256:17bdbcc636a9ad8d49514c3b9b782b9adbf9ae9260a95cafc15237a9c1d23c87
+```
+
+Note: direct local `docker push` to GHCR failed because the local Docker/GitHub token did not have the required package-write scope, so the existing repo workflow was used.
+
+## Deploys
+
+Relay deploy:
+
+```bash
+bun run deploy
+```
+
+Package:
+
+```text
+packages/qcut-relay
+```
+
+Result:
+
+```text
+https://qcut-relay.zdhpeter.workers.dev
+Version ID: acf68421-181f-40d6-a023-8f8be78dedce
+```
+
+License server deploy:
+
+```bash
+bun run deploy
+```
+
+Package:
+
+```text
+packages/license-server
+```
+
+Reason: online Daytona agents read `QCUT_IMAGE_TAG` from the license server, so the license server had to be deployed after changing the tag.
+
+Result:
+
+```text
+https://qcut-license-server.zdhpeter.workers.dev
+Version ID: d57a6ddb-4fe0-49a9-bd28-c8cf2a6249ff
+QCUT_IMAGE_TAG = ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824
+```
+
+## Online Sandbox Chat-Agent E2E
+
+Harness:
+
+```bash
+bun scripts/agent-chat-imarouter-ref2v-e2e.ts --generation-timeout-ms 2400000
+```
+
+Production chat-agent URL:
+
+```text
+https://quriosity.com.au/chat-agent.html
+```
+
+Session:
+
+```text
+5b9013c2-0930-42ea-8724-ace7d24b8f0a
+```
+
+Sandbox output root:
+
+```text
+/tmp/qcut-output/imarouter-ref2v-e2e-1779830523126
+```
+
+Local evidence directory:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/agent-chat-imarouter-ref2v-e2e-2026-05-26T21-22-03-126Z
+```
+
+Result:
+
+```text
+status=passed
+REF2V_READY
+downloaded evidence files=8
+```
+
+Generated video:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/agent-chat-imarouter-ref2v-e2e-2026-05-26T21-22-03-126Z/imarouter_seedance_2_0_ref2v_5-second-video-using-the-reference-image-clean-product_1779830655171.mp4
+```
+
+Observed media:
+
+```text
+1280x720, h264, 24 fps, 5.041667 s, 1.4 MB
+```
+
+IMA sidecar:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/agent-chat-imarouter-ref2v-e2e-2026-05-26T21-22-03-126Z/imarouter_seedance_2_0_ref2v_5-second-video-using-the-reference-image-clean-product_1779830655171.json
+```
+
+Sidecar confirms:
+
+```text
+model=imarouter_seedance_2_0_ref2v
+endpoint=v1/videos
+cost=0.3
+duration_seconds=94.615
+inputs.reference_images contains the submitted public reference image URL
+params.image_urls contains the staged reference image URL
+```
+
+The sandbox env check confirmed an IMA Router key was present, without recording the key value:
+
+```text
+HAS_IMAROUTER_API_KEY=yes
+IMAROUTER_API_KEY_LENGTH=51
+QCut_VERSION=1.0.0
+Codex_VERSION=codex-cli 0.130.0
+```
+
+The command log included:
+
+```text
+Proxy call failed for imarouter (API error 401); falling back to local IMAROUTER_KEY
+status=ok
+command=create-video
+cost=0.3
+duration_ms=94617
+```
+
+## Verification Commands
+
+Focused tests:
+
+```bash
+bunx vitest run electron/native-pipeline/execution/__tests__/step-executors-imarouter-ref2v.test.ts electron/native-pipeline/cli/cli-runner/__tests__/handler-generate-duration.test.ts
+```
+
+Result:
+
+```text
+2 files passed, 10 tests passed
+```
+
+Relay tests:
+
+```bash
+bun --cwd packages/qcut-relay test
+```
+
+Result:
+
+```text
+2 files passed, 21 tests passed
+```
+
+License server tests:
+
+```bash
+bun --cwd packages/license-server test
+```
+
+Result:
+
+```text
+16 files passed, 132 tests passed
+```
+
+TypeScript:
+
+```bash
+bun x tsc --noEmit
+```
+
+Run from:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/electron
+```
+
+Result:
+
+```text
+passed
+```
+
+Biome:
+
+```bash
+bunx biome check electron/native-pipeline/execution/step-executors.ts electron/native-pipeline/cli/cli-runner/handler-generate.ts electron/native-pipeline/execution/__tests__/step-executors-imarouter-ref2v.test.ts electron/native-pipeline/cli/cli-runner/__tests__/handler-generate-duration.test.ts packages/license-server/wrangler.toml docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-env.md docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-smoke-result.md
+```
+
+Result:
+
+```text
+passed
+```
+
+E2E harness check:
+
+```bash
+bunx biome check --write scripts/agent-chat-imarouter-ref2v-e2e.ts
+bun scripts/agent-chat-imarouter-ref2v-e2e.ts --help
+```
+
+Result:
+
+```text
+passed
+```
+
+## Failure And Fix During E2E
+
+The first online E2E connected to the deployed image but failed because the natural-language prompt asked Codex to make its own preflight decision, and Codex wrote `preflight-failed.txt` even though the downloaded `models.json` did include:
+
+```text
+imarouter_seedance_2_0_ref2v
+imarouter_seedance_2_0_cn_ref2v
+```
+
+The harness prompt was tightened to ask Codex to run an exact shell script. The rerun passed.
+
+## Remaining Local-File Gap
+
+The online E2E used a public HTTPS reference image because the available sandbox/local secrets include `IMAROUTER_API_KEY` but not a valid `FAL_KEY`. The local-file path is implemented and unit-covered, but the exact chain `local file -> FAL storage URL -> IMA asset -> asset:// -> IMA video` still requires a valid FAL key or another public staging backend.

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
@@ -23,7 +23,7 @@ The upload path was fixed by refreshing `QCUT_AUTH_TOKEN` for the default agent 
 Current unauthenticated online agent session resolves to default user:
 
 ```text
-userId=79bf60b02770d2cc510da53e471590f4
+userId=<redacted-default-user-id>
 imageTag=ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824
 ```
 
@@ -54,7 +54,7 @@ FAL_API_KEY
 Direct Daytona sandbox environment check:
 
 ```text
-sandboxId=daa84f1c-9989-4dc9-a86a-e0d7f44c4d59
+sandboxId=<redacted-sandbox-id>
 state=started
 HAS_FAL_KEY=no
 FAL_KEY_LENGTH=0
@@ -71,7 +71,7 @@ This confirms the running sandbox itself has the IMA Router key but does not hav
 A fresh QCut session token was inserted into `sessions` for:
 
 ```text
-user_id=79bf60b02770d2cc510da53e471590f4
+user_id=<redacted-default-user-id>
 ```
 
 Then `agent_secrets.QCUT_AUTH_TOKEN` for that user was updated to the new token value.
@@ -195,7 +195,7 @@ Observed media:
 The complete online local-file E2E now passes through the QCut proxy. If we also want direct BYOK FAL fallback inside the sandbox, add a valid FAL upload secret for the default agent user:
 
 ```text
-user_id=79bf60b02770d2cc510da53e471590f4
+user_id=<redacted-default-user-id>
 key=FAL_KEY
 value=<valid fal key>
 ```

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
@@ -14,7 +14,9 @@ local reference image -> FAL storage URL -> IMA /v1/assets/create -> asset://...
 
 ## Result
 
-No. The online sandbox/default agent user does not currently have a `FAL_KEY` or `FAL_API_KEY` secret in `agent_secrets`.
+The online sandbox/default agent user does not have a direct `FAL_KEY` or `FAL_API_KEY` secret in `agent_secrets`.
+
+The upload path was fixed by refreshing `QCUT_AUTH_TOKEN` for the default agent user. With a valid QCut session token, the sandbox can call the license-server `/api/ai/upload-url` proxy, and that worker uses its configured `FAL_API_KEY` secret to vend FAL upload URLs.
 
 ## Evidence
 
@@ -64,6 +66,26 @@ IMAROUTER_API_KEY_LENGTH=52
 
 This confirms the running sandbox itself has the IMA Router key but does not have either FAL upload secret.
 
+## Fix Applied
+
+A fresh QCut session token was inserted into `sessions` for:
+
+```text
+user_id=79bf60b02770d2cc510da53e471590f4
+```
+
+Then `agent_secrets.QCUT_AUTH_TOKEN` for that user was updated to the new token value.
+
+Safe proxy check with that token:
+
+```text
+POST /api/ai/upload-url
+status=200
+response keys=fileUrl,uploadUrl
+```
+
+No FAL secret value was copied into this document.
+
 ## Local Smoke With Local File
 
 Command shape:
@@ -109,9 +131,68 @@ Unit coverage:
 electron/native-pipeline/infra/__tests__/api-caller-fal-upload.test.ts
 ```
 
-## What Is Needed
+## Online Local-File E2E After Fix
 
-To run the complete online local-file E2E, add a valid FAL upload secret for the default agent user:
+Harness:
+
+```bash
+bun scripts/agent-chat-imarouter-ref2v-e2e.ts --local-reference-file --generation-timeout-ms 2400000
+```
+
+Result:
+
+```text
+status=passed
+session=029265bb-927c-4e6e-a844-d9d0bfa1b83f
+root=/tmp/qcut-output/imarouter-ref2v-e2e-1779834324797
+```
+
+Local evidence directory:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/agent-chat-imarouter-ref2v-e2e-2026-05-26T22-25-24-797Z
+```
+
+The E2E downloaded the public reference URL to a sandbox-local file and passed that local path to the CLI:
+
+```text
+referenceInput=/tmp/qcut-output/imarouter-ref2v-e2e-1779834324797/reference.png
+```
+
+The generated sidecar confirms local-file input reached QCut:
+
+```text
+inputs.reference_images=[
+  "/tmp/qcut-output/imarouter-ref2v-e2e-1779834324797/reference.png"
+]
+params.image_urls=[
+  "/tmp/qcut-output/imarouter-ref2v-e2e-1779834324797/reference.png"
+]
+model=imarouter_seedance_2_0_ref2v
+endpoint=v1/videos
+```
+
+Generated video:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/output/playwright/agent-chat-imarouter-ref2v-e2e-2026-05-26T22-25-24-797Z/imarouter_seedance_2_0_ref2v_5-second-video-using-the-reference-image-clean-product_1779834541195.mp4
+```
+
+Convenience copy:
+
+```text
+/Users/peter/Desktop/code/qcut/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/evidence/imarouter-ref2v-local-file-online-e2e.mp4
+```
+
+Observed media:
+
+```text
+1280x720, h264, 24 fps, 5.041667 s, 1.8 MB
+```
+
+## What Would Be Needed For Direct BYOK FAL
+
+The complete online local-file E2E now passes through the QCut proxy. If we also want direct BYOK FAL fallback inside the sandbox, add a valid FAL upload secret for the default agent user:
 
 ```text
 user_id=79bf60b02770d2cc510da53e471590f4
@@ -125,4 +206,4 @@ or:
 key=FAL_API_KEY
 ```
 
-After that, rebuild/publish the CLI image from the PR head, deploy the license server with that image tag, and rerun the local-file Ref2V E2E.
+After that, rebuild/publish the CLI image from the PR head, deploy the license server with that image tag, and rerun the local-file Ref2V E2E to verify the fallback path too.

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
@@ -1,0 +1,113 @@
+# FAL Secret Check
+
+Date: 2026-05-26
+
+## Question
+
+Can the full local-file reference image pipeline run in the online Daytona sandbox?
+
+Required chain:
+
+```text
+local reference image -> FAL storage URL -> IMA /v1/assets/create -> asset://... -> IMA /v1/videos
+```
+
+## Result
+
+No. The online sandbox/default agent user does not currently have a `FAL_KEY` or `FAL_API_KEY` secret in `agent_secrets`.
+
+## Evidence
+
+Current unauthenticated online agent session resolves to default user:
+
+```text
+userId=79bf60b02770d2cc510da53e471590f4
+imageTag=ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824
+```
+
+Supabase `agent_secrets` keys for that user:
+
+```text
+CODEX_AUTH_JSON
+GEMINI_API_KEY
+GMI_API_KEY
+IMAROUTER_API_KEY
+OPENROUTER_API_KEY
+QCUT_AUTH_TOKEN
+```
+
+Targeted query for FAL secrets:
+
+```text
+[]
+```
+
+So the sandbox injection source has no:
+
+```text
+FAL_KEY
+FAL_API_KEY
+```
+
+## Local Smoke With Local File
+
+Command shape:
+
+```bash
+QCUT_OUTPUT_DIR=/tmp/qcut-output-fal-secret-check bun run qcut gen video \
+  -m imarouter_seedance_2_0_ref2v \
+  --reference-images /Users/peter/Desktop/code/qcut/qcut/output/gmi-five-image-smoke/gpt_image_2_gmi_a-yellow-toy-submarine-product-photo-on-white-background_1779155348312_3.png \
+  -t "5 second video using the local reference image" \
+  -d 5s \
+  --aspect-ratio 16:9 \
+  --resolution 720p \
+  --json
+```
+
+Observed result:
+
+```text
+Proxy upload URL failed: Upload URL request failed (401): Invalid token
+falling back to local FAL_KEY
+FAL upload initiate failed: 401
+```
+
+This proves the fallback code path runs, but the local `FAL_KEY` value currently available on this machine is also rejected by FAL.
+
+## Code Change In PR
+
+PR #312 now includes fallback logic:
+
+```text
+proxy upload URL -> if it fails and FAL_KEY/FAL_API_KEY exists -> direct FAL storage initiate
+```
+
+Commit:
+
+```text
+6ad904b71 Fallback to local FAL key for uploads
+```
+
+Unit coverage:
+
+```text
+electron/native-pipeline/infra/__tests__/api-caller-fal-upload.test.ts
+```
+
+## What Is Needed
+
+To run the complete online local-file E2E, add a valid FAL upload secret for the default agent user:
+
+```text
+user_id=79bf60b02770d2cc510da53e471590f4
+key=FAL_KEY
+value=<valid fal key>
+```
+
+or:
+
+```text
+key=FAL_API_KEY
+```
+
+After that, rebuild/publish the CLI image from the PR head, deploy the license server with that image tag, and rerun the local-file Ref2V E2E.

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/fal-secret-check.md
@@ -49,6 +49,21 @@ FAL_KEY
 FAL_API_KEY
 ```
 
+Direct Daytona sandbox environment check:
+
+```text
+sandboxId=daa84f1c-9989-4dc9-a86a-e0d7f44c4d59
+state=started
+HAS_FAL_KEY=no
+FAL_KEY_LENGTH=0
+HAS_FAL_API_KEY=no
+FAL_API_KEY_LENGTH=0
+HAS_IMAROUTER_API_KEY=yes
+IMAROUTER_API_KEY_LENGTH=52
+```
+
+This confirms the running sandbox itself has the IMA Router key but does not have either FAL upload secret.
+
 ## Local Smoke With Local File
 
 Command shape:

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-env.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-env.md
@@ -1,0 +1,27 @@
+# Local IMA Router Env
+
+Local key file:
+
+```text
+/Users/peter/.qcut/.env
+```
+
+Stored key:
+
+```text
+IMAROUTER_API_KEY
+```
+
+Notes:
+
+- The key value is intentionally not recorded in this document.
+- The file permission is `0600`.
+- The value was pulled from Supabase project `kbrtxitvavpuimuihppz`, table `public.agent_secrets`, where `key = 'IMAROUTER_API_KEY'`.
+- QCut CLI resolves this file through the normal local env-file tier.
+
+Safe verification:
+
+```bash
+grep -c '^IMAROUTER_API_KEY=' /Users/peter/.qcut/.env
+stat -f '%Sp %N' /Users/peter/.qcut/.env
+```

--- a/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-smoke-result.md
+++ b/qcut/docs/task/daytona-supabase-agent/fix-imarouter-reference-images/local-smoke-result.md
@@ -1,0 +1,55 @@
+# Local Smoke Result
+
+Date: 2026-05-26
+
+## Result
+
+IMA Router Ref2V `--reference-images` smoke passed with a public HTTPS reference URL.
+
+Output:
+
+```text
+/tmp/qcut-output/imarouter_seedance_2_0_ref2v_5-second-video-using-the-reference-image_1779828346048.mp4
+```
+
+Sidecar:
+
+```text
+/tmp/qcut-output/imarouter_seedance_2_0_ref2v_5-second-video-using-the-reference-image_1779828346048.json
+```
+
+Observed output media:
+
+```text
+1280x720, 24 fps, 5.041667 s, 3.1 MB
+```
+
+CLI result:
+
+```text
+status=ok
+model=imarouter_seedance_2_0_ref2v
+endpoint=v1/videos
+cost=0.3
+duration=135.615s
+```
+
+## Local File Attempt
+
+The exact local-file command reached the local upload step but failed before IMA Router:
+
+```text
+FAL upload error: Upload URL request failed (401): Invalid token
+```
+
+Supabase `agent_secrets` currently has `IMAROUTER_API_KEY` but no `FAL_KEY`, so the full local-file path cannot be proven until a valid FAL key is available or local IMA references use a different public staging backend.
+
+## What This Proves
+
+- The CLI now stages IMA Ref2V `--reference-images`.
+- The executor accepts `image_urls` for IMA Ref2V and submits a successful IMA Router `v1/videos` job.
+- The generated video downloaded successfully to the local output directory.
+
+## Remaining Gap
+
+The full chain `local file -> FAL storage URL -> IMA asset -> asset:// -> IMA video` is still blocked by the invalid/missing FAL key.

--- a/qcut/electron/native-pipeline/cli/cli-runner/__tests__/handler-generate-duration.test.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/__tests__/handler-generate-duration.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../execution/executor.js";
 import type { StepInput } from "../../../execution/step-executors.js";
 import { ModelRegistry } from "../../../infra/registry.js";
+import { registerImageToVideoModels } from "../../../registry-data/image-to-video.js";
 import { registerTextToVideoModels } from "../../../registry-data/text-to-video.js";
 import {
 	getDefaultModelForCommand,
@@ -62,6 +63,9 @@ describe("create-video duration validation", () => {
 	beforeAll(() => {
 		if (!ModelRegistry.has("imarouter_seedance_2_0_fast_t2v")) {
 			registerTextToVideoModels();
+		}
+		if (!ModelRegistry.has("imarouter_seedance_2_0_ref2v")) {
+			registerImageToVideoModels();
 		}
 	});
 
@@ -122,6 +126,30 @@ describe("create-video duration validation", () => {
 				duration: "5s",
 			})
 		).toBeUndefined();
+	});
+
+	it("stages IMA Router Ref2V reference images for executor upload", async () => {
+		const executor = new CapturingExecutor();
+
+		const result = await handleGenerate(
+			{
+				...buildVideoOptions({
+					model: "imarouter_seedance_2_0_ref2v",
+				}),
+				referenceImages: ["/tmp/a.png", "/tmp/b.png"],
+			},
+			ignoreProgress,
+			executor,
+			new AbortController().signal
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("executor reached");
+		expect(executor.steps).toHaveLength(1);
+		expect(executor.steps[0].params.image_urls).toEqual([
+			"/tmp/a.png",
+			"/tmp/b.png",
+		]);
 	});
 });
 

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-generate.ts
@@ -530,8 +530,9 @@ export async function handleGenerate(
 		}
 	}
 
-	// Happy Horse models reuse --reference-images / --audio-setting:
+	// Ref2V models reuse --reference-images / --audio-setting:
 	// - happy_horse_ref2v: 1–9 images become payload `image_urls`
+	// - imarouter_*_ref2v: 1–14 images become IMA Router `images`
 	// - happy_horse_video_edit: ≤5 images become payload `reference_image_urls`
 	// Field-name mapping happens inside step-executors per-model branches;
 	// the CLI just stages the array under a stable key the executor reads.
@@ -539,6 +540,11 @@ export async function handleGenerate(
 		if (options.referenceImages && options.referenceImages.length > 0) {
 			if (options.model === "happy_horse_ref2v") {
 				params.image_urls = options.referenceImages.slice(0, 9);
+			} else if (
+				options.model === "imarouter_seedance_2_0_ref2v" ||
+				options.model === "imarouter_seedance_2_0_cn_ref2v"
+			) {
+				params.image_urls = options.referenceImages.slice(0, 14);
 			} else if (options.model === "happy_horse_video_edit") {
 				params.reference_image_urls = options.referenceImages.slice(0, 5);
 			}

--- a/qcut/electron/native-pipeline/execution/__tests__/step-executors-imarouter-ref2v.test.ts
+++ b/qcut/electron/native-pipeline/execution/__tests__/step-executors-imarouter-ref2v.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infra/api-caller.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../infra/api-caller.js")
+	>("../../infra/api-caller.js");
+	return {
+		...actual,
+		callModelApi: vi.fn(),
+		downloadOutput: vi.fn(async (_url: string, dest: string) => dest),
+		envApiKeyProvider: vi.fn(async () => "ima-key"),
+		uploadToFalStorage: vi.fn(),
+	};
+});
+
+vi.mock("../../infra/imarouter-assets.js", () => ({
+	channelFor: vi.fn((modelKey: string) =>
+		modelKey.includes("_cn")
+			? {
+					region: "cn",
+					uploadModel: "ima-pro-upload-cn",
+					groupIdKey: "groupIdCn",
+				}
+			: {
+					region: "overseas",
+					uploadModel: "seedance-upload",
+					groupIdKey: "groupIdOverseas",
+				}
+	),
+	ensureGroup: vi.fn(async () => "group-1"),
+	uploadAsset: vi.fn(async (url: string) => {
+		if (url.includes("fal.storage/local-a.png")) return "asset://local-a";
+		if (url.includes("remote.png")) return "asset://remote";
+		if (url.includes("lead.png")) return "asset://lead";
+		return "asset://unknown";
+	}),
+}));
+
+import {
+	callModelApi,
+	envApiKeyProvider,
+	uploadToFalStorage,
+} from "../../infra/api-caller.js";
+import {
+	channelFor,
+	ensureGroup,
+	uploadAsset,
+} from "../../infra/imarouter-assets.js";
+import { ModelRegistry } from "../../infra/registry.js";
+import { registerImageToVideoModels } from "../../registry-data/image-to-video.js";
+import { executeStep } from "../step-executors.js";
+
+const mockedCallModelApi = vi.mocked(callModelApi);
+const mockedEnvApiKeyProvider = vi.mocked(envApiKeyProvider);
+const mockedUploadToFalStorage = vi.mocked(uploadToFalStorage);
+const mockedChannelFor = vi.mocked(channelFor);
+const mockedEnsureGroup = vi.mocked(ensureGroup);
+const mockedUploadAsset = vi.mocked(uploadAsset);
+
+beforeEach(() => {
+	if (!ModelRegistry.has("imarouter_seedance_2_0_ref2v")) {
+		registerImageToVideoModels();
+	}
+	vi.clearAllMocks();
+	mockedCallModelApi.mockResolvedValue({
+		success: true,
+		outputUrl: "https://video.imarouter.example/out.mp4",
+		duration: 1,
+		data: {},
+	});
+	mockedEnvApiKeyProvider.mockResolvedValue("ima-key");
+	mockedUploadToFalStorage.mockResolvedValue({
+		success: true,
+		url: "https://fal.storage/local-a.png",
+		duration: 0,
+	});
+});
+
+describe("executeImageToVideo — IMA Router Ref2V references", () => {
+	it("uploads CLI reference-images and submits them as top-level images", async () => {
+		const model = ModelRegistry.get("imarouter_seedance_2_0_ref2v");
+
+		await executeStep(
+			model,
+			{ text: "make a short product video" },
+			{
+				duration: 5,
+				aspect_ratio: "16:9",
+				resolution: "720p",
+				image_urls: [
+					"/tmp/local-a.png",
+					"https://example.com/remote.png",
+					"asset://already-approved",
+				],
+			},
+			{}
+		);
+
+		expect(mockedUploadToFalStorage).toHaveBeenCalledWith("/tmp/local-a.png");
+		expect(mockedUploadAsset).toHaveBeenCalledTimes(2);
+		expect(mockedUploadAsset.mock.calls[0][0]).toBe(
+			"https://fal.storage/local-a.png"
+		);
+		expect(mockedUploadAsset.mock.calls[1][0]).toBe(
+			"https://example.com/remote.png"
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.provider).toBe("imarouter");
+		expect(call.endpoint).toBe("v1/videos");
+		expect(call.payload.images).toEqual([
+			"asset://local-a",
+			"asset://remote",
+			"asset://already-approved",
+		]);
+		expect(call.payload).not.toHaveProperty("image_urls");
+		expect(call.payload.metadata).toMatchObject({
+			audio: false,
+			aspect_ratio: "16:9",
+			resolution: "720p",
+			role_mode: "reference",
+		});
+	});
+
+	it("merges --image-url with --reference-images for IMA Router Ref2V", async () => {
+		const model = ModelRegistry.get("imarouter_seedance_2_0_ref2v");
+
+		await executeStep(
+			model,
+			{
+				text: "use all supplied material",
+				imageUrl: "https://example.com/lead.png",
+			},
+			{
+				image_urls: ["asset://already-approved"],
+			},
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.payload.images).toEqual([
+			"asset://lead",
+			"asset://already-approved",
+		]);
+		expect(call.payload).not.toHaveProperty("image_url");
+		expect(call.payload).not.toHaveProperty("image_urls");
+	});
+
+	it("passes asset references through without requiring an API key", async () => {
+		mockedEnvApiKeyProvider.mockResolvedValue(undefined);
+		const model = ModelRegistry.get("imarouter_seedance_2_0_cn_ref2v");
+
+		await executeStep(
+			model,
+			{ text: "use approved assets" },
+			{
+				image_urls: ["asset://cn-a", "asset://cn-b"],
+			},
+			{}
+		);
+
+		const call = mockedCallModelApi.mock.calls[0][0];
+		expect(call.payload.images).toEqual(["asset://cn-a", "asset://cn-b"]);
+		expect(mockedEnsureGroup).not.toHaveBeenCalled();
+		expect(mockedUploadAsset).not.toHaveBeenCalled();
+	});
+
+	it("uses the CN upload channel for CN Ref2V references", async () => {
+		const model = ModelRegistry.get("imarouter_seedance_2_0_cn_ref2v");
+
+		await executeStep(
+			model,
+			{ text: "use cn material" },
+			{
+				image_urls: ["https://example.com/remote.png"],
+			},
+			{}
+		);
+
+		expect(mockedChannelFor).toHaveBeenCalledWith(
+			"imarouter_seedance_2_0_cn_ref2v"
+		);
+		expect(mockedEnsureGroup.mock.calls[0][0]).toMatchObject({
+			region: "cn",
+			uploadModel: "ima-pro-upload-cn",
+		});
+	});
+});

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -107,6 +107,10 @@ function isRemoteUrl(url: string): boolean {
 	return /^https?:\/\//i.test(url);
 }
 
+function isImaRouterAssetUrl({ url }: { url: string }): boolean {
+	return /^asset:\/\//i.test(url);
+}
+
 function getMediaMimeType({ input }: { input: string }): string {
 	switch (path.extname(input).toLowerCase()) {
 		case ".mov":
@@ -126,6 +130,17 @@ function getMediaMimeType({ input }: { input: string }): string {
 		default:
 			return "video/mp4";
 	}
+}
+
+function asRecord({
+	value,
+}: {
+	value: unknown;
+}): Record<string, unknown> | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	return value as Record<string, unknown>;
 }
 
 function toOpenRouterMediaUrl({ input }: { input: string }): string {
@@ -157,6 +172,10 @@ function collectReferenceImages({
 
 type ReferenceImageResolution =
 	| { success: true; url: string }
+	| { success: false; error: string };
+
+type ReferenceImagesResolution =
+	| { success: true; urls: string[] }
 	| { success: false; error: string };
 
 async function resolveReferenceImages({
@@ -207,6 +226,108 @@ async function resolveReferenceImages({
 	};
 }
 
+async function resolveImaRouterUploadSource({
+	entry,
+	options,
+}: {
+	entry: string;
+	options: {
+		onProgress?: (p: number, m: string) => void;
+		signal?: AbortSignal;
+	};
+}): Promise<ReferenceImageResolution> {
+	if (isImaRouterAssetUrl({ url: entry }) || isRemoteUrl(entry)) {
+		return { success: true, url: entry };
+	}
+	if (options.signal?.aborted) {
+		return {
+			success: false,
+			error: "Step cancelled before reference image upload",
+		};
+	}
+	options.onProgress?.(8, "Uploading reference image...");
+	const upload = await uploadToFalStorage(entry);
+	if (!upload.success || !upload.url) {
+		return {
+			success: false,
+			error: upload.error || `Failed to upload reference image: ${entry}`,
+		};
+	}
+	return { success: true, url: upload.url };
+}
+
+async function resolveImaRouterReferenceImages({
+	entries,
+	modelKey,
+	options,
+}: {
+	entries: string[];
+	modelKey: string;
+	options: {
+		onProgress?: (p: number, m: string) => void;
+		signal?: AbortSignal;
+	};
+}): Promise<ReferenceImagesResolution> {
+	const raw = entries
+		.filter((entry) => typeof entry === "string" && entry.trim())
+		.slice(0, 14);
+	if (raw.length === 0) return { success: true, urls: [] };
+	if (raw.every((entry) => isImaRouterAssetUrl({ url: entry }))) {
+		return { success: true, urls: raw };
+	}
+
+	const { channelFor, ensureGroup, uploadAsset } = await import(
+		"../infra/imarouter-assets.js"
+	);
+	const { envApiKeyProvider } = await import("../infra/api-caller.js");
+	const apiKey = await envApiKeyProvider("imarouter");
+	if (!apiKey) {
+		return {
+			success: false,
+			error: "IMAROUTER_API_KEY not configured",
+		};
+	}
+
+	const channel = channelFor(modelKey);
+	const groupId = await ensureGroup(channel, { apiKey });
+	const uploadSources = await Promise.all(
+		raw.map((entry) => resolveImaRouterUploadSource({ entry, options }))
+	);
+	const sourceFailure = uploadSources.find((item) => !item.success);
+	if (sourceFailure) return { success: false, error: sourceFailure.error };
+
+	const assets = await Promise.all(
+		uploadSources.map(async (item): Promise<ReferenceImageResolution> => {
+			if (!item.success) return item;
+			if (isImaRouterAssetUrl({ url: item.url })) {
+				return { success: true, url: item.url };
+			}
+			try {
+				const assetUrl = await uploadAsset(item.url, channel, groupId, {
+					apiKey,
+					signal: options.signal,
+				});
+				return { success: true, url: assetUrl };
+			} catch (error) {
+				return {
+					success: false,
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to upload IMA Router reference image",
+				};
+			}
+		})
+	);
+	const assetFailure = assets.find((item) => !item.success);
+	if (assetFailure) return { success: false, error: assetFailure.error };
+
+	return {
+		success: true,
+		urls: assets.flatMap((item) => (item.success ? [item.url] : [])),
+	};
+}
+
 /**
  * Reshape a flat payload into the IMA Router `/v1/videos` body shape:
  * top-level `{ model, prompt, duration, images?, size? }` plus a nested
@@ -218,7 +339,8 @@ function reshapeForImaRouter(
 	payload: Record<string, unknown>
 ): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
-	const metadata: Record<string, unknown> = {};
+	const flatMetadata: Record<string, unknown> = {};
+	const nestedMetadata = { ...(asRecord({ value: payload.metadata }) ?? {}) };
 	const METADATA_KEYS = new Set([
 		"resolution",
 		"aspect_ratio",
@@ -226,12 +348,15 @@ function reshapeForImaRouter(
 		"role_mode",
 		"reference_video_urls",
 		"reference_audio_urls",
+		"first_frame_image",
 	]);
 	for (const [k, v] of Object.entries(payload)) {
 		if (v === undefined || v === null) continue;
-		if (METADATA_KEYS.has(k)) metadata[k] = v;
+		if (k === "metadata") continue;
+		if (METADATA_KEYS.has(k)) flatMetadata[k] = v;
 		else out[k] = v;
 	}
+	const metadata = { ...nestedMetadata, ...flatMetadata };
 	// `size` (WxH) overrides `resolution` per IMA Router spec — drop the
 	// duplicate metadata.resolution so the API picks the explicit size.
 	if (typeof out.size === "string" && "resolution" in metadata) {
@@ -602,7 +727,9 @@ async function executeImageToVideo(
 		// Auto-upload local paths to FAL CDN so any provider (GMI, FAL, etc.)
 		// receives a fetchable HTTPS URL.
 		let imageUrl = input.imageUrl;
-		if (!/^https?:\/\//i.test(imageUrl)) {
+		const isImaRouterAssetInput =
+			provider === "imarouter" && isImaRouterAssetUrl({ url: imageUrl });
+		if (!isRemoteUrl(imageUrl) && !isImaRouterAssetInput) {
 			if (options.signal?.aborted) {
 				return {
 					success: false,
@@ -685,35 +812,54 @@ async function executeImageToVideo(
 				payload.duration = String(payload.duration);
 			}
 		} else if (provider === "imarouter") {
-			// IMA Router routes through `/v1/assets/create` for portrait /
-			// real-people refs (rejected as inline URLs with Error 601400),
-			// then sends `images: ["asset://..."]` to `/v1/videos`. Channel
-			// (overseas vs CN) determines the upload model — never mix.
-			const { channelFor, ensureGroup, uploadAsset } = await import(
-				"../infra/imarouter-assets.js"
-			);
-			const channel = channelFor(model.key);
-			const { envApiKeyProvider } = await import("../infra/api-caller.js");
-			const apiKey = await envApiKeyProvider("imarouter");
-			if (!apiKey) {
+			const refs = await resolveImaRouterReferenceImages({
+				entries: [imageUrl],
+				modelKey: model.key,
+				options,
+			});
+			if (!refs.success) {
 				return {
 					success: false,
-					error: "IMAROUTER_API_KEY not configured",
+					error: refs.error,
 					duration: 0,
 				};
 			}
-			const groupId = await ensureGroup(channel, { apiKey });
-			const assetUrl = await uploadAsset(imageUrl, channel, groupId, {
-				apiKey,
-				signal: options.signal,
-			});
-			payload.images = [assetUrl];
+			payload.images = refs.urls;
 		} else {
 			payload.image_url = imageUrl;
 		}
 	}
 	if (input.text) {
 		payload.prompt = input.text;
+	}
+
+	const isImaRouterRef2V =
+		provider === "imarouter" &&
+		(model.key === "imarouter_seedance_2_0_ref2v" ||
+			model.key === "imarouter_seedance_2_0_cn_ref2v");
+	if (isImaRouterRef2V && Array.isArray(payload.image_urls)) {
+		const existingImages = Array.isArray(payload.images)
+			? (payload.images as unknown[]).flatMap((entry) =>
+					typeof entry === "string" ? [entry] : []
+				)
+			: [];
+		const imageUrls = (payload.image_urls as unknown[]).flatMap((entry) =>
+			typeof entry === "string" ? [entry] : []
+		);
+		const refs = await resolveImaRouterReferenceImages({
+			entries: [...existingImages, ...imageUrls],
+			modelKey: model.key,
+			options,
+		});
+		if (!refs.success) {
+			return {
+				success: false,
+				error: refs.error,
+				duration: 0,
+			};
+		}
+		payload.images = refs.urls;
+		delete payload.image_urls;
 	}
 
 	// Happy Horse Ref2V can receive multiple references via the CLI's

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -268,9 +268,13 @@ async function resolveImaRouterReferenceImages({
 		signal?: AbortSignal;
 	};
 }): Promise<ReferenceImagesResolution> {
-	const raw = entries
-		.filter((entry) => typeof entry === "string" && entry.trim())
-		.slice(0, 14);
+	const raw = Array.from(
+		new Set(
+			entries
+				.filter((entry) => typeof entry === "string" && entry.trim())
+				.map((entry) => entry.trim())
+		)
+	).slice(0, 14);
 	if (raw.length === 0) return { success: true, urls: [] };
 	if (raw.every((entry) => isImaRouterAssetUrl({ url: entry }))) {
 		return { success: true, urls: raw };
@@ -280,7 +284,16 @@ async function resolveImaRouterReferenceImages({
 		"../infra/imarouter-assets.js"
 	);
 	const { envApiKeyProvider } = await import("../infra/api-caller.js");
-	const apiKey = await envApiKeyProvider("imarouter");
+	let apiKey = await envApiKeyProvider("imarouter");
+	if (!apiKey) {
+		try {
+			const { getDecryptedApiKeys } = await import("../../api-key-handler.js");
+			const keys = await getDecryptedApiKeys();
+			apiKey = (keys as { imarouterApiKey?: string }).imarouterApiKey || "";
+		} catch {
+			// Not in Electron — env-var-only resolution already attempted above
+		}
+	}
 	if (!apiKey) {
 		return {
 			success: false,

--- a/qcut/electron/native-pipeline/execution/step-executors.ts
+++ b/qcut/electron/native-pipeline/execution/step-executors.ts
@@ -256,6 +256,12 @@ async function resolveImaRouterUploadSource({
 	return { success: true, url: upload.url };
 }
 
+/**
+ * Resolve raw reference-image entries into IMA Router asset URLs. Deduplicates
+ * and caps entries at 14, short-circuits when all are already asset URLs, and
+ * otherwise uploads each source to the model's asset channel. Returns the
+ * resolved URLs or a failure with the first upload error.
+ */
 async function resolveImaRouterReferenceImages({
 	entries,
 	modelKey,

--- a/qcut/electron/native-pipeline/infra/__tests__/api-caller-fal-upload.test.ts
+++ b/qcut/electron/native-pipeline/infra/__tests__/api-caller-fal-upload.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	fetch: vi.fn(),
+	isProxyAvailable: vi.fn(),
+	proxyUploadUrl: vi.fn(),
+}));
+const originalFetch = globalThis.fetch;
+const originalFalKey = process.env.FAL_KEY;
+const originalFalApiKey = process.env.FAL_API_KEY;
+
+vi.mock("../proxy-client.js", async () => {
+	const actual =
+		await vi.importActual<typeof import("../proxy-client.js")>(
+			"../proxy-client.js"
+		);
+	return {
+		...actual,
+		isProxyAvailable: mocks.isProxyAvailable,
+		proxyUploadUrl: mocks.proxyUploadUrl,
+	};
+});
+
+vi.mock("../../api-key-handler.js", () => ({
+	getDecryptedApiKeys: vi.fn().mockResolvedValue({}),
+}));
+
+import {
+	envApiKeyProvider,
+	setApiKeyProvider,
+	uploadToFalStorage,
+} from "../api-caller.js";
+
+function mockResponse({
+	ok,
+	status,
+	json,
+	text = "",
+}: {
+	ok: boolean;
+	status: number;
+	json?: unknown;
+	text?: string;
+}): Response {
+	return {
+		ok,
+		status,
+		json: async () => json,
+		text: async () => text,
+	} as Response;
+}
+
+function writeFixture(): { dir: string; path: string } {
+	const dir = mkdtempSync(join(tmpdir(), "qcut-fal-upload-"));
+	const path = join(dir, "reference.png");
+	writeFileSync(path, Buffer.from([1, 2, 3]));
+	return { dir, path };
+}
+
+describe("uploadToFalStorage", () => {
+	beforeEach(() => {
+		globalThis.fetch = mocks.fetch as unknown as typeof fetch;
+		vi.clearAllMocks();
+		setApiKeyProvider(envApiKeyProvider);
+		delete process.env.FAL_KEY;
+		delete process.env.FAL_API_KEY;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		if (originalFalKey === undefined) delete process.env.FAL_KEY;
+		else process.env.FAL_KEY = originalFalKey;
+		if (originalFalApiKey === undefined) delete process.env.FAL_API_KEY;
+		else process.env.FAL_API_KEY = originalFalApiKey;
+	});
+
+	it("falls back to direct FAL upload when proxy URL vending fails and FAL_KEY is available", async () => {
+		process.env.FAL_KEY = "sandbox-fal-key";
+		mocks.isProxyAvailable.mockResolvedValue(true);
+		mocks.proxyUploadUrl.mockRejectedValue(
+			new Error("Upload URL request failed (401): invalid token")
+		);
+		mocks.fetch
+			.mockResolvedValueOnce(
+				mockResponse({
+					ok: true,
+					status: 200,
+					json: {
+						upload_url: "https://fal.direct/upload/reference.png",
+						file_url: "https://fal.direct/files/reference.png",
+					},
+				})
+			)
+			.mockResolvedValueOnce(mockResponse({ ok: true, status: 200 }));
+		const fixture = writeFixture();
+
+		try {
+			const result = await uploadToFalStorage(fixture.path);
+
+			expect(result).toEqual({
+				success: true,
+				url: "https://fal.direct/files/reference.png",
+			});
+			expect(mocks.proxyUploadUrl).toHaveBeenCalledWith({
+				fileName: "reference.png",
+				contentType: "image/png",
+			});
+			const [initUrl, init] = mocks.fetch.mock.calls[0];
+			expect(String(initUrl)).toContain(
+				"rest.alpha.fal.ai/storage/upload/initiate"
+			);
+			expect((init as RequestInit).method).toBe("POST");
+			const headers = (init as RequestInit).headers as Record<string, string>;
+			expect(headers.Authorization).toBe("Key sandbox-fal-key");
+			const [, put] = mocks.fetch.mock.calls[1];
+			expect((put as RequestInit).method).toBe("PUT");
+		} finally {
+			rmSync(fixture.dir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not attempt direct FAL upload after proxy failure when no local FAL key exists", async () => {
+		mocks.isProxyAvailable.mockResolvedValue(true);
+		mocks.proxyUploadUrl.mockRejectedValue(
+			new Error("Upload URL request failed (401): invalid token")
+		);
+		const fixture = writeFixture();
+
+		try {
+			const result = await uploadToFalStorage(fixture.path);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("Upload URL request failed (401)");
+			expect(mocks.fetch).not.toHaveBeenCalled();
+		} finally {
+			rmSync(fixture.dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -361,6 +361,11 @@ export async function uploadToFalStorage(
 	}
 }
 
+/**
+ * Vend FAL storage upload URLs directly via the FAL API using a local key
+ * (the BYOK fallback when the proxy path is unavailable). The initiate POST is
+ * bounded by a 15s timeout. Throws if FAL doesn't return both URLs.
+ */
 async function createFalUploadUrls({
 	filename,
 	contentType,

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -288,7 +288,7 @@ export async function uploadToFalStorage(
 
 		// Proxy mode: server vends the signed URL (key never leaves server)
 		const useProxy = await isProxyAvailable();
-		const apiKey = useProxy ? "" : await getApiKey("fal");
+		const apiKey = await getApiKey("fal");
 
 		if (!useProxy && !apiKey) {
 			return { success: false, error: "No FAL API key configured" };
@@ -298,41 +298,34 @@ export async function uploadToFalStorage(
 		let fileUrl: string;
 
 		if (useProxy) {
-			const urls = await proxyUploadUrl({
-				fileName: filename,
+			try {
+				const urls = await proxyUploadUrl({
+					fileName: filename,
+					contentType,
+				});
+				uploadUrl = urls.uploadUrl;
+				fileUrl = urls.fileUrl;
+			} catch (error) {
+				if (!apiKey) throw error;
+				console.warn(
+					`[api-caller] Proxy upload URL failed (${error instanceof Error ? error.message : String(error)}); falling back to local FAL_KEY`
+				);
+				const urls = await createFalUploadUrls({
+					filename,
+					contentType,
+					apiKey,
+				});
+				uploadUrl = urls.uploadUrl;
+				fileUrl = urls.fileUrl;
+			}
+		} else {
+			const urls = await createFalUploadUrls({
+				filename,
 				contentType,
+				apiKey,
 			});
 			uploadUrl = urls.uploadUrl;
 			fileUrl = urls.fileUrl;
-		} else {
-			const initRes = await fetch(FAL_STORAGE_INITIATE, {
-				method: "POST",
-				headers: {
-					Authorization: `Key ${apiKey}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					file_name: filename,
-					content_type: contentType,
-				}),
-			});
-
-			if (!initRes.ok) {
-				return {
-					success: false,
-					error: `FAL upload initiate failed: ${initRes.status}`,
-				};
-			}
-
-			const initData = (await initRes.json()) as {
-				upload_url?: string;
-				file_url?: string;
-			};
-			if (!initData.upload_url || !initData.file_url) {
-				return { success: false, error: "FAL API did not return upload URLs" };
-			}
-			uploadUrl = initData.upload_url;
-			fileUrl = initData.file_url;
 		}
 
 		// Step 2: Read file and PUT to signed URL
@@ -366,6 +359,41 @@ export async function uploadToFalStorage(
 			error: `FAL upload error: ${err instanceof Error ? err.message : String(err)}`,
 		};
 	}
+}
+
+async function createFalUploadUrls({
+	filename,
+	contentType,
+	apiKey,
+}: {
+	filename: string;
+	contentType: string;
+	apiKey: string;
+}): Promise<{ uploadUrl: string; fileUrl: string }> {
+	const initRes = await fetch(FAL_STORAGE_INITIATE, {
+		method: "POST",
+		headers: {
+			Authorization: `Key ${apiKey}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			file_name: filename,
+			content_type: contentType,
+		}),
+	});
+
+	if (!initRes.ok) {
+		throw new Error(`FAL upload initiate failed: ${initRes.status}`);
+	}
+
+	const initData = (await initRes.json()) as {
+		upload_url?: string;
+		file_url?: string;
+	};
+	if (!initData.upload_url || !initData.file_url) {
+		throw new Error("FAL API did not return upload URLs");
+	}
+	return { uploadUrl: initData.upload_url, fileUrl: initData.file_url };
 }
 
 export { GEMINI_BASE, OPENROUTER_BASE, VOLCENGINE_BASE };

--- a/qcut/electron/native-pipeline/infra/api-caller.ts
+++ b/qcut/electron/native-pipeline/infra/api-caller.ts
@@ -380,6 +380,7 @@ async function createFalUploadUrls({
 			file_name: filename,
 			content_type: contentType,
 		}),
+		signal: AbortSignal.timeout(15_000),
 	});
 
 	if (!initRes.ok) {

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -16,7 +16,9 @@ PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
 QCUT_AGENT_ALLOW_DEFAULT_USER = "true"
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824"
+# Pinned to immutable digest so retags can't silently change sandbox runtime.
+# Human-readable tag: cli-image-v12-ref2v-20260526205824
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:ff56c1087655b6e1893dc44766a4a9a6e3ae156e6b625f77871624a9fbe79cf6"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -16,7 +16,7 @@ PAYMENTS_CANARY_ONLY = "false"
 CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
 QCUT_AGENT_ALLOW_DEFAULT_USER = "true"
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:gen-image-ratio-size-20260526034624"
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
+++ b/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
@@ -1,0 +1,755 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+
+const DEFAULT_URL = "https://quriosity.com.au/chat-agent.html";
+const DEFAULT_LICENSE_SERVER_URL =
+	"https://qcut-license-server.zdhpeter.workers.dev";
+const POLL_INTERVAL_MS = 15_000;
+const DEFAULT_REFERENCE_IMAGE_URL =
+	"https://storage.googleapis.com/gmi-video-assests-prod/user-assets/3e51f140-4e66-4cb2-bca4-6f412e5d6113/780402b5-bbc0-4941-b029-a4ce0cdab845/gmi-videogen/generated/source_image_c4046b99-7fad-4e4d-b681-fef11bd431e3579b9b15-2a03-45a3-94e5-42fa4a8ab5a4.png";
+
+declare global {
+	interface Window {
+		AgentChatAPI?: {
+			clearStoredAgentSessionId?: () => void;
+			createAgentSession?: () => Promise<{ id?: string } | null>;
+			endAgentSession?: ({
+				sessionId,
+			}: {
+				sessionId: string;
+			}) => Promise<unknown>;
+		};
+		AgentChatReady?: Promise<unknown>;
+		PaymentAPI?: {
+			getApiBaseUrl?: () => string;
+			getAuthToken?: () => string;
+		};
+	}
+}
+
+type Config = {
+	url: string;
+	licenseServerUrl: string;
+	outDir: string;
+	referenceImageUrl: string;
+	headed: boolean;
+	connectTimeoutMs: number;
+	generationTimeoutMs: number;
+};
+
+type SessionContext = {
+	apiBase: string;
+	sessionId: string;
+	token: string;
+};
+
+type StepResult = {
+	name: string;
+	status: "passed" | "failed";
+	durationMs: number;
+	detail?: string;
+	screenshot?: string;
+};
+
+type RunState = {
+	browser: Browser;
+	page: Page;
+	config: Config;
+	runId: string;
+	root: string;
+	steps: StepResult[];
+	downloads: Array<{ remotePath: string; localPath: string }>;
+};
+
+function readOption({ argv, name }: { argv: string[]; name: string }): string {
+	const index = argv.indexOf(name);
+	if (index === -1) return "";
+	return argv[index + 1] || "";
+}
+
+function hasFlag({ argv, name }: { argv: string[]; name: string }): boolean {
+	return argv.includes(name);
+}
+
+function readNumberOption({
+	argv,
+	name,
+	defaultValue,
+}: {
+	argv: string[];
+	name: string;
+	defaultValue: number;
+}): number {
+	const raw = readOption({ argv, name });
+	if (raw.length === 0) return defaultValue;
+	const value = Number(raw);
+	return Number.isFinite(value) && value > 0 ? value : defaultValue;
+}
+
+function parseArgs({ argv }: { argv: string[] }): Config {
+	if (hasFlag({ argv, name: "--help" }) || hasFlag({ argv, name: "-h" })) {
+		printHelp();
+		process.exit(0);
+	}
+
+	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const defaultOutDir = join(
+		process.cwd(),
+		"output/playwright",
+		`agent-chat-imarouter-ref2v-e2e-${timestamp}`
+	);
+	return {
+		url:
+			readOption({ argv, name: "--url" }) ||
+			process.env.AGENT_CHAT_E2E_URL ||
+			DEFAULT_URL,
+		licenseServerUrl:
+			readOption({ argv, name: "--license-server-url" }) ||
+			process.env.QCUT_LICENSE_SERVER_URL ||
+			DEFAULT_LICENSE_SERVER_URL,
+		outDir: resolve(readOption({ argv, name: "--out-dir" }) || defaultOutDir),
+		referenceImageUrl:
+			readOption({ argv, name: "--reference-image-url" }) ||
+			process.env.IMAROUTER_REF2V_E2E_REFERENCE_IMAGE_URL ||
+			DEFAULT_REFERENCE_IMAGE_URL,
+		headed:
+			hasFlag({ argv, name: "--headed" }) ||
+			hasFlag({ argv, name: "--headful" }),
+		connectTimeoutMs: readNumberOption({
+			argv,
+			name: "--connect-timeout-ms",
+			defaultValue: 300_000,
+		}),
+		generationTimeoutMs: readNumberOption({
+			argv,
+			name: "--generation-timeout-ms",
+			defaultValue: 1_800_000,
+		}),
+	};
+}
+
+function printHelp() {
+	console.log(`QCut IMA Router Ref2V Chat Agent E2E
+
+Usage:
+  bun scripts/agent-chat-imarouter-ref2v-e2e.ts [options]
+
+Options:
+  --url <url>                         Chat Agent URL. Default: ${DEFAULT_URL}
+  --license-server-url <url>          License server base URL fallback.
+  --out-dir <path>                    Screenshot/result output directory.
+  --reference-image-url <url>         Public image URL to pass via --reference-images.
+  --headed, --headful                 Show the browser.
+  --connect-timeout-ms <ms>           Connect/Codex ready timeout.
+  --generation-timeout-ms <ms>        Ref2V generation timeout.
+`);
+}
+
+function log({ message }: { message: string }) {
+	console.log(`[agent-chat-imarouter-ref2v-e2e] ${message}`);
+}
+
+function assertCondition({
+	condition,
+	message,
+}: {
+	condition: boolean;
+	message: string;
+}) {
+	if (!condition) throw new Error(message);
+}
+
+async function screenshot({
+	page,
+	outDir,
+	name,
+}: {
+	page: Page;
+	outDir: string;
+	name: string;
+}): Promise<string> {
+	const path = join(outDir, `${name}.png`);
+	await page.screenshot({ path, fullPage: true });
+	return path;
+}
+
+async function runStep({
+	state,
+	name,
+	screenshotName,
+	action,
+}: {
+	state: RunState;
+	name: string;
+	screenshotName: string;
+	action: () => Promise<string | undefined>;
+}): Promise<void> {
+	const startedAt = Date.now();
+	try {
+		const detail = await action();
+		const image = await screenshot({
+			page: state.page,
+			outDir: state.config.outDir,
+			name: screenshotName,
+		});
+		const durationMs = Date.now() - startedAt;
+		state.steps.push({
+			name,
+			status: "passed",
+			durationMs,
+			detail,
+			screenshot: image,
+		});
+		log({ message: `PASS ${name} (${durationMs}ms)` });
+	} catch (error) {
+		const image = await screenshot({
+			page: state.page,
+			outDir: state.config.outDir,
+			name: `${screenshotName}-failed`,
+		});
+		const durationMs = Date.now() - startedAt;
+		const detail = error instanceof Error ? error.message : String(error);
+		state.steps.push({
+			name,
+			status: "failed",
+			durationMs,
+			detail,
+			screenshot: image,
+		});
+		throw error;
+	}
+}
+
+async function waitForAgentChatReady({ page }: { page: Page }) {
+	await page.waitForFunction(
+		async () => {
+			const ready = window.AgentChatReady;
+			if (!ready || typeof ready.then !== "function") return false;
+			await ready;
+			return true;
+		},
+		null,
+		{ timeout: 30_000 }
+	);
+}
+
+async function readTerminalStatus({ page }: { page: Page }): Promise<string> {
+	return (
+		await page.locator("#agent-terminal-status").innerText({ timeout: 5_000 })
+	).trim();
+}
+
+async function readTerminalText({ page }: { page: Page }): Promise<string> {
+	try {
+		return await page.locator("#agent-terminal").innerText({ timeout: 2_000 });
+	} catch {
+		return "";
+	}
+}
+
+async function waitForCodexReady({
+	page,
+	timeoutMs,
+}: {
+	page: Page;
+	timeoutMs: number;
+}) {
+	await page.waitForFunction(
+		() => {
+			const status = document
+				.querySelector("#agent-terminal-status")
+				?.textContent?.trim();
+			const terminalText =
+				document.querySelector("#agent-terminal")?.textContent || "";
+			return status === "connected" && terminalText.includes("OpenAI Codex");
+		},
+		null,
+		{ timeout: timeoutMs }
+	);
+}
+
+async function resetServerSessionThroughUi({ page }: { page: Page }) {
+	await page.waitForTimeout(2_000);
+	const endedSessionId = await page.evaluate(async () => {
+		const api = window.AgentChatAPI;
+		if (!api?.createAgentSession || !api?.endAgentSession) return "";
+		try {
+			const session = await api.createAgentSession();
+			const sessionId = typeof session?.id === "string" ? session.id : "";
+			if (sessionId.length > 0) {
+				await api.endAgentSession({ sessionId });
+			}
+			api.clearStoredAgentSessionId?.();
+			return sessionId;
+		} catch {
+			api.clearStoredAgentSessionId?.();
+			return "";
+		}
+	});
+	await page.locator("#agent-new-session").click();
+	await page.waitForFunction(
+		() => {
+			const status = document
+				.querySelector("#agent-terminal-status")
+				?.textContent?.trim();
+			const sessionId =
+				window.localStorage.getItem("qcut_agent_session_id") || "";
+			const text =
+				document.querySelector("#agent-session-status")?.textContent?.trim() ||
+				"";
+			return (
+				status === "disconnected" &&
+				sessionId.length === 0 &&
+				(text === "none" || text.length === 0)
+			);
+		},
+		null,
+		{ timeout: 60_000 }
+	);
+	return endedSessionId.length > 0
+		? `ended active session=${endedSessionId}`
+		: "confirmed no active session";
+}
+
+async function typePromptIntoTerminal({
+	page,
+	prompt,
+}: {
+	page: Page;
+	prompt: string;
+}) {
+	const terminal = page.locator("#agent-terminal");
+	const helperTextarea = page.locator("#agent-terminal .xterm-helper-textarea");
+	await helperTextarea.waitFor({ state: "attached", timeout: 10_000 });
+	await terminal.click({ position: { x: 260, y: 420 } });
+	await helperTextarea.focus();
+	await page.keyboard.type(prompt, { delay: 1 });
+	await page.waitForTimeout(750);
+	await page.keyboard.press("Control+M");
+}
+
+async function getSessionContext({
+	page,
+	fallbackApiBase,
+}: {
+	page: Page;
+	fallbackApiBase: string;
+}): Promise<SessionContext> {
+	return page.evaluate((apiBaseFallback) => {
+		const apiBase = window.PaymentAPI?.getApiBaseUrl?.() || apiBaseFallback;
+		const token = window.PaymentAPI?.getAuthToken?.() || "";
+		const sessionId =
+			window.localStorage.getItem("qcut_agent_session_id") || "";
+		if (sessionId.length === 0) {
+			throw new Error("missing agent session id");
+		}
+		return { apiBase, token, sessionId };
+	}, fallbackApiBase);
+}
+
+function buildSessionFileUrl({
+	context,
+	remotePath,
+}: {
+	context: SessionContext;
+	remotePath: string;
+}): string {
+	return `${context.apiBase}/api/agent/sessions/${encodeURIComponent(
+		context.sessionId
+	)}/files/download?path=${encodeURIComponent(remotePath)}`;
+}
+
+async function fetchSessionText({
+	context,
+	remotePath,
+}: {
+	context: SessionContext;
+	remotePath: string;
+}): Promise<string | null> {
+	const response = await fetch(buildSessionFileUrl({ context, remotePath }), {
+		headers:
+			context.token.length === 0
+				? undefined
+				: { Authorization: `Bearer ${context.token}` },
+	});
+	if (!response.ok) return null;
+	return response.text();
+}
+
+async function downloadSessionFile({
+	context,
+	remotePath,
+	localPath,
+}: {
+	context: SessionContext;
+	remotePath: string;
+	localPath: string;
+}): Promise<boolean> {
+	const response = await fetch(buildSessionFileUrl({ context, remotePath }), {
+		headers:
+			context.token.length === 0
+				? undefined
+				: { Authorization: `Bearer ${context.token}` },
+	});
+	if (!response.ok) return false;
+	const bytes = Buffer.from(await response.arrayBuffer());
+	writeFileSync(localPath, bytes);
+	return true;
+}
+
+async function waitForRef2VReady({
+	context,
+	root,
+	timeoutMs,
+}: {
+	context: SessionContext;
+	root: string;
+	timeoutMs: number;
+}): Promise<string> {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		const preflightFailure = await fetchSessionText({
+			context,
+			remotePath: `${root}/preflight-failed.txt`,
+		});
+		if (preflightFailure !== null) {
+			throw new Error(`preflight failed: ${preflightFailure}`);
+		}
+		const generationFailure = await fetchSessionText({
+			context,
+			remotePath: `${root}/ref2v-failed.txt`,
+		});
+		if (generationFailure !== null) {
+			throw new Error(`ref2v failed: ${generationFailure}`);
+		}
+		const readyText = await fetchSessionText({
+			context,
+			remotePath: `${root}/ref2v-ready.txt`,
+		});
+		if (readyText !== null) return readyText;
+		await new Promise((resolveDelay) =>
+			setTimeout(resolveDelay, POLL_INTERVAL_MS)
+		);
+	}
+	throw new Error(`timed out waiting for ${root}/ref2v-ready.txt`);
+}
+
+function buildGenerationPrompt({
+	root,
+	referenceImageUrl,
+}: {
+	root: string;
+	referenceImageUrl: string;
+}): string {
+	return `Please run a real online QCut IMA Router Ref2V smoke test in this Daytona sandbox. Do not mock anything, do not use a different model, and do not print or write any API secret.
+
+Run this exact shell script as-is:
+
+cat > /tmp/qcut-imarouter-ref2v-e2e.sh <<'SH'
+set -u
+
+ROOT="${root}"
+REF="${referenceImageUrl}"
+mkdir -p "$ROOT/generated"
+
+{
+  if [ -n "\${IMAROUTER_API_KEY:-}" ]; then
+    echo "HAS_IMAROUTER_API_KEY=yes"
+    echo "IMAROUTER_API_KEY_LENGTH=\${#IMAROUTER_API_KEY}"
+  else
+    echo "HAS_IMAROUTER_API_KEY=no"
+    echo "IMAROUTER_API_KEY_LENGTH=0"
+  fi
+  printf "QCut_VERSION="
+  qcut --version || true
+  printf "Codex_VERSION="
+  codex --version || true
+} > "$ROOT/env-check.txt"
+
+qcut system models --json > "$ROOT/models.json" 2> "$ROOT/models.stderr" || true
+
+set +e
+QCUT_OUTPUT_DIR="$ROOT/generated" qcut gen video \
+  -m imarouter_seedance_2_0_ref2v \
+  --reference-images "$REF" \
+  -t "5 second video using the reference image, clean product turntable shot" \
+  -d 5s \
+  --aspect-ratio 16:9 \
+  --resolution 720p \
+  --json > "$ROOT/ref2v-command.log" 2>&1
+status=$?
+set -e
+
+video_path="$(find "$ROOT/generated" -type f -name '*.mp4' | head -n 1)"
+sidecar_path="$(find "$ROOT/generated" -type f -name '*.json' | head -n 1)"
+
+if [ -z "$video_path" ]; then
+  {
+    echo "exit_status=$status"
+    cat "$ROOT/ref2v-command.log"
+  } > "$ROOT/ref2v-failed.txt"
+  exit 0
+fi
+
+ffprobe -v error -show_streams -show_format -of json "$video_path" > "$ROOT/ffprobe.json"
+
+python3 - "$ROOT/ref2v-result.json" "$REF" "$video_path" "$sidecar_path" "$ROOT/ffprobe.json" <<'PY'
+import json
+import sys
+
+out, ref, video, sidecar, ffprobe = sys.argv[1:]
+with open(out, "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "status": "SUCCESS",
+            "model": "imarouter_seedance_2_0_ref2v",
+            "referenceImageUrl": ref,
+            "videoPath": video,
+            "sidecarPath": sidecar,
+            "ffprobePath": ffprobe,
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\\n")
+PY
+
+{
+  echo "REF2V_READY"
+  echo "videoPath=$video_path"
+} > "$ROOT/ref2v-ready.txt"
+SH
+
+bash /tmp/qcut-imarouter-ref2v-e2e.sh
+
+After the script finishes, reply with REF2V_READY and the root path: ${root}.
+
+Final response should include REF2V_READY and the root path.`;
+}
+
+async function downloadEvidenceFiles({
+	state,
+	context,
+	remotePaths,
+}: {
+	state: RunState;
+	context: SessionContext;
+	remotePaths: string[];
+}) {
+	for (const remotePath of remotePaths) {
+		const localPath = join(state.config.outDir, basename(remotePath));
+		const downloaded = await downloadSessionFile({
+			context,
+			remotePath,
+			localPath,
+		});
+		if (downloaded) {
+			state.downloads.push({ remotePath, localPath });
+		}
+	}
+}
+
+async function main() {
+	const config = parseArgs({ argv: process.argv.slice(2) });
+	mkdirSync(config.outDir, { recursive: true });
+
+	const runId = String(Date.now());
+	const root = `/tmp/qcut-output/imarouter-ref2v-e2e-${runId}`;
+	const browser = await chromium.launch({ headless: !config.headed });
+	const page = await browser.newPage({
+		acceptDownloads: true,
+		viewport: { width: 1280, height: 960 },
+	});
+	await page.addInitScript(() => {
+		window.localStorage.removeItem("qcut_agent_session_id");
+	});
+
+	const state: RunState = {
+		browser,
+		page,
+		config,
+		runId,
+		root,
+		steps: [],
+		downloads: [],
+	};
+	let exitCode = 0;
+	let context: SessionContext | null = null;
+	let readyText = "";
+	let resultText = "";
+
+	try {
+		await runStep({
+			state,
+			name: "load chat agent page",
+			screenshotName: "01-initial-load",
+			action: async () => {
+				await page.goto(config.url, {
+					waitUntil: "domcontentloaded",
+					timeout: 60_000,
+				});
+				await waitForAgentChatReady({ page });
+				const status = await readTerminalStatus({ page });
+				assertCondition({
+					condition: status === "disconnected",
+					message: `expected disconnected after load, got ${status}`,
+				});
+				return `status=${status}`;
+			},
+		});
+
+		await runStep({
+			state,
+			name: "reset active server session",
+			screenshotName: "02-reset-active-session",
+			action: async () => resetServerSessionThroughUi({ page }),
+		});
+
+		await runStep({
+			state,
+			name: "connect to Daytona Codex terminal",
+			screenshotName: "03-codex-ready",
+			action: async () => {
+				await page.locator("#agent-terminal-connect").click();
+				await waitForCodexReady({
+					page,
+					timeoutMs: config.connectTimeoutMs,
+				});
+				context = await getSessionContext({
+					page,
+					fallbackApiBase: config.licenseServerUrl,
+				});
+				log({ message: `session=${context.sessionId}; root=${root}` });
+				return `session=${context.sessionId}; root=${root}`;
+			},
+		});
+
+		await runStep({
+			state,
+			name: "natural language request runs real IMA Ref2V with reference image",
+			screenshotName: "04-ref2v-request",
+			action: async () => {
+				if (!context) throw new Error("missing session context");
+				await typePromptIntoTerminal({
+					page,
+					prompt: buildGenerationPrompt({
+						root,
+						referenceImageUrl: config.referenceImageUrl,
+					}),
+				});
+				readyText = await waitForRef2VReady({
+					context,
+					root,
+					timeoutMs: config.generationTimeoutMs,
+				});
+				resultText =
+					(await fetchSessionText({
+						context,
+						remotePath: `${root}/ref2v-result.json`,
+					})) || "";
+				assertCondition({
+					condition: readyText.includes("REF2V_READY"),
+					message: "ready marker missing",
+				});
+				assertCondition({
+					condition:
+						resultText.includes('"status"') && resultText.includes("SUCCESS"),
+					message: "result JSON did not report SUCCESS",
+				});
+				return readyText.trim();
+			},
+		});
+
+		await runStep({
+			state,
+			name: "download sandbox evidence files",
+			screenshotName: "05-evidence-downloaded",
+			action: async () => {
+				if (!context) throw new Error("missing session context");
+				const parsed = JSON.parse(resultText) as {
+					videoPath?: string;
+					sidecarPath?: string;
+				};
+				const paths = [
+					`${root}/env-check.txt`,
+					`${root}/models.json`,
+					`${root}/ref2v-command.log`,
+					`${root}/ffprobe.json`,
+					`${root}/ref2v-result.json`,
+					`${root}/ref2v-ready.txt`,
+					parsed.videoPath || "",
+					parsed.sidecarPath || "",
+				].filter((entry) => entry.length > 0);
+				await downloadEvidenceFiles({
+					state,
+					context,
+					remotePaths: paths,
+				});
+				assertCondition({
+					condition: state.downloads.some((item) =>
+						item.remotePath.endsWith(".mp4")
+					),
+					message: "generated video was not downloaded",
+				});
+				return `downloaded=${state.downloads.length}`;
+			},
+		});
+
+		await runStep({
+			state,
+			name: "final browser screenshot captures ready terminal",
+			screenshotName: "06-final-proof",
+			action: async () => {
+				const terminalText = await readTerminalText({ page });
+				return terminalText.includes("REF2V_READY")
+					? "terminal shows REF2V_READY"
+					: "terminal screenshot captured";
+			},
+		});
+	} catch (error) {
+		exitCode = 1;
+		log({
+			message:
+				error instanceof Error
+					? `FAILED ${error.message}`
+					: `FAILED ${String(error)}`,
+		});
+	} finally {
+		const resultPath = join(config.outDir, "result.json");
+		writeFileSync(
+			resultPath,
+			`${JSON.stringify(
+				{
+					status: exitCode === 0 ? "passed" : "failed",
+					runId,
+					url: config.url,
+					root,
+					referenceImageUrl: config.referenceImageUrl,
+					outDir: config.outDir,
+					steps: state.steps,
+					readyText,
+					downloads: state.downloads,
+				},
+				null,
+				2
+			)}\n`
+		);
+		log({ message: `result=${resultPath}` });
+		await browser.close();
+	}
+
+	process.exit(exitCode);
+}
+
+void main().catch((error: unknown) => {
+	log({
+		message:
+			error instanceof Error
+				? `UNHANDLED ${error.message}`
+				: `UNHANDLED ${String(error)}`,
+	});
+	process.exit(1);
+});

--- a/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
+++ b/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
@@ -35,6 +35,7 @@ type Config = {
 	licenseServerUrl: string;
 	outDir: string;
 	referenceImageUrl: string;
+	useLocalReferenceFile: boolean;
 	headed: boolean;
 	connectTimeoutMs: number;
 	generationTimeoutMs: number;
@@ -115,6 +116,7 @@ function parseArgs({ argv }: { argv: string[] }): Config {
 			readOption({ argv, name: "--reference-image-url" }) ||
 			process.env.IMAROUTER_REF2V_E2E_REFERENCE_IMAGE_URL ||
 			DEFAULT_REFERENCE_IMAGE_URL,
+		useLocalReferenceFile: hasFlag({ argv, name: "--local-reference-file" }),
 		headed:
 			hasFlag({ argv, name: "--headed" }) ||
 			hasFlag({ argv, name: "--headful" }),
@@ -142,6 +144,7 @@ Options:
   --license-server-url <url>          License server base URL fallback.
   --out-dir <path>                    Screenshot/result output directory.
   --reference-image-url <url>         Public image URL to pass via --reference-images.
+  --local-reference-file              Download the reference URL in the sandbox, then pass the local file path.
   --headed, --headful                 Show the browser.
   --connect-timeout-ms <ms>           Connect/Codex ready timeout.
   --generation-timeout-ms <ms>        Ref2V generation timeout.
@@ -440,10 +443,17 @@ async function waitForRef2VReady({
 function buildGenerationPrompt({
 	root,
 	referenceImageUrl,
+	useLocalReferenceFile,
 }: {
 	root: string;
 	referenceImageUrl: string;
+	useLocalReferenceFile: boolean;
 }): string {
+	const referenceInput = useLocalReferenceFile ? "$ROOT/reference.png" : "$REF";
+	const localReferenceSetup = useLocalReferenceFile
+		? `curl -fsSL "$REF" -o "$ROOT/reference.png"
+REFERENCE_INPUT="$ROOT/reference.png"`
+		: `REFERENCE_INPUT="$REF"`;
 	return `Please run a real online QCut IMA Router Ref2V smoke test in this Daytona sandbox. Do not mock anything, do not use a different model, and do not print or write any API secret.
 
 Run this exact shell script as-is:
@@ -454,6 +464,7 @@ set -u
 ROOT="${root}"
 REF="${referenceImageUrl}"
 mkdir -p "$ROOT/generated"
+${localReferenceSetup}
 
 {
   if [ -n "\${IMAROUTER_API_KEY:-}" ]; then
@@ -474,7 +485,7 @@ qcut system models --json > "$ROOT/models.json" 2> "$ROOT/models.stderr" || true
 set +e
 QCUT_OUTPUT_DIR="$ROOT/generated" qcut gen video \
   -m imarouter_seedance_2_0_ref2v \
-  --reference-images "$REF" \
+  --reference-images "${referenceInput}" \
   -t "5 second video using the reference image, clean product turntable shot" \
   -d 5s \
   --aspect-ratio 16:9 \
@@ -496,17 +507,18 @@ fi
 
 ffprobe -v error -show_streams -show_format -of json "$video_path" > "$ROOT/ffprobe.json"
 
-python3 - "$ROOT/ref2v-result.json" "$REF" "$video_path" "$sidecar_path" "$ROOT/ffprobe.json" <<'PY'
+python3 - "$ROOT/ref2v-result.json" "$REF" "$REFERENCE_INPUT" "$video_path" "$sidecar_path" "$ROOT/ffprobe.json" <<'PY'
 import json
 import sys
 
-out, ref, video, sidecar, ffprobe = sys.argv[1:]
+out, ref, reference_input, video, sidecar, ffprobe = sys.argv[1:]
 with open(out, "w", encoding="utf-8") as handle:
     json.dump(
         {
             "status": "SUCCESS",
             "model": "imarouter_seedance_2_0_ref2v",
             "referenceImageUrl": ref,
+            "referenceInput": reference_input,
             "videoPath": video,
             "sidecarPath": sidecar,
             "ffprobePath": ffprobe,
@@ -638,6 +650,7 @@ async function main() {
 					prompt: buildGenerationPrompt({
 						root,
 						referenceImageUrl: config.referenceImageUrl,
+						useLocalReferenceFile: config.useLocalReferenceFile,
 					}),
 				});
 				readyText = await waitForRef2VReady({
@@ -728,6 +741,7 @@ async function main() {
 					url: config.url,
 					root,
 					referenceImageUrl: config.referenceImageUrl,
+					useLocalReferenceFile: config.useLocalReferenceFile,
 					outDir: config.outDir,
 					steps: state.steps,
 					readyText,

--- a/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
+++ b/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
@@ -8,6 +8,7 @@ const DEFAULT_URL = "https://quriosity.com.au/chat-agent.html";
 const DEFAULT_LICENSE_SERVER_URL =
 	"https://qcut-license-server.zdhpeter.workers.dev";
 const POLL_INTERVAL_MS = 15_000;
+const SESSION_FETCH_TIMEOUT_MS = 30_000;
 const DEFAULT_REFERENCE_IMAGE_URL =
 	"https://storage.googleapis.com/gmi-video-assests-prod/user-assets/3e51f140-4e66-4cb2-bca4-6f412e5d6113/780402b5-bbc0-4941-b029-a4ce0cdab845/gmi-videogen/generated/source_image_c4046b99-7fad-4e4d-b681-fef11bd431e3579b9b15-2a03-45a3-94e5-42fa4a8ab5a4.png";
 
@@ -327,7 +328,7 @@ async function typePromptIntoTerminal({
 	const terminal = page.locator("#agent-terminal");
 	const helperTextarea = page.locator("#agent-terminal .xterm-helper-textarea");
 	await helperTextarea.waitFor({ state: "attached", timeout: 10_000 });
-	await terminal.click({ position: { x: 260, y: 420 } });
+	await terminal.click();
 	await helperTextarea.focus();
 	await page.keyboard.type(prompt, { delay: 1 });
 	await page.waitForTimeout(750);
@@ -377,6 +378,7 @@ async function fetchSessionText({
 			context.token.length === 0
 				? undefined
 				: { Authorization: `Bearer ${context.token}` },
+		signal: AbortSignal.timeout(SESSION_FETCH_TIMEOUT_MS),
 	});
 	if (!response.ok) return null;
 	return response.text();
@@ -396,6 +398,7 @@ async function downloadSessionFile({
 			context.token.length === 0
 				? undefined
 				: { Authorization: `Bearer ${context.token}` },
+		signal: AbortSignal.timeout(SESSION_FETCH_TIMEOUT_MS),
 	});
 	if (!response.ok) return false;
 	const bytes = Buffer.from(await response.arrayBuffer());
@@ -440,6 +443,10 @@ async function waitForRef2VReady({
 	throw new Error(`timed out waiting for ${root}/ref2v-ready.txt`);
 }
 
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function buildGenerationPrompt({
 	root,
 	referenceImageUrl,
@@ -462,7 +469,7 @@ cat > /tmp/qcut-imarouter-ref2v-e2e.sh <<'SH'
 set -u
 
 ROOT="${root}"
-REF="${referenceImageUrl}"
+REF=${shellQuote(referenceImageUrl)}
 mkdir -p "$ROOT/generated"
 ${localReferenceSetup}
 
@@ -667,9 +674,15 @@ async function main() {
 					condition: readyText.includes("REF2V_READY"),
 					message: "ready marker missing",
 				});
+				let resultStatus = "";
+				try {
+					resultStatus =
+						(JSON.parse(resultText) as { status?: string }).status ?? "";
+				} catch {
+					resultStatus = "";
+				}
 				assertCondition({
-					condition:
-						resultText.includes('"status"') && resultText.includes("SUCCESS"),
+					condition: resultStatus === "SUCCESS",
 					message: "result JSON did not report SUCCESS",
 				});
 				return readyText.trim();

--- a/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
+++ b/qcut/scripts/agent-chat-imarouter-ref2v-e2e.ts
@@ -66,16 +66,19 @@ type RunState = {
 	downloads: Array<{ remotePath: string; localPath: string }>;
 };
 
+/** Read the value following a named CLI flag, or "" when the flag is absent. */
 function readOption({ argv, name }: { argv: string[]; name: string }): string {
 	const index = argv.indexOf(name);
 	if (index === -1) return "";
 	return argv[index + 1] || "";
 }
 
+/** Return true when a boolean CLI flag is present in argv. */
 function hasFlag({ argv, name }: { argv: string[]; name: string }): boolean {
 	return argv.includes(name);
 }
 
+/** Parse a numeric CLI option, falling back to defaultValue when missing or non-positive. */
 function readNumberOption({
 	argv,
 	name,
@@ -91,6 +94,7 @@ function readNumberOption({
 	return Number.isFinite(value) && value > 0 ? value : defaultValue;
 }
 
+/** Build the run Config from argv, env-var fallbacks, and defaults (exits on --help). */
 function parseArgs({ argv }: { argv: string[] }): Config {
 	if (hasFlag({ argv, name: "--help" }) || hasFlag({ argv, name: "-h" })) {
 		printHelp();
@@ -134,6 +138,7 @@ function parseArgs({ argv }: { argv: string[] }): Config {
 	};
 }
 
+/** Print CLI usage and the supported options to stdout. */
 function printHelp() {
 	console.log(`QCut IMA Router Ref2V Chat Agent E2E
 
@@ -152,10 +157,12 @@ Options:
 `);
 }
 
+/** Write a namespaced progress line to stdout. */
 function log({ message }: { message: string }) {
 	console.log(`[agent-chat-imarouter-ref2v-e2e] ${message}`);
 }
 
+/** Throw an Error with the given message when condition is false. */
 function assertCondition({
 	condition,
 	message,
@@ -166,6 +173,7 @@ function assertCondition({
 	if (!condition) throw new Error(message);
 }
 
+/** Capture a full-page screenshot into outDir and return its file path. */
 async function screenshot({
 	page,
 	outDir,
@@ -180,6 +188,10 @@ async function screenshot({
 	return path;
 }
 
+/**
+ * Run a named step: execute its action, capture a screenshot, and record a
+ * passed/failed StepResult with timing. Re-throws after recording on failure.
+ */
 async function runStep({
 	state,
 	name,
@@ -227,6 +239,7 @@ async function runStep({
 	}
 }
 
+/** Wait until the page's `window.AgentChatReady` promise resolves (30s cap). */
 async function waitForAgentChatReady({ page }: { page: Page }) {
 	await page.waitForFunction(
 		async () => {
@@ -240,12 +253,14 @@ async function waitForAgentChatReady({ page }: { page: Page }) {
 	);
 }
 
+/** Read the trimmed text of the `#agent-terminal-status` element. */
 async function readTerminalStatus({ page }: { page: Page }): Promise<string> {
 	return (
 		await page.locator("#agent-terminal-status").innerText({ timeout: 5_000 })
 	).trim();
 }
 
+/** Read the terminal's inner text, returning "" if it isn't available yet. */
 async function readTerminalText({ page }: { page: Page }): Promise<string> {
 	try {
 		return await page.locator("#agent-terminal").innerText({ timeout: 2_000 });
@@ -254,6 +269,7 @@ async function readTerminalText({ page }: { page: Page }): Promise<string> {
 	}
 }
 
+/** Wait until the terminal reports `connected` and shows the Codex banner. */
 async function waitForCodexReady({
 	page,
 	timeoutMs,
@@ -275,6 +291,11 @@ async function waitForCodexReady({
 	);
 }
 
+/**
+ * Tear down any lingering server session via the page API and the "new
+ * session" button, then wait for a clean disconnected state. Returns a
+ * human-readable summary of what was reset.
+ */
 async function resetServerSessionThroughUi({ page }: { page: Page }) {
 	await page.waitForTimeout(2_000);
 	const endedSessionId = await page.evaluate(async () => {
@@ -318,6 +339,7 @@ async function resetServerSessionThroughUi({ page }: { page: Page }) {
 		: "confirmed no active session";
 }
 
+/** Focus the xterm helper textarea, type the prompt, and submit it (Ctrl+M). */
 async function typePromptIntoTerminal({
 	page,
 	prompt,
@@ -335,6 +357,10 @@ async function typePromptIntoTerminal({
 	await page.keyboard.press("Control+M");
 }
 
+/**
+ * Read the active session's API base, auth token, and session id from the
+ * page. Throws when no agent session id is present in localStorage.
+ */
 async function getSessionContext({
 	page,
 	fallbackApiBase,
@@ -354,6 +380,7 @@ async function getSessionContext({
 	}, fallbackApiBase);
 }
 
+/** Build the session file-download URL for a given remote path. */
 function buildSessionFileUrl({
 	context,
 	remotePath,
@@ -366,6 +393,10 @@ function buildSessionFileUrl({
 	)}/files/download?path=${encodeURIComponent(remotePath)}`;
 }
 
+/**
+ * Fetch a session file as text, returning null on a non-OK response. The
+ * request is bounded by SESSION_FETCH_TIMEOUT_MS so a stall can't hang polling.
+ */
 async function fetchSessionText({
 	context,
 	remotePath,
@@ -384,6 +415,10 @@ async function fetchSessionText({
 	return response.text();
 }
 
+/**
+ * Download a session file to localPath, returning false on a non-OK response.
+ * The request is bounded by SESSION_FETCH_TIMEOUT_MS to avoid hanging downloads.
+ */
 async function downloadSessionFile({
 	context,
 	remotePath,
@@ -406,6 +441,10 @@ async function downloadSessionFile({
 	return true;
 }
 
+/**
+ * Poll the sandbox for Ref2V completion markers until ready or timeout.
+ * Throws on preflight/generation failure markers; returns the ready-file text.
+ */
 async function waitForRef2VReady({
 	context,
 	root,
@@ -443,10 +482,18 @@ async function waitForRef2VReady({
 	throw new Error(`timed out waiting for ${root}/ref2v-ready.txt`);
 }
 
+/**
+ * Wrap a value in single quotes for safe embedding in the generated shell
+ * script, escaping embedded single quotes via the `'\''` idiom.
+ */
 function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/**
+ * Build the natural-language prompt that instructs the sandbox agent to run
+ * the real IMA Router Ref2V smoke-test shell script and report REF2V_READY.
+ */
 function buildGenerationPrompt({
 	root,
 	referenceImageUrl,
@@ -549,6 +596,10 @@ After the script finishes, reply with REF2V_READY and the root path: ${root}.
 Final response should include REF2V_READY and the root path.`;
 }
 
+/**
+ * Download each remote evidence path into the run's output directory and
+ * record successful downloads on the run state.
+ */
 async function downloadEvidenceFiles({
 	state,
 	context,
@@ -571,6 +622,11 @@ async function downloadEvidenceFiles({
 	}
 }
 
+/**
+ * Orchestrate the full E2E run: launch the browser, reset and connect a
+ * session, drive the Ref2V generation, download evidence, write result.json,
+ * and exit with a status code reflecting success or failure.
+ */
 async function main() {
 	const config = parseArgs({ argv: process.argv.slice(2) });
 	mkdirSync(config.outDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Wire CLI `--reference-images` into IMA Router Ref2V requests.
- Resolve local, public HTTPS, and `asset://` references into IMA Router-compatible `images` payloads.
- Publish and deploy the new CLI image for online Daytona agents, then add an online chat-agent E2E harness and evidence docs.

## Root Cause

The CLI accepted `--reference-images`, but IMA Router Ref2V models were not staging those references into the executor path that uploads/submits them to `/v1/videos`.

## Validation

- `bunx vitest run electron/native-pipeline/execution/__tests__/step-executors-imarouter-ref2v.test.ts electron/native-pipeline/cli/cli-runner/__tests__/handler-generate-duration.test.ts`
- `bun --cwd packages/qcut-relay test`
- `bun --cwd packages/license-server test`
- `cd electron && bun x tsc --noEmit`
- `bunx biome check ...`
- `QCUT_VERSION=cli-image-v12-ref2v-20260526205824 bun run build:cli-image`
- GitHub Actions CLI image publish/smoke: https://github.com/Quriosity-agent/qcut/actions/runs/26475075951
- Online sandbox chat-agent Ref2V E2E passed; evidence recorded in `docs/task/daytona-supabase-agent/fix-imarouter-reference-images/build-deploy-online-e2e-result.md`

## Deploys

- Relay: `acf68421-181f-40d6-a023-8f8be78dedce`
- License server: `d57a6ddb-4fe0-49a9-bd28-c8cf2a6249ff`
- CLI image: `ghcr.io/quriosity-agent/qcut-cli:cli-image-v12-ref2v-20260526205824`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded reference-image support for Ref2V video generation and CLI handling.
  * New automated browser E2E script to validate online Ref2V runs and capture artifacts.

* **Bug Fixes**
  * Improved upload reliability with automatic fallback to a local upload key when proxy upload fails.
  * Hardened E2E harness prompting to reduce preflight mismatch failures.

* **Tests**
  * Added tests covering reference-image staging, Ref2V execution paths, and upload fallback behavior.

* **Documentation**
  * New docs: online E2E results, secret-check, local-env guidance, and local smoke results.

* **Chores**
  * Updated CLI image tag used by the license-server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->