### PR TITLE
chore: pin Daytona CLI image for consistency analysis

### DIFF
--- a/qcut/packages/agent-worker/src/daytona/constants.ts
+++ b/qcut/packages/agent-worker/src/daytona/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d";
 export const IMAGE_TAG = process.env.QCUT_IMAGE_TAG ?? DEFAULT_DAYTONA_IMAGE;
 export const TIMEOUT_SECONDS = 30 * 60;
 export const DAYTONA_CREATE_TIMEOUT_SECONDS = 300;

--- a/qcut/packages/agent-worker/src/run-on-daytona.ephemeral.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.ephemeral.test.ts
@@ -154,7 +154,7 @@ describe("runOnDaytona ephemeral jobs", () => {
 		expect(createCalls).toEqual([
 			{
 				image:
-					"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56",
+					"ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d",
 				envVars: {
 					QCUT_SESSION_ROLE: "agent",
 					OPENAI_API_KEY: "sk-test",

--- a/qcut/packages/agent-worker/src/run-on-daytona.sessions.test.ts
+++ b/qcut/packages/agent-worker/src/run-on-daytona.sessions.test.ts
@@ -22,7 +22,7 @@ describe("runOnDaytona persisted sessions", () => {
 					status: "active",
 					provider_session_id: "sandbox-persisted",
 					image_tag:
-						"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56",
+						"ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d",
 					last_active_at: "2026-05-14T00:00:00.000Z",
 					expires_at: "2099-01-01T00:00:00.000Z",
 					end_reason: null,

--- a/qcut/packages/license-server/src/routes/agent-parts/constants.ts
+++ b/qcut/packages/license-server/src/routes/agent-parts/constants.ts
@@ -16,9 +16,9 @@ export const CODEX_AGENT_COMMAND = "codex exec --skip-git-repo-check --json -";
 
 // Pinned to an immutable manifest digest so the default agent image cannot
 // drift if the upstream tag is republished. Human-readable tag for this
-// digest: `review-agent-20260604025944`.
+// digest: `dev-2026-06-19-character-consistency`.
 export const DEFAULT_DAYTONA_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d";
 
 export const TEXT_ARTIFACT_KINDS = new Set(["json", "log"]);
 

--- a/qcut/packages/license-server/src/routes/agent.test-utils.ts
+++ b/qcut/packages/license-server/src/routes/agent.test-utils.ts
@@ -53,7 +53,7 @@ export const {
 } = await import("./agent");
 
 export const DEFAULT_PINNED_QCUT_IMAGE =
-	"ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56";
+	"ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d";
 
 const ORIGINAL_ENV = { ...process.env };
 

--- a/qcut/packages/license-server/wrangler.toml
+++ b/qcut/packages/license-server/wrangler.toml
@@ -17,8 +17,8 @@ CORS_ALLOWED_ORIGINS = ""
 AI_PROXY_RATE_LIMIT = "60"
 QCUT_AGENT_ALLOW_DEFAULT_USER = "true"
 # Pinned to immutable digest so retags can't silently change sandbox runtime.
-# Human-readable tag: review-agent-20260604025944
-QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:1baf3bbae082bb38c4056718f672c5965195f1888980f73b1e51759e7a480f56"
+# Human-readable tag: dev-2026-06-19-character-consistency
+QCUT_IMAGE_TAG = "ghcr.io/quriosity-agent/qcut-cli@sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d"
 
 # AI provider keys are stored as Wrangler secrets (not vars):
 # wrangler secret put FAL_API_KEY


### PR DESCRIPTION
## Summary
- Pin Daytona QCut CLI runtime to the rebuilt image digest containing `qcut analyze consistency`
- Sync license-server and agent-worker default image constants and tests

## Verification
- cli-image workflow run `27813557677` succeeded and pushed `ghcr.io/quriosity-agent/qcut-cli:dev-2026-06-19-character-consistency` / `:latest`
- Docker smoke verified `qcut analyze consistency --help --json` from digest `sha256:5036f6915281d1770e07ad90d9bc95fb29b259e2cadcee3a8c3da137dac8f50d`
- License-server targeted tests passed:
  `bunx vitest run --config vitest.config.ts src/routes/agent.terminal-token.test.ts src/routes/agent.validation.test.ts`
- Agent-worker targeted tests passed:
  `bunx vitest run --config vitest.config.ts src/run-on-daytona.sessions.test.ts src/run-on-daytona.ephemeral.test.ts`
- `bun run deploy` in `packages/license-server` succeeded; deployed Worker version `9281706f-d565-4150-b968-a4de1519b579`
- Production Chat Agent E2E passed: `output/playwright/character-consistency-daytona-image-deployed-e2e/result.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default container image version used by the agent worker across configurations and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->