### PR TITLE
[codex] Add video review guidance for online agents

### DIFF
--- a/qcut/.agents/skills/native-cli/SKILL.md
+++ b/qcut/.agents/skills/native-cli/SKILL.md
@@ -97,6 +97,50 @@ supports `--output-dir/-o`, or move final user-requested files into
 `/tmp/qcut-output` before finishing. Keep scratch files and package installs
 under `/tmp/qcut-tools` or `/tmp`.
 
+## Video Review / 审片
+
+Use QCut's review mode when the user asks for video review, 审片, timestamped
+feedback, CSV/JSON comments, or human-style short-drama notes. Do not use
+generic `aicp analyze-video` for this workflow.
+
+```bash
+QCUT_DEBUG_OPENROUTER_VIDEO=1 \
+QCUT_OUTPUT_DIR=/tmp/qcut-output \
+qcut analyze video \
+  --video-url /tmp/qcut-input/video.mp4 \
+  --analysis-type review \
+  --review-language zh \
+  --max-tokens 16000 \
+  -m openrouter_gemini_3_5_flash_video \
+  --json \
+  -o /tmp/qcut-output
+```
+
+For English review comments, use `--review-language en`. The review output is
+written under `/tmp/qcut-output`:
+
+```text
+review-comments.json
+review-comments.csv
+review-feedback-browser.html
+review-feedback-summary.html
+review-agent-report.md
+review-agent-prompts/
+raw-analysis.json
+review-split-manifest.json   # only when the video is split
+```
+
+Long local videos are split automatically when the estimated base64 payload is
+too large. If a part fails because OpenRouter returned truncated JSON, inspect
+`review-split-manifest.json` and rerun the failed part rather than rerunning the
+whole episode. The parser salvages complete comments from partial JSON arrays,
+so non-empty `raw-analysis.json` with empty CSV usually means the model did not
+emit complete comment objects.
+
+In Daytona Chat Agent sessions, local host paths such as `/Users/peter/...` are
+not available. First upload the file into the session, use its `/tmp/qcut-input`
+path, or use a public/network URL that the model provider can read.
+
 ### Command Groups
 
 | Group | Description | Example |

--- a/qcut/.agents/skills/native-cli/references/REFERENCE.md
+++ b/qcut/.agents/skills/native-cli/references/REFERENCE.md
@@ -116,10 +116,23 @@ Analyze a video with AI vision.
 | `--input` | `-i` | string | | Video file or URL (required) |
 | `--video-url` | | string | | Alias for input |
 | `--model` | `-m` | string | `openrouter_gemini_3_5_flash_video` | Vision model |
-| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript` |
+| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript`, `review` |
 | `--prompt` | | string | | Custom prompt (overrides analysis-type) |
 | `--text` | `-t` | string | | Alias for prompt |
 | `--output-format` | `-f` | string | `md` | `md`, `json`, `both` |
+| `--review-language` | | string | `zh` | Review prompt language: `zh` or `en` |
+| `--review-prompt-dir` | | string | | Custom directory for review prompt markdown files |
+| `--max-tokens` | | integer | `12000` for review | Maximum model output tokens |
+
+Review mode writes `review-comments.json`, `review-comments.csv`,
+`review-feedback-browser.html`, `review-feedback-summary.html`,
+`review-agent-report.md`, `raw-analysis.json`, and a
+`review-agent-prompts/` snapshot to the output directory. Oversized local
+videos are split automatically and also write `review-split-manifest.json`.
+
+```bash
+qcut analyze video -i video.mp4 --analysis-type review --review-language zh --max-tokens 16000 --json -o /tmp/qcut-output
+```
 
 ### `analyze transcribe`
 

--- a/qcut/.agents/skills/qcut-toolkit/ai-content-pipeline/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/ai-content-pipeline/SKILL.md
@@ -148,6 +148,62 @@ aicp analyze-video -i video.mp4 -t transcribe
 aicp analyze-video -i video.mp4 -t describe -f json
 ```
 
+### Review Video (QCut CLI)
+
+Use QCut's review path when the user asks for video review, 审片, review
+comments, timestamped feedback, CSV/JSON review export, or human-style short
+drama notes. Do not use generic `aicp analyze-video` for this workflow.
+
+```bash
+QCUT_OUTPUT_DIR=/tmp/qcut-output \
+bun run qcut analyze video \
+  --video-url /path/to/video.mp4 \
+  --analysis-type review \
+  --review-language zh \
+  -m openrouter_gemini_3_5_flash_video \
+  --json
+```
+
+Useful options:
+
+```bash
+--review-language zh          # Chinese human review style
+--review-language en          # English review output
+--max-tokens 16000            # Larger response budget for long reviews
+```
+
+Useful debug environment:
+
+```bash
+QCUT_DEBUG_OPENROUTER_VIDEO=1
+QCUT_OPENROUTER_HEARTBEAT=1
+QCUT_REVIEW_SPLIT_MAX_PAYLOAD_CHARS=18000000
+```
+
+Review outputs are written under `QCUT_OUTPUT_DIR`:
+
+```text
+review-comments.json
+review-comments.csv
+review-feedback-browser.html
+review-feedback-summary.html
+review-agent-report.md
+review-agent-prompts/
+raw-analysis.json
+review-split-manifest.json   # present when the video was split
+```
+
+Long local videos are split automatically when the estimated base64 payload is
+too large. If one split part fails because OpenRouter returned truncated JSON,
+rerun only that part and merge the comments; do not rerun the full episode
+unless the split files are missing.
+
+For Daytona/online agent sessions, remember that local host paths such as
+`/Users/peter/...` are not available inside the sandbox. Upload the source file
+to the sandbox first, or pass a public/network URL that the model provider can
+read. Always write outputs to `/tmp/qcut-output` so the online agent artifact
+poller can find and download them.
+
 ### Analyze Video (HTTP API)
 
 QCut exposes video analysis through the Claude HTTP server (port 8765).

--- a/qcut/.claude/skills/native-cli/SKILL.md
+++ b/qcut/.claude/skills/native-cli/SKILL.md
@@ -97,6 +97,50 @@ supports `--output-dir/-o`, or move final user-requested files into
 `/tmp/qcut-output` before finishing. Keep scratch files and package installs
 under `/tmp/qcut-tools` or `/tmp`.
 
+## Video Review / 审片
+
+Use QCut's review mode when the user asks for video review, 审片, timestamped
+feedback, CSV/JSON comments, or human-style short-drama notes. Do not use
+generic `aicp analyze-video` for this workflow.
+
+```bash
+QCUT_DEBUG_OPENROUTER_VIDEO=1 \
+QCUT_OUTPUT_DIR=/tmp/qcut-output \
+qcut analyze video \
+  --video-url /tmp/qcut-input/video.mp4 \
+  --analysis-type review \
+  --review-language zh \
+  --max-tokens 16000 \
+  -m openrouter_gemini_3_5_flash_video \
+  --json \
+  -o /tmp/qcut-output
+```
+
+For English review comments, use `--review-language en`. The review output is
+written under `/tmp/qcut-output`:
+
+```text
+review-comments.json
+review-comments.csv
+review-feedback-browser.html
+review-feedback-summary.html
+review-agent-report.md
+review-agent-prompts/
+raw-analysis.json
+review-split-manifest.json   # only when the video is split
+```
+
+Long local videos are split automatically when the estimated base64 payload is
+too large. If a part fails because OpenRouter returned truncated JSON, inspect
+`review-split-manifest.json` and rerun the failed part rather than rerunning the
+whole episode. The parser salvages complete comments from partial JSON arrays,
+so non-empty `raw-analysis.json` with empty CSV usually means the model did not
+emit complete comment objects.
+
+In Daytona Chat Agent sessions, local host paths such as `/Users/peter/...` are
+not available. First upload the file into the session, use its `/tmp/qcut-input`
+path, or use a public/network URL that the model provider can read.
+
 ### Command Groups
 
 | Group | Description | Example |

--- a/qcut/.claude/skills/native-cli/references/REFERENCE.md
+++ b/qcut/.claude/skills/native-cli/references/REFERENCE.md
@@ -116,10 +116,23 @@ Analyze a video with AI vision.
 | `--input` | `-i` | string | | Video file or URL (required) |
 | `--video-url` | | string | | Alias for input |
 | `--model` | `-m` | string | `openrouter_gemini_3_5_flash_video` | Vision model |
-| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript` |
+| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript`, `review` |
 | `--prompt` | | string | | Custom prompt (overrides analysis-type) |
 | `--text` | `-t` | string | | Alias for prompt |
 | `--output-format` | `-f` | string | `md` | `md`, `json`, `both` |
+| `--review-language` | | string | `zh` | Review prompt language: `zh` or `en` |
+| `--review-prompt-dir` | | string | | Custom directory for review prompt markdown files |
+| `--max-tokens` | | integer | `12000` for review | Maximum model output tokens |
+
+Review mode writes `review-comments.json`, `review-comments.csv`,
+`review-feedback-browser.html`, `review-feedback-summary.html`,
+`review-agent-report.md`, `raw-analysis.json`, and a
+`review-agent-prompts/` snapshot to the output directory. Oversized local
+videos are split automatically and also write `review-split-manifest.json`.
+
+```bash
+qcut analyze video -i video.mp4 --analysis-type review --review-language zh --max-tokens 16000 --json -o /tmp/qcut-output
+```
 
 ### `analyze transcribe`
 

--- a/qcut/packages/agent-worker/src/daytona/constants.ts
+++ b/qcut/packages/agent-worker/src/daytona/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
 export const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 export const TIMEOUT_SECONDS = 30 * 60;
 export const DAYTONA_CREATE_TIMEOUT_SECONDS = 300;

--- a/qcut/packages/agent-worker/src/run-container.ts
+++ b/qcut/packages/agent-worker/src/run-container.ts
@@ -30,6 +30,7 @@ const CODEX_SANDBOX_CONTEXT = [
 	`Related native-cli references live under ${NATIVE_CLI_SKILL_DIR}/references and editor docs live under ${NATIVE_CLI_SKILL_DIR}/editor.`,
 	"Read that skill before running nontrivial QCut CLI workflows or when command syntax is unclear.",
 	"yt-dlp and deno are available for authorized video download probes.",
+	"Use `qcut analyze video --analysis-type review --review-language zh -m openrouter_gemini_3_5_flash_video --json -o /tmp/qcut-output` for video review, 审片, timestamped comments, and CSV/JSON review exports.",
 	"For long-running shell commands, stream user-visible stdout with tee -a /tmp/qcut-output/codex-live-stdout.log.",
 	"Put temporary tools, caches, and package installs under /tmp/qcut-tools or /tmp, not /tmp/qcut-output.",
 	"Write only final user-requested files and small diagnostic summaries/logs under /tmp/qcut-output.",

--- a/qcut/packages/agent-worker/src/run-on-daytona.command.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.command.test.ts
@@ -153,6 +153,9 @@ describe("buildDaytonaEnv", () => {
 		);
 		expect(
 			Buffer.from(env.QCUT_CODEX_PROMPT_B64, "base64").toString("utf8")
+		).toContain("qcut analyze video --analysis-type review");
+		expect(
+			Buffer.from(env.QCUT_CODEX_PROMPT_B64, "base64").toString("utf8")
 		).toContain("User task:\nExplain QCut's agent path.");
 	});
 

--- a/qcut/packages/agent-worker/src/run-on-daytona.ephemeral.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ephemeral.test.ts
@@ -154,7 +154,7 @@ describe("runOnDaytona ephemeral jobs", () => {
 		expect(createCalls).toEqual([
 			{
 				image:
-					"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923",
+					"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56",
 				envVars: {
 					QCUT_SESSION_ROLE: "agent",
 					OPENAI_API_KEY: "sk-test",

--- a/qcut/packages/agent-worker/src/run-on-daytona.sessions.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.sessions.test.ts
@@ -22,7 +22,7 @@ describe("runOnDaytona persisted sessions", () => {
 					status: "active",
 					provider_session_id: "sandbox-persisted",
 					image_tag:
-						"ghcr.io/quriosity-agent/qcut-cli@sha256:48aa813162bf7a4b20d38ec694ccc0e1ffc9b61dcdc8c9e1447749d77b500923",
+						"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56",
 					last_active_at: "2026-05-14T00:00:00.000Z",
 					expires_at: "2099-01-01T00:00:00.000Z",
 					end_reason: null,

--- a/qcut/packages/license-server/src/routes/agent-parts/constants.ts
+++ b/qcut/packages/license-server/src/routes/agent-parts/constants.ts
@@ -16,9 +16,9 @@ export const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
 
 // Pinned to an immutable manifest digest so the default agent image cannot
 // drift if the upstream tag is republished. Human-readable tag for this
-// digest: `imarouter-gpt-image-20260519061748`.
+// digest: `review-agent-20260604025944`.
 export const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:c266afcb3a0da99ef0ff191bb4f929ada47f4a7f25b118228cfb6acc0ce575ca";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
 
 export const TEXT_ARTIFACT_KINDS = new Set(["json", "log"]);
 

--- a/qcut/packages/license-server/src/routes/agent.test-utils.ts
+++ b/qcut/packages/license-server/src/routes/agent.test-utils.ts
@@ -53,7 +53,7 @@ export const {
 } = await import("./agent");
 
 export const DEFAULT_PINNED_QCUT_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:c266afcb3a0da99ef0ff191bb4f929ada47f4a7f25b118228cfb6acc0ce575ca";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
 
 const ORIGINAL_ENV = { ...process.env };
 

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -17,8 +17,8 @@ CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
 QCUT_AGENT_ALLOW_DEFAULT_USER = "true"
 # Pinned to immutable digest so retags can't silently change sandbox runtime.
-# Human-readable tag: cli-image-v12-ref2v-20260526205824
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:ff56c1087655b6e1893dc44766a4a9a6e3ae156e6b625f77871624a9fbe79cf6"
+# Human-readable tag: review-agent-20260604025944
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY

--- a/qcut/resources/default-skills/native-cli/SKILL.md
+++ b/qcut/resources/default-skills/native-cli/SKILL.md
@@ -97,6 +97,50 @@ supports `--output-dir/-o`, or move final user-requested files into
 `/tmp/qcut-output` before finishing. Keep scratch files and package installs
 under `/tmp/qcut-tools` or `/tmp`.
 
+## Video Review / 审片
+
+Use QCut's review mode when the user asks for video review, 审片, timestamped
+feedback, CSV/JSON comments, or human-style short-drama notes. Do not use
+generic `aicp analyze-video` for this workflow.
+
+```bash
+QCUT_DEBUG_OPENROUTER_VIDEO=1 \
+QCUT_OUTPUT_DIR=/tmp/qcut-output \
+qcut analyze video \
+  --video-url /tmp/qcut-input/video.mp4 \
+  --analysis-type review \
+  --review-language zh \
+  --max-tokens 16000 \
+  -m openrouter_gemini_3_5_flash_video \
+  --json \
+  -o /tmp/qcut-output
+```
+
+For English review comments, use `--review-language en`. The review output is
+written under `/tmp/qcut-output`:
+
+```text
+review-comments.json
+review-comments.csv
+review-feedback-browser.html
+review-feedback-summary.html
+review-agent-report.md
+review-agent-prompts/
+raw-analysis.json
+review-split-manifest.json   # only when the video is split
+```
+
+Long local videos are split automatically when the estimated base64 payload is
+too large. If a part fails because OpenRouter returned truncated JSON, inspect
+`review-split-manifest.json` and rerun the failed part rather than rerunning the
+whole episode. The parser salvages complete comments from partial JSON arrays,
+so non-empty `raw-analysis.json` with empty CSV usually means the model did not
+emit complete comment objects.
+
+In Daytona Chat Agent sessions, local host paths such as `/Users/peter/...` are
+not available. First upload the file into the session, use its `/tmp/qcut-input`
+path, or use a public/network URL that the model provider can read.
+
 ### Command Groups
 
 | Group | Description | Example |

--- a/qcut/resources/default-skills/native-cli/references/REFERENCE.md
+++ b/qcut/resources/default-skills/native-cli/references/REFERENCE.md
@@ -116,10 +116,23 @@ Analyze a video with AI vision.
 | `--input` | `-i` | string | | Video file or URL (required) |
 | `--video-url` | | string | | Alias for input |
 | `--model` | `-m` | string | `openrouter_gemini_3_5_flash_video` | Vision model |
-| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript` |
+| `--analysis-type` | | string | `timeline` | `timeline`, `summary`, `description`, `transcript`, `review` |
 | `--prompt` | | string | | Custom prompt (overrides analysis-type) |
 | `--text` | `-t` | string | | Alias for prompt |
 | `--output-format` | `-f` | string | `md` | `md`, `json`, `both` |
+| `--review-language` | | string | `zh` | Review prompt language: `zh` or `en` |
+| `--review-prompt-dir` | | string | | Custom directory for review prompt markdown files |
+| `--max-tokens` | | integer | `12000` for review | Maximum model output tokens |
+
+Review mode writes `review-comments.json`, `review-comments.csv`,
+`review-feedback-browser.html`, `review-feedback-summary.html`,
+`review-agent-report.md`, `raw-analysis.json`, and a
+`review-agent-prompts/` snapshot to the output directory. Oversized local
+videos are split automatically and also write `review-split-manifest.json`.
+
+```bash
+qcut analyze video -i video.mp4 --analysis-type review --review-language zh --max-tokens 16000 --json -o /tmp/qcut-output
+```
 
 ### `analyze transcribe`
 

--- a/qcut/scripts/agent-chat-e2e.ts
+++ b/qcut/scripts/agent-chat-e2e.ts
@@ -56,6 +56,7 @@ type RunState = {
 	steps: StepResult[];
 };
 
+/** Return the value following a single-value CLI option, or "" if absent. */
 function readOption({ argv, name }: { argv: string[]; name: string }): string {
 	const index = argv.indexOf(name);
 	if (index === -1) {
@@ -64,6 +65,11 @@ function readOption({ argv, name }: { argv: string[]; name: string }): string {
 	return argv[index + 1] || "";
 }
 
+/**
+ * Collect every value for a repeatable CLI option (e.g. `--expect-artifact`).
+ * Flag-like values (starting with `-`) are skipped so a value-less option does
+ * not accidentally swallow the next flag.
+ */
 function readRepeatedOptions({
 	argv,
 	name,
@@ -83,10 +89,12 @@ function readRepeatedOptions({
 	return values;
 }
 
+/** Return whether a boolean CLI flag is present in argv. */
 function hasFlag({ argv, name }: { argv: string[]; name: string }): boolean {
 	return argv.includes(name);
 }
 
+/** Read a positive, finite numeric CLI option, falling back to defaultValue. */
 function readNumberOption({
 	argv,
 	name,
@@ -104,6 +112,7 @@ function readNumberOption({
 	return Number.isFinite(value) && value > 0 ? value : defaultValue;
 }
 
+/** Parse `filename=substring` pairs into artifact-text assertion objects. */
 function parseExpectedArtifactText({
 	values,
 }: {
@@ -129,6 +138,7 @@ function parseExpectedArtifactText({
 	return expectations;
 }
 
+/** Resolve the custom terminal prompt from `--terminal-prompt-file` or `--terminal-prompt`. */
 function readTerminalPrompt({ argv }: { argv: string[] }): string {
 	const promptFile = readOption({ argv, name: "--terminal-prompt-file" });
 	if (promptFile.length > 0) {
@@ -137,6 +147,7 @@ function readTerminalPrompt({ argv }: { argv: string[] }): string {
 	return readOption({ argv, name: "--terminal-prompt" }).trim();
 }
 
+/** Build the run {@link Config} from raw CLI argv, applying env and defaults. */
 function parseArgs({ argv }: { argv: string[] }): Config {
 	if (hasFlag({ argv, name: "--help" }) || hasFlag({ argv, name: "-h" })) {
 		printHelp();
@@ -208,6 +219,7 @@ function parseArgs({ argv }: { argv: string[] }): Config {
 	};
 }
 
+/** Print CLI usage and the full option list to stdout. */
 function printHelp() {
 	console.log(`QCut Chat Agent E2E
 
@@ -236,10 +248,12 @@ Options:
 `);
 }
 
+/** Write a namespaced `[agent-chat-e2e]` line to the console. */
 function log({ message }: { message: string }) {
 	console.log(`[agent-chat-e2e] ${message}`);
 }
 
+/** Capture a full-page screenshot into outDir and return its file path. */
 async function screenshot({
 	page,
 	outDir,
@@ -254,6 +268,7 @@ async function screenshot({
 	return path;
 }
 
+/** Read a selector's innerText, returning "" if it is not found within 2s. */
 async function readText({
 	page,
 	selector,
@@ -268,20 +283,28 @@ async function readText({
 	}
 }
 
+/** Read the visible text of the terminal pane. */
 async function readTerminalText({ page }: { page: Page }): Promise<string> {
 	return readText({ page, selector: "#agent-terminal" });
 }
 
+/** Read and trim the terminal connection status (e.g. "connected"). */
 async function readTerminalStatus({ page }: { page: Page }): Promise<string> {
 	return (
 		await page.locator("#agent-terminal-status").innerText({ timeout: 5_000 })
 	).trim();
 }
 
+/** Read the text of the terminal debug pane (relay ack diagnostics). */
 async function readTerminalDebug({ page }: { page: Page }): Promise<string> {
 	return readText({ page, selector: "#agent-terminal-debug" });
 }
 
+/**
+ * Run a named test step: execute its action, screenshot the result, and record
+ * a passed/failed {@link StepResult}. Re-throws on failure after capturing a
+ * `-failed` screenshot.
+ */
 async function runStep({
 	state,
 	name,
@@ -329,6 +352,7 @@ async function runStep({
 	}
 }
 
+/** Throw an Error with the given message when condition is false. */
 function assertCondition({
 	condition,
 	message,
@@ -341,6 +365,7 @@ function assertCondition({
 	}
 }
 
+/** When enabled, serve the local agent-chat.js for the page's JS request. */
 async function setupLocalJsRoute({
 	page,
 	enabled,
@@ -361,6 +386,7 @@ async function setupLocalJsRoute({
 	});
 }
 
+/** Wait until the terminal reports "connected" and shows the OpenAI Codex banner. */
 async function waitForCodexReady({
 	page,
 	timeoutMs,
@@ -382,12 +408,14 @@ async function waitForCodexReady({
 	);
 }
 
+/** Read the agent session id persisted in localStorage, or "" if none. */
 async function readStoredAgentSessionId({ page }: { page: Page }) {
 	return page.evaluate(
 		() => window.localStorage.getItem("qcut_agent_session_id") || ""
 	);
 }
 
+/** Wait for the debug pane to show a relay input-ack line (`ack #N N bytes`). */
 async function waitForRelayInputAck({ page }: { page: Page }) {
 	await page.waitForFunction(
 		() => {
@@ -400,6 +428,10 @@ async function waitForRelayInputAck({ page }: { page: Page }) {
 	);
 }
 
+/**
+ * Connect to establish a server session, then start a fresh one via the UI.
+ * Returns the ended session id (or a note when none was stored).
+ */
 async function resetServerSessionThroughUi({
 	page,
 	timeoutMs,
@@ -441,6 +473,10 @@ async function resetServerSessionThroughUi({
 		: "reset without stored session";
 }
 
+/**
+ * Type a prompt into the terminal, submit it, and wait for the relay ack.
+ * When echoNeedle is set, also wait until the terminal echoes that text.
+ */
 async function typePromptIntoTerminal({
 	page,
 	prompt,
@@ -471,6 +507,7 @@ async function typePromptIntoTerminal({
 	}
 }
 
+/** Wait until the given filename appears in the artifacts pane. */
 async function waitForArtifact({
 	page,
 	filename,
@@ -491,6 +528,7 @@ async function waitForArtifact({
 	);
 }
 
+/** Return the `data-path` of every artifact tile in the artifacts pane. */
 async function readArtifactPaths({ page }: { page: Page }): Promise<string[]> {
 	return page.evaluate(() =>
 		Array.from(document.querySelectorAll("#agent-artifacts .sandbox-file-tile"))
@@ -499,6 +537,7 @@ async function readArtifactPaths({ page }: { page: Page }): Promise<string[]> {
 	);
 }
 
+/** Wait for an image artifact whose filename starts with namePrefix, returning that filename. */
 async function waitForImageArtifact({
 	page,
 	namePrefix,
@@ -536,6 +575,7 @@ async function waitForImageArtifact({
 	return match;
 }
 
+/** Click an artifact row's download button and save the file under outDir. */
 async function downloadArtifactWithButton({
 	page,
 	filename,
@@ -557,6 +597,7 @@ async function downloadArtifactWithButton({
 	return targetPath;
 }
 
+/** Fetch an artifact's text content via the session's download API from the page context. */
 async function fetchArtifactTextFromPage({
 	page,
 	filename,
@@ -593,6 +634,7 @@ async function fetchArtifactTextFromPage({
 	);
 }
 
+/** Click disconnect and wait until the terminal status becomes "disconnected". */
 async function disconnectTerminal({ page }: { page: Page }) {
 	await page.locator("#agent-terminal-disconnect").click();
 	await page.waitForFunction(
@@ -604,6 +646,10 @@ async function disconnectTerminal({ page }: { page: Page }) {
 	);
 }
 
+/**
+ * Entry point: parse CLI args, drive the full chat-agent E2E flow through its
+ * steps, write results/screenshots to the out dir, and exit non-zero on failure.
+ */
 async function main() {
 	const config = parseArgs({ argv: process.argv.slice(2) });
 	mkdirSync(config.outDir, { recursive: true });

--- a/qcut/scripts/agent-chat-e2e.ts
+++ b/qcut/scripts/agent-chat-e2e.ts
@@ -75,8 +75,10 @@ function readRepeatedOptions({
 	for (let index = 0; index < argv.length; index += 1) {
 		if (argv[index] !== name) continue;
 		const value = argv[index + 1] || "";
-		if (value.length > 0) values.push(value);
-		index += 1;
+		if (value.length > 0 && !value.startsWith("-")) {
+			values.push(value);
+			index += 1;
+		}
 	}
 	return values;
 }
@@ -717,6 +719,11 @@ async function main() {
 						});
 					}
 					for (const expectation of config.expectedArtifactText) {
+						await waitForArtifact({
+							page,
+							filename: expectation.filename,
+							timeoutMs: config.artifactTimeoutMs,
+						});
 						const fetchedText = await fetchArtifactTextFromPage({
 							page,
 							filename: expectation.filename,

--- a/qcut/scripts/agent-chat-e2e.ts
+++ b/qcut/scripts/agent-chat-e2e.ts
@@ -42,6 +42,10 @@ type Config = {
 	promptTimeoutMs: number;
 	artifactTimeoutMs: number;
 	resetSessionBeforeConnect: boolean;
+	terminalPrompt: string;
+	terminalPromptEchoNeedle: string;
+	expectedArtifacts: string[];
+	expectedArtifactText: Array<{ filename: string; contains: string }>;
 };
 
 type RunState = {
@@ -58,6 +62,23 @@ function readOption({ argv, name }: { argv: string[]; name: string }): string {
 		return "";
 	}
 	return argv[index + 1] || "";
+}
+
+function readRepeatedOptions({
+	argv,
+	name,
+}: {
+	argv: string[];
+	name: string;
+}): string[] {
+	const values: string[] = [];
+	for (let index = 0; index < argv.length; index += 1) {
+		if (argv[index] !== name) continue;
+		const value = argv[index + 1] || "";
+		if (value.length > 0) values.push(value);
+		index += 1;
+	}
+	return values;
 }
 
 function hasFlag({ argv, name }: { argv: string[]; name: string }): boolean {
@@ -79,6 +100,39 @@ function readNumberOption({
 	}
 	const value = Number(raw);
 	return Number.isFinite(value) && value > 0 ? value : defaultValue;
+}
+
+function parseExpectedArtifactText({
+	values,
+}: {
+	values: string[];
+}): Array<{ filename: string; contains: string }> {
+	const expectations: Array<{ filename: string; contains: string }> = [];
+	for (const value of values) {
+		const separator = value.indexOf("=");
+		if (separator <= 0) {
+			throw new Error(
+				`--expect-artifact-text must use filename=substring, got ${value}`
+			);
+		}
+		const filename = value.slice(0, separator).trim();
+		const contains = value.slice(separator + 1);
+		if (filename.length === 0 || contains.length === 0) {
+			throw new Error(
+				`--expect-artifact-text must include both filename and substring, got ${value}`
+			);
+		}
+		expectations.push({ filename, contains });
+	}
+	return expectations;
+}
+
+function readTerminalPrompt({ argv }: { argv: string[] }): string {
+	const promptFile = readOption({ argv, name: "--terminal-prompt-file" });
+	if (promptFile.length > 0) {
+		return readFileSync(resolve(promptFile), "utf8").trim();
+	}
+	return readOption({ argv, name: "--terminal-prompt" }).trim();
 }
 
 function parseArgs({ argv }: { argv: string[] }): Config {
@@ -134,6 +188,21 @@ function parseArgs({ argv }: { argv: string[] }): Config {
 			argv,
 			name: "--skip-session-reset",
 		}),
+		terminalPrompt: readTerminalPrompt({ argv }),
+		terminalPromptEchoNeedle: readOption({
+			argv,
+			name: "--terminal-prompt-echo-needle",
+		}),
+		expectedArtifacts: readRepeatedOptions({
+			argv,
+			name: "--expect-artifact",
+		}),
+		expectedArtifactText: parseExpectedArtifactText({
+			values: readRepeatedOptions({
+				argv,
+				name: "--expect-artifact-text",
+			}),
+		}),
 	};
 }
 
@@ -157,6 +226,11 @@ Options:
   --prompt-timeout-ms <ms>            Prompt completion timeout. Default: 180000.
   --artifact-timeout-ms <ms>          Artifact visibility timeout. Default: 180000.
   --skip-session-reset                Reuse the current active server-side session.
+  --terminal-prompt <text>            Run this custom prompt after Codex connects.
+  --terminal-prompt-file <path>       Read the custom prompt from a file.
+  --terminal-prompt-echo-needle <str> Wait until terminal echoes this text after input.
+  --expect-artifact <filename>        Wait for an artifact filename. Repeatable.
+  --expect-artifact-text <file=text>  Download artifact and assert it contains text. Repeatable.
 `);
 }
 
@@ -621,161 +695,207 @@ async function main() {
 			},
 		});
 
-		const artifactFilename = `terminal-image-e2e-${runId}.txt`;
-		const artifactText = `qcut image generated ${runId}`;
-		const imageNamePrefix = `terminal-image-e2e-${runId}`;
-		let imageFilename = "";
-		await runStep({
-			state,
-			name: "direct terminal qcut image generation creates artifacts",
-			screenshotName: "05-artifact-visible",
-			action: async () => {
-				await typePromptIntoTerminal({
-					page,
-					prompt: `Run qcut CLI image generation in the sandbox: qcut gen image -t "e2e ${runId} small blue square icon on a clean white background" --json -o /tmp/qcut-output. After it succeeds, copy one generated image to /tmp/qcut-output/${imageNamePrefix} with the same image extension, write "${artifactText}" into /tmp/qcut-output/${artifactFilename}, and reply with IMAGE_DONE_${runId} plus the artifact paths.`,
-					echoNeedle: imageNamePrefix,
-				});
-				await waitForArtifact({
-					page,
-					filename: artifactFilename,
-					timeoutMs: config.artifactTimeoutMs,
-				});
-				imageFilename = await waitForImageArtifact({
-					page,
-					namePrefix: imageNamePrefix,
-					timeoutMs: config.artifactTimeoutMs,
-				});
-				const debugText = await readTerminalDebug({ page });
-				assertCondition({
-					condition: /ack #\d+ \d+ bytes/.test(debugText),
-					message: `expected relay ack after image prompt, got ${debugText}`,
-				});
-				assertCondition({
-					condition: !debugText.includes("no relay ack"),
-					message: `unexpected stale ack warning after image prompt: ${debugText}`,
-				});
-				return `marker=${artifactFilename}; image=${imageFilename}; debug=${debugText}`;
-			},
-		});
+		if (config.terminalPrompt.length > 0) {
+			await runStep({
+				state,
+				name: "custom terminal prompt creates expected artifacts",
+				screenshotName: "05-custom-terminal-prompt",
+				action: async () => {
+					await typePromptIntoTerminal({
+						page,
+						prompt: config.terminalPrompt,
+						echoNeedle:
+							config.terminalPromptEchoNeedle ||
+							config.expectedArtifacts[0] ||
+							"",
+					});
+					for (const filename of config.expectedArtifacts) {
+						await waitForArtifact({
+							page,
+							filename,
+							timeoutMs: config.artifactTimeoutMs,
+						});
+					}
+					for (const expectation of config.expectedArtifactText) {
+						const fetchedText = await fetchArtifactTextFromPage({
+							page,
+							filename: expectation.filename,
+							licenseServerUrl: config.licenseServerUrl,
+						});
+						assertCondition({
+							condition: fetchedText.includes(expectation.contains),
+							message: `${expectation.filename} did not contain ${expectation.contains}`,
+						});
+					}
+					const debugText = await readTerminalDebug({ page });
+					assertCondition({
+						condition: /ack #\d+ \d+ bytes/.test(debugText),
+						message: `expected relay ack after custom prompt, got ${debugText}`,
+					});
+					assertCondition({
+						condition: !debugText.includes("no relay ack"),
+						message: `unexpected stale ack warning after custom prompt: ${debugText}`,
+					});
+					return `artifacts=${config.expectedArtifacts.join(",")}; debug=${debugText}`;
+				},
+			});
+		} else {
+			const artifactFilename = `terminal-image-e2e-${runId}.txt`;
+			const artifactText = `qcut image generated ${runId}`;
+			const imageNamePrefix = `terminal-image-e2e-${runId}`;
+			let imageFilename = "";
+			await runStep({
+				state,
+				name: "direct terminal qcut image generation creates artifacts",
+				screenshotName: "05-artifact-visible",
+				action: async () => {
+					await typePromptIntoTerminal({
+						page,
+						prompt: `Run qcut CLI image generation in the sandbox: qcut gen image -t "e2e ${runId} small blue square icon on a clean white background" --json -o /tmp/qcut-output. After it succeeds, copy one generated image to /tmp/qcut-output/${imageNamePrefix} with the same image extension, write "${artifactText}" into /tmp/qcut-output/${artifactFilename}, and reply with IMAGE_DONE_${runId} plus the artifact paths.`,
+						echoNeedle: imageNamePrefix,
+					});
+					await waitForArtifact({
+						page,
+						filename: artifactFilename,
+						timeoutMs: config.artifactTimeoutMs,
+					});
+					imageFilename = await waitForImageArtifact({
+						page,
+						namePrefix: imageNamePrefix,
+						timeoutMs: config.artifactTimeoutMs,
+					});
+					const debugText = await readTerminalDebug({ page });
+					assertCondition({
+						condition: /ack #\d+ \d+ bytes/.test(debugText),
+						message: `expected relay ack after image prompt, got ${debugText}`,
+					});
+					assertCondition({
+						condition: !debugText.includes("no relay ack"),
+						message: `unexpected stale ack warning after image prompt: ${debugText}`,
+					});
+					return `marker=${artifactFilename}; image=${imageFilename}; debug=${debugText}`;
+				},
+			});
 
-		const secondArtifactFilename = `terminal-second-input-e2e-${runId}.txt`;
-		const secondArtifactText = `second input ok ${runId}`;
-		await runStep({
-			state,
-			name: "second terminal input works after image generation",
-			screenshotName: "06-second-input-after-image",
-			action: async () => {
-				await typePromptIntoTerminal({
-					page,
-					prompt: `This is the second input after image generation. Write "${secondArtifactText}" into /tmp/qcut-output/${secondArtifactFilename}, then reply SECOND_INPUT_DONE_${runId}.`,
-					echoNeedle: secondArtifactFilename,
-				});
-				await waitForArtifact({
-					page,
-					filename: secondArtifactFilename,
-					timeoutMs: config.promptTimeoutMs,
-				});
-				const fetchedText = await fetchArtifactTextFromPage({
-					page,
-					filename: secondArtifactFilename,
-					licenseServerUrl: config.licenseServerUrl,
-				});
-				assertCondition({
-					condition: fetchedText.trim() === secondArtifactText,
-					message: `second input artifact mismatch: ${fetchedText.trim()}`,
-				});
-				const debugText = await readTerminalDebug({ page });
-				assertCondition({
-					condition: !debugText.includes("no relay ack"),
-					message: `unexpected stale ack warning after second input: ${debugText}`,
-				});
-				return `second=${secondArtifactFilename}; debug=${debugText}`;
-			},
-		});
+			const secondArtifactFilename = `terminal-second-input-e2e-${runId}.txt`;
+			const secondArtifactText = `second input ok ${runId}`;
+			await runStep({
+				state,
+				name: "second terminal input works after image generation",
+				screenshotName: "06-second-input-after-image",
+				action: async () => {
+					await typePromptIntoTerminal({
+						page,
+						prompt: `This is the second input after image generation. Write "${secondArtifactText}" into /tmp/qcut-output/${secondArtifactFilename}, then reply SECOND_INPUT_DONE_${runId}.`,
+						echoNeedle: secondArtifactFilename,
+					});
+					await waitForArtifact({
+						page,
+						filename: secondArtifactFilename,
+						timeoutMs: config.promptTimeoutMs,
+					});
+					const fetchedText = await fetchArtifactTextFromPage({
+						page,
+						filename: secondArtifactFilename,
+						licenseServerUrl: config.licenseServerUrl,
+					});
+					assertCondition({
+						condition: fetchedText.trim() === secondArtifactText,
+						message: `second input artifact mismatch: ${fetchedText.trim()}`,
+					});
+					const debugText = await readTerminalDebug({ page });
+					assertCondition({
+						condition: !debugText.includes("no relay ack"),
+						message: `unexpected stale ack warning after second input: ${debugText}`,
+					});
+					return `second=${secondArtifactFilename}; debug=${debugText}`;
+				},
+			});
 
-		await runStep({
-			state,
-			name: "terminal-generated image artifacts download from the web UI",
-			screenshotName: "07-artifact-download",
-			action: async () => {
-				const downloadedMarkerPath = await downloadArtifactWithButton({
-					page,
-					filename: artifactFilename,
-					outDir: config.outDir,
-				});
-				const downloadedImagePath = await downloadArtifactWithButton({
-					page,
-					filename: imageFilename,
-					outDir: config.outDir,
-				});
-				const fetchedText = await fetchArtifactTextFromPage({
-					page,
-					filename: artifactFilename,
-					licenseServerUrl: config.licenseServerUrl,
-				});
-				assertCondition({
-					condition: fetchedText.trim() === artifactText,
-					message: `artifact content mismatch: ${fetchedText.trim()}`,
-				});
-				return `downloaded=${downloadedMarkerPath}; image=${downloadedImagePath}`;
-			},
-		});
+			await runStep({
+				state,
+				name: "terminal-generated image artifacts download from the web UI",
+				screenshotName: "07-artifact-download",
+				action: async () => {
+					const downloadedMarkerPath = await downloadArtifactWithButton({
+						page,
+						filename: artifactFilename,
+						outDir: config.outDir,
+					});
+					const downloadedImagePath = await downloadArtifactWithButton({
+						page,
+						filename: imageFilename,
+						outDir: config.outDir,
+					});
+					const fetchedText = await fetchArtifactTextFromPage({
+						page,
+						filename: artifactFilename,
+						licenseServerUrl: config.licenseServerUrl,
+					});
+					assertCondition({
+						condition: fetchedText.trim() === artifactText,
+						message: `artifact content mismatch: ${fetchedText.trim()}`,
+					});
+					return `downloaded=${downloadedMarkerPath}; image=${downloadedImagePath}`;
+				},
+			});
 
-		await runStep({
-			state,
-			name: "reconnect opens Codex again",
-			screenshotName: "08-reconnect-codex-ready",
-			action: async () => {
-				const beforeSessionId = await readStoredAgentSessionId({ page });
-				await page.locator("#agent-terminal-reconnect").click();
-				await waitForCodexReady({
-					page,
-					timeoutMs: config.connectTimeoutMs,
-				});
-				const afterSessionId = await readStoredAgentSessionId({ page });
-				assertCondition({
-					condition:
-						beforeSessionId.length > 0 && beforeSessionId === afterSessionId,
-					message: `reconnect changed session ${beforeSessionId} -> ${afterSessionId}`,
-				});
-				return `sameSession=${afterSessionId}`;
-			},
-		});
+			await runStep({
+				state,
+				name: "reconnect opens Codex again",
+				screenshotName: "08-reconnect-codex-ready",
+				action: async () => {
+					const beforeSessionId = await readStoredAgentSessionId({ page });
+					await page.locator("#agent-terminal-reconnect").click();
+					await waitForCodexReady({
+						page,
+						timeoutMs: config.connectTimeoutMs,
+					});
+					const afterSessionId = await readStoredAgentSessionId({ page });
+					assertCondition({
+						condition:
+							beforeSessionId.length > 0 && beforeSessionId === afterSessionId,
+						message: `reconnect changed session ${beforeSessionId} -> ${afterSessionId}`,
+					});
+					return `sameSession=${afterSessionId}`;
+				},
+			});
 
-		const reconnectArtifactFilename = `terminal-reconnect-e2e-${runId}.txt`;
-		const reconnectArtifactText = `reconnect input ok ${runId}`;
-		await runStep({
-			state,
-			name: "input works after explicit reconnect",
-			screenshotName: "09-input-after-reconnect",
-			action: async () => {
-				await typePromptIntoTerminal({
-					page,
-					prompt: `After explicit Reconnect, write "${reconnectArtifactText}" into /tmp/qcut-output/${reconnectArtifactFilename}, then reply RECONNECT_INPUT_DONE_${runId}.`,
-					echoNeedle: reconnectArtifactFilename,
-				});
-				await waitForArtifact({
-					page,
-					filename: reconnectArtifactFilename,
-					timeoutMs: config.promptTimeoutMs,
-				});
-				const fetchedText = await fetchArtifactTextFromPage({
-					page,
-					filename: reconnectArtifactFilename,
-					licenseServerUrl: config.licenseServerUrl,
-				});
-				assertCondition({
-					condition: fetchedText.trim() === reconnectArtifactText,
-					message: `reconnect artifact mismatch: ${fetchedText.trim()}`,
-				});
-				const debugText = await readTerminalDebug({ page });
-				assertCondition({
-					condition: !debugText.includes("no relay ack"),
-					message: `unexpected stale ack warning after reconnect input: ${debugText}`,
-				});
-				return `reconnect=${reconnectArtifactFilename}; debug=${debugText}`;
-			},
-		});
+			const reconnectArtifactFilename = `terminal-reconnect-e2e-${runId}.txt`;
+			const reconnectArtifactText = `reconnect input ok ${runId}`;
+			await runStep({
+				state,
+				name: "input works after explicit reconnect",
+				screenshotName: "09-input-after-reconnect",
+				action: async () => {
+					await typePromptIntoTerminal({
+						page,
+						prompt: `After explicit Reconnect, write "${reconnectArtifactText}" into /tmp/qcut-output/${reconnectArtifactFilename}, then reply RECONNECT_INPUT_DONE_${runId}.`,
+						echoNeedle: reconnectArtifactFilename,
+					});
+					await waitForArtifact({
+						page,
+						filename: reconnectArtifactFilename,
+						timeoutMs: config.promptTimeoutMs,
+					});
+					const fetchedText = await fetchArtifactTextFromPage({
+						page,
+						filename: reconnectArtifactFilename,
+						licenseServerUrl: config.licenseServerUrl,
+					});
+					assertCondition({
+						condition: fetchedText.trim() === reconnectArtifactText,
+						message: `reconnect artifact mismatch: ${fetchedText.trim()}`,
+					});
+					const debugText = await readTerminalDebug({ page });
+					assertCondition({
+						condition: !debugText.includes("no relay ack"),
+						message: `unexpected stale ack warning after reconnect input: ${debugText}`,
+					});
+					return `reconnect=${reconnectArtifactFilename}; debug=${debugText}`;
+				},
+			});
+		}
 
 		await runStep({
 			state,

--- a/qcut/scripts/daytona-worker-dogfood.ts
+++ b/qcut/scripts/daytona-worker-dogfood.ts
@@ -18,6 +18,8 @@
  * Optional env:
  *   QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:v0
  *   QCUT_DOGFOOD_COMMAND="qcut system doctor --json --skip-health"
+ *   QCUT_DOGFOOD_CODEX_PROMPT="Review a video and write artifacts..."
+ *   QCUT_DOGFOOD_CODEX_PROMPT_FILE=/tmp/prompt.txt
  *   QCUT_DOGFOOD_TIMEOUT_MS=600000
  */
 
@@ -32,6 +34,7 @@ const REQUIRED_ENV = [
 	"SUPABASE_SERVICE_ROLE_KEY",
 	"QCUT_DOGFOOD_USER_ID",
 ] as const;
+const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
 
 type RequiredEnv = (typeof REQUIRED_ENV)[number];
 type TerminalStatus = "succeeded" | "failed" | "cancelled";
@@ -43,6 +46,7 @@ interface DogfoodEnv {
 	QCUT_DOGFOOD_USER_ID: string;
 	QCUT_IMAGE_TAG: string;
 	QCUT_DOGFOOD_COMMAND: string;
+	QCUT_DOGFOOD_CODEX_PROMPT: string;
 	QCUT_DOGFOOD_TIMEOUT_MS: number;
 }
 
@@ -87,6 +91,14 @@ function loadQcutEnvFile() {
 	}
 }
 
+function readCodexPrompt(): string {
+	const promptFile = process.env.QCUT_DOGFOOD_CODEX_PROMPT_FILE;
+	if (promptFile && promptFile.trim().length > 0) {
+		return readFileSync(promptFile, "utf8").trim();
+	}
+	return (process.env.QCUT_DOGFOOD_CODEX_PROMPT ?? "").trim();
+}
+
 function getEnv(): DogfoodEnv {
 	const missing: RequiredEnv[] = [];
 	for (const key of REQUIRED_ENV) {
@@ -96,6 +108,13 @@ function getEnv(): DogfoodEnv {
 		throw new Error(`Missing required env: ${missing.join(", ")}`);
 	}
 
+	const codexPrompt = readCodexPrompt();
+	const command =
+		process.env.QCUT_DOGFOOD_COMMAND ??
+		(codexPrompt.length > 0
+			? CODEX_AGENT_COMMAND
+			: "qcut system doctor --json --skip-health");
+
 	return {
 		DAYTONA_API_KEY: process.env.DAYTONA_API_KEY as string,
 		SUPABASE_URL: process.env.SUPABASE_URL as string,
@@ -103,9 +122,8 @@ function getEnv(): DogfoodEnv {
 		QCUT_DOGFOOD_USER_ID: process.env.QCUT_DOGFOOD_USER_ID as string,
 		QCUT_IMAGE_TAG:
 			process.env.QCUT_IMAGE_TAG ?? "ghcr.io/quriosity-agent/qcut-cli:v0",
-		QCUT_DOGFOOD_COMMAND:
-			process.env.QCUT_DOGFOOD_COMMAND ??
-			"qcut system doctor --json --skip-health",
+		QCUT_DOGFOOD_COMMAND: command,
+		QCUT_DOGFOOD_CODEX_PROMPT: codexPrompt,
 		QCUT_DOGFOOD_TIMEOUT_MS: Number(
 			process.env.QCUT_DOGFOOD_TIMEOUT_MS ?? "600000"
 		),
@@ -172,7 +190,10 @@ async function insertJob({ env, jobId }: { env: DogfoodEnv; jobId: string }) {
 				user_id: env.QCUT_DOGFOOD_USER_ID,
 				status: "queued",
 				command: env.QCUT_DOGFOOD_COMMAND,
-				args: {},
+				args:
+					env.QCUT_DOGFOOD_CODEX_PROMPT.length > 0
+						? { codexPrompt: env.QCUT_DOGFOOD_CODEX_PROMPT }
+						: {},
 				created_at: now,
 			}),
 		},
@@ -282,6 +303,11 @@ const jobId = `dogfood-${randomUUID()}`;
 console.log(`[dogfood] image=${env.QCUT_IMAGE_TAG}`);
 console.log(`[dogfood] user=${env.QCUT_DOGFOOD_USER_ID}`);
 console.log(`[dogfood] command=${env.QCUT_DOGFOOD_COMMAND}`);
+if (env.QCUT_DOGFOOD_CODEX_PROMPT.length > 0) {
+	console.log(
+		`[dogfood] codexPromptChars=${env.QCUT_DOGFOOD_CODEX_PROMPT.length}`
+	);
+}
 
 const secretCount = await countSecrets({ env });
 console.log(`[dogfood] agent_secrets count=${secretCount}`);

--- a/qcut/scripts/daytona-worker-dogfood.ts
+++ b/qcut/scripts/daytona-worker-dogfood.ts
@@ -16,7 +16,8 @@
  *   QCUT_DOGFOOD_USER_ID
  *
  * Optional env:
- *   QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:v0
+ *   QCUT_IMAGE_TAG=ghcr.io/quriosity-agent/qcut-cli:custom-tag
+ *   QCUT_DOGFOOD_USE_WORKER_DEFAULT_IMAGE=true
  *   QCUT_DOGFOOD_COMMAND="qcut system doctor --json --skip-health"
  *   QCUT_DOGFOOD_CODEX_PROMPT="Review a video and write artifacts..."
  *   QCUT_DOGFOOD_CODEX_PROMPT_FILE=/tmp/prompt.txt
@@ -44,7 +45,7 @@ interface DogfoodEnv {
 	SUPABASE_URL: string;
 	SUPABASE_SERVICE_ROLE_KEY: string;
 	QCUT_DOGFOOD_USER_ID: string;
-	QCUT_IMAGE_TAG: string;
+	QCUT_IMAGE_TAG?: string;
 	QCUT_DOGFOOD_COMMAND: string;
 	QCUT_DOGFOOD_CODEX_PROMPT: string;
 	QCUT_DOGFOOD_TIMEOUT_MS: number;
@@ -114,14 +115,17 @@ function getEnv(): DogfoodEnv {
 		(codexPrompt.length > 0
 			? CODEX_AGENT_COMMAND
 			: "qcut system doctor --json --skip-health");
+	const useWorkerDefaultImage =
+		process.env.QCUT_DOGFOOD_USE_WORKER_DEFAULT_IMAGE === "true";
 
 	return {
 		DAYTONA_API_KEY: process.env.DAYTONA_API_KEY as string,
 		SUPABASE_URL: process.env.SUPABASE_URL as string,
 		SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY as string,
 		QCUT_DOGFOOD_USER_ID: process.env.QCUT_DOGFOOD_USER_ID as string,
-		QCUT_IMAGE_TAG:
-			process.env.QCUT_IMAGE_TAG ?? "ghcr.io/quriosity-agent/qcut-cli:v0",
+		QCUT_IMAGE_TAG: useWorkerDefaultImage
+			? undefined
+			: process.env.QCUT_IMAGE_TAG?.trim() || undefined,
 		QCUT_DOGFOOD_COMMAND: command,
 		QCUT_DOGFOOD_CODEX_PROMPT: codexPrompt,
 		QCUT_DOGFOOD_TIMEOUT_MS: Number(
@@ -277,15 +281,19 @@ async function pollJob({
 }
 
 function startWorker({ env }: { env: DogfoodEnv }): Bun.Subprocess {
+	const workerEnv = {
+		...process.env,
+		DAYTONA_API_KEY: env.DAYTONA_API_KEY,
+		SUPABASE_URL: env.SUPABASE_URL,
+		SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY,
+		IDLE_POLL_MS: "2000",
+	};
+	Reflect.deleteProperty(workerEnv, "QCUT_IMAGE_TAG");
+	if (env.QCUT_IMAGE_TAG) {
+		workerEnv.QCUT_IMAGE_TAG = env.QCUT_IMAGE_TAG;
+	}
 	return Bun.spawn(["bun", "--cwd", "packages/agent-worker", "start"], {
-		env: {
-			...process.env,
-			DAYTONA_API_KEY: env.DAYTONA_API_KEY,
-			QCUT_IMAGE_TAG: env.QCUT_IMAGE_TAG,
-			SUPABASE_URL: env.SUPABASE_URL,
-			SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY,
-			IDLE_POLL_MS: "2000",
-		},
+		env: workerEnv,
 		stdout: "inherit",
 		stderr: "inherit",
 	});
@@ -300,7 +308,9 @@ loadQcutEnvFile();
 const env = getEnv();
 const jobId = `dogfood-${randomUUID()}`;
 
-console.log(`[dogfood] image=${env.QCUT_IMAGE_TAG}`);
+console.log(
+	`[dogfood] image=${env.QCUT_IMAGE_TAG ?? "(agent-worker default)"}`
+);
 console.log(`[dogfood] user=${env.QCUT_DOGFOOD_USER_ID}`);
 console.log(`[dogfood] command=${env.QCUT_DOGFOOD_COMMAND}`);
 if (env.QCUT_DOGFOOD_CODEX_PROMPT.length > 0) {


### PR DESCRIPTION
## Summary

- Add native CLI skill guidance for video review workflows, including review-language and artifact export examples.
- Surface the video review command in the Codex sandbox prompt for Daytona-backed agent jobs.
- Extend agent chat and Daytona dogfood scripts so online agent review flows can run custom prompts and assert expected artifacts.

## Impact

This makes it easier for online agents to discover and execute QCut video review workflows, especially Chinese-language review runs that should produce timestamped comments and CSV/JSON artifacts.

## Validation

- `bun --cwd packages/agent-worker test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Video Review (审片) docs across CLI materials: review-mode workflow, timestamped human-style feedback, CSV/JSON/MD exports, expected output artifacts, example review commands, review-specific flags (language, prompt dir, token budget), and guidance for splitting/retrying long videos and sandboxed sessions.

* **Chores**
  * Pinned/updated agent container image digests.
  * Enhanced CLI scripts/tests to support terminal prompt customization, artifact assertions, and optional Codex-style prompt injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->