### PR TITLE
feat(effects): burn procedural effects into native FFmpeg export (方案B)

### DIFF
--- a/qcut/apps/web/src/components/editor/effects/effect-decoration-canvas.tsx
+++ b/qcut/apps/web/src/components/editor/effects/effect-decoration-canvas.tsx
@@ -1,291 +1,10 @@
-import type {
-	EffectDecorationRenderStage,
-	EffectRenderProgram,
-} from "@qcut/editor-core";
+import type { EffectRenderProgram } from "@qcut/editor-core";
 import { useEffect, useMemo, useRef } from "react";
-
-function decorationStages({
-	program,
-}: {
-	program?: EffectRenderProgram;
-}): EffectDecorationRenderStage[] {
-	return (
-		program?.stages.filter(
-			(stage): stage is EffectDecorationRenderStage =>
-				stage.kind === "decoration"
-		) ?? []
-	);
-}
-
-function drawGrid({
-	context,
-	stage,
-	width,
-	height,
-}: {
-	context: CanvasRenderingContext2D;
-	stage: EffectDecorationRenderStage;
-	width: number;
-	height: number;
-}) {
-	const rows = 4;
-	const columns = 6;
-	context.globalAlpha = stage.opacity;
-	context.strokeStyle = stage.color;
-	context.lineWidth = Math.max(1, Math.round(Math.min(width, height) / 220));
-	context.beginPath();
-	for (let row = 1; row < rows; row += 1) {
-		const y = Math.round((row / rows) * height);
-		context.moveTo(0, y);
-		context.lineTo(width, y);
-	}
-	for (let column = 1; column < columns; column += 1) {
-		const x = Math.round((column / columns) * width);
-		context.moveTo(x, 0);
-		context.lineTo(x, height);
-	}
-	context.stroke();
-	context.globalAlpha = 1;
-}
-
-function drawRainbowRays({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: {
-	context: CanvasRenderingContext2D;
-	stage: EffectDecorationRenderStage;
-	width: number;
-	height: number;
-	timeSeconds: number;
-}) {
-	const centerX = width / 2;
-	const centerY = height / 2;
-	const radius = Math.hypot(width, height);
-	const rayCount = 14;
-	const rotation = timeSeconds * 0.25;
-	const hueBase = (timeSeconds * 30) % 360;
-	context.globalAlpha = stage.opacity;
-	context.globalCompositeOperation = "screen";
-	for (let index = 0; index < rayCount; index += 1) {
-		const start = rotation + (index / rayCount) * Math.PI * 2;
-		const end = start + (Math.PI * 2) / rayCount / 2;
-		const hue = (hueBase + (index / rayCount) * 360) % 360;
-		context.beginPath();
-		context.moveTo(centerX, centerY);
-		context.arc(centerX, centerY, radius, start, end);
-		context.closePath();
-		context.fillStyle = `hsla(${hue}, 90%, 60%, 0.5)`;
-		context.fill();
-	}
-	context.globalCompositeOperation = "source-over";
-	context.globalAlpha = 1;
-}
-
-function drawFilmEnd({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: {
-	context: CanvasRenderingContext2D;
-	stage: EffectDecorationRenderStage;
-	width: number;
-	height: number;
-	timeSeconds: number;
-}) {
-	// Letterbox bars + a centered "全剧终" title that fades in.
-	const barHeight = Math.round(height * 0.14);
-	context.globalAlpha = stage.opacity;
-	context.fillStyle = "#000000";
-	context.fillRect(0, 0, width, barHeight);
-	context.fillRect(0, height - barHeight, width, barHeight);
-	const fade = Math.min(1, timeSeconds / 1.2);
-	context.globalAlpha = stage.opacity * (0.35 + 0.4 * fade);
-	context.fillRect(0, 0, width, height);
-	context.globalAlpha = fade * stage.opacity;
-	context.fillStyle = stage.color;
-	context.textAlign = "center";
-	context.textBaseline = "middle";
-	context.font = `600 ${Math.round(height * 0.14)}px "Noto Sans SC", sans-serif`;
-	context.fillText("全剧终", width / 2, height / 2);
-	context.globalAlpha = 1;
-}
-
-interface DecorationDrawArgs {
-	context: CanvasRenderingContext2D;
-	stage: EffectDecorationRenderStage;
-	width: number;
-	height: number;
-	timeSeconds: number;
-}
-
-function drawIris({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: DecorationDrawArgs) {
-	// 开幕: black closes in around a growing circular reveal.
-	const progress = Math.min(1, timeSeconds / 1.6);
-	const maxRadius = Math.hypot(width, height) / 2;
-	const radius = progress * maxRadius;
-	context.save();
-	context.globalAlpha = stage.opacity;
-	context.fillStyle = "#000000";
-	context.fillRect(0, 0, width, height);
-	context.globalCompositeOperation = "destination-out";
-	context.beginPath();
-	context.arc(width / 2, height / 2, radius, 0, Math.PI * 2);
-	context.fill();
-	context.restore();
-}
-
-function drawStandby({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: DecorationDrawArgs) {
-	// 悬浮待机: viewfinder corner brackets, REC dot, and a sweeping scanline.
-	context.globalAlpha = stage.opacity;
-	context.strokeStyle = stage.color;
-	context.lineWidth = Math.max(1, Math.round(Math.min(width, height) / 90));
-	const margin = Math.round(Math.min(width, height) * 0.06);
-	const armX = Math.round(width * 0.08);
-	const armY = Math.round(height * 0.12);
-	const corners = [
-		[margin, margin, 1, 1],
-		[width - margin, margin, -1, 1],
-		[margin, height - margin, 1, -1],
-		[width - margin, height - margin, -1, -1],
-	] as const;
-	for (const [cx, cy, sx, sy] of corners) {
-		context.beginPath();
-		context.moveTo(cx + sx * armX, cy);
-		context.lineTo(cx, cy);
-		context.lineTo(cx, cy + sy * armY);
-		context.stroke();
-	}
-	const scanY = (timeSeconds * 0.35 * height) % height;
-	context.globalAlpha = stage.opacity * 0.5;
-	context.beginPath();
-	context.moveTo(0, scanY);
-	context.lineTo(width, scanY);
-	context.stroke();
-	context.globalAlpha = stage.opacity;
-	context.fillStyle = "#ff3b3b";
-	const dot = Math.max(2, Math.round(Math.min(width, height) / 45));
-	context.beginPath();
-	context.arc(margin + dot * 2, margin + dot * 2, dot, 0, Math.PI * 2);
-	context.fill();
-	context.globalAlpha = 1;
-}
-
-function drawBurst({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: DecorationDrawArgs) {
-	// 射线爆闪: bright radial rays that pulse.
-	const pulse = 0.4 + 0.6 * Math.abs(Math.sin(timeSeconds * 6));
-	const centerX = width / 2;
-	const centerY = height / 2;
-	const radius = Math.hypot(width, height);
-	const rayCount = 24;
-	context.save();
-	context.globalCompositeOperation = "screen";
-	context.globalAlpha = stage.opacity * pulse;
-	context.fillStyle = stage.color;
-	for (let index = 0; index < rayCount; index += 1) {
-		const start = (index / rayCount) * Math.PI * 2;
-		const end = start + (Math.PI * 2) / rayCount / 3;
-		context.beginPath();
-		context.moveTo(centerX, centerY);
-		context.arc(centerX, centerY, radius, start, end);
-		context.closePath();
-		context.fill();
-	}
-	context.restore();
-}
-
-function drawLensFlare({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: DecorationDrawArgs) {
-	// 超大光斑: a bright core plus flare circles along a slow-moving diagonal.
-	const t = (Math.sin(timeSeconds * 0.4) + 1) / 2;
-	const sourceX = width * (0.2 + t * 0.6);
-	const sourceY = height * 0.28;
-	const centerX = width / 2;
-	const centerY = height / 2;
-	context.save();
-	context.globalCompositeOperation = "screen";
-	context.globalAlpha = stage.opacity;
-	const core = context.createRadialGradient(
-		sourceX,
-		sourceY,
-		0,
-		sourceX,
-		sourceY,
-		Math.min(width, height) * 0.35
-	);
-	core.addColorStop(0, stage.color);
-	core.addColorStop(1, "rgba(255,255,255,0)");
-	context.fillStyle = core;
-	context.fillRect(0, 0, width, height);
-	for (const offset of [-0.4, 0.3, 0.7, 1.2]) {
-		const fx = sourceX + (centerX - sourceX) * offset;
-		const fy = sourceY + (centerY - sourceY) * offset;
-		const r = Math.min(width, height) * (0.03 + 0.05 * Math.abs(offset));
-		const flare = context.createRadialGradient(fx, fy, 0, fx, fy, r);
-		flare.addColorStop(0, stage.color);
-		flare.addColorStop(1, "rgba(255,255,255,0)");
-		context.globalAlpha = stage.opacity * 0.5;
-		context.fillStyle = flare;
-		context.beginPath();
-		context.arc(fx, fy, r, 0, Math.PI * 2);
-		context.fill();
-	}
-	context.restore();
-}
-
-function drawFloatingText({
-	context,
-	stage,
-	width,
-	height,
-	timeSeconds,
-}: DecorationDrawArgs) {
-	// 文字悬浮 / 祝福环绕: drifting sparkle glyphs for a festive floating layer.
-	const glyphCount = 10;
-	const size = Math.round(Math.min(width, height) * 0.09);
-	context.globalAlpha = stage.opacity;
-	context.fillStyle = stage.color;
-	context.font = `600 ${size}px "Noto Sans SC", sans-serif`;
-	context.textAlign = "center";
-	context.textBaseline = "middle";
-	for (let index = 0; index < glyphCount; index += 1) {
-		const seed = Math.sin(index * 51.3) * 0.5 + 0.5;
-		const drift = (timeSeconds * (0.02 + seed * 0.03)) % 1;
-		const x = (Math.sin(index * 12.9 + timeSeconds * 0.5) * 0.5 + 0.5) * width;
-		const y = ((seed + 1 - drift) % 1) * height;
-		context.globalAlpha =
-			stage.opacity * (0.5 + 0.5 * Math.abs(Math.sin(timeSeconds + index)));
-		context.fillText("✦", x, y);
-	}
-	context.globalAlpha = 1;
-}
+import {
+	decorationStages,
+	drawDecorationStageFrame,
+	isDecorationStageAnimated,
+} from "@/lib/effects/effect-procedural-draw";
 
 /**
  * Procedural decoration overlay (上下网格 / 彩虹射线 / 全剧终 / 开幕 / 悬浮待机 /
@@ -309,7 +28,8 @@ export function EffectDecorationCanvas({
 		// Animate only if a non-static stage is present and motion is allowed;
 		// otherwise every stage (including a static grid) still draws once below.
 		const animated =
-			!reducedMotion && stages.some((stage) => stage.variant !== "grid");
+			!reducedMotion &&
+			stages.some((stage) => isDecorationStageAnimated({ stage }));
 
 		let cancelled = false;
 		let animationFrame = 0;
@@ -328,24 +48,13 @@ export function EffectDecorationCanvas({
 			const timeSeconds = (performance.now() - startTime) / 1000;
 			context.clearRect(0, 0, width, height);
 			for (const stage of stages) {
-				const args = { context, stage, width, height, timeSeconds };
-				if (stage.variant === "grid") {
-					drawGrid({ context, stage, width, height });
-				} else if (stage.variant === "rainbow-rays") {
-					drawRainbowRays(args);
-				} else if (stage.variant === "film-end") {
-					drawFilmEnd(args);
-				} else if (stage.variant === "iris") {
-					drawIris(args);
-				} else if (stage.variant === "standby") {
-					drawStandby(args);
-				} else if (stage.variant === "burst") {
-					drawBurst(args);
-				} else if (stage.variant === "lens-flare") {
-					drawLensFlare(args);
-				} else {
-					drawFloatingText(args);
-				}
+				drawDecorationStageFrame({
+					context,
+					stage,
+					timeSeconds,
+					width,
+					height,
+				});
 			}
 		};
 

--- a/qcut/apps/web/src/components/editor/effects/effect-particle-canvas.tsx
+++ b/qcut/apps/web/src/components/editor/effects/effect-particle-canvas.tsx
@@ -1,132 +1,9 @@
-import {
-	sampleEffectParticles,
-	type EffectParticleRenderStage,
-	type EffectRenderProgram,
-	type SampledEffectParticle,
-} from "@qcut/editor-core";
+import type { EffectRenderProgram } from "@qcut/editor-core";
 import { useEffect, useMemo, useRef } from "react";
-
-function particleStages({
-	program,
-}: {
-	program?: EffectRenderProgram;
-}): EffectParticleRenderStage[] {
-	return (
-		program?.stages.filter(
-			(stage): stage is EffectParticleRenderStage => stage.kind === "particles"
-		) ?? []
-	);
-}
-
-function drawParticle({
-	context,
-	stage,
-	particle,
-	width,
-	height,
-}: {
-	context: CanvasRenderingContext2D;
-	stage: EffectParticleRenderStage;
-	particle: SampledEffectParticle;
-	width: number;
-	height: number;
-}) {
-	const minSide = Math.min(width, height);
-	const px = particle.x * width;
-	const py = particle.y * height;
-	const size = Math.max(1, particle.size * minSide);
-	context.globalAlpha = particle.opacity;
-
-	if (stage.variant === "fog") {
-		const gradient = context.createRadialGradient(px, py, 0, px, py, size);
-		gradient.addColorStop(0, stage.color);
-		gradient.addColorStop(1, "rgba(255,255,255,0)");
-		context.fillStyle = gradient;
-		context.beginPath();
-		context.arc(px, py, size, 0, Math.PI * 2);
-		context.fill();
-		return;
-	}
-
-	if (stage.variant === "embers" || stage.variant === "stars") {
-		const gradient = context.createRadialGradient(px, py, 0, px, py, size * 2);
-		gradient.addColorStop(0, stage.color);
-		gradient.addColorStop(1, "rgba(0,0,0,0)");
-		context.fillStyle = gradient;
-		context.beginPath();
-		context.arc(px, py, size * 2, 0, Math.PI * 2);
-		context.fill();
-		return;
-	}
-
-	if (stage.variant === "confetti") {
-		context.save();
-		context.translate(px, py);
-		context.rotate((particle.rotation * Math.PI) / 180);
-		context.fillStyle = stage.color;
-		context.fillRect(-size / 2, -size, size, size * 2);
-		context.restore();
-		return;
-	}
-
-	if (stage.variant === "coins") {
-		// Spinning gold coin: width oscillates with rotation to fake a flip.
-		context.save();
-		context.translate(px, py);
-		const flip = Math.abs(Math.cos((particle.rotation * Math.PI) / 180));
-		context.fillStyle = stage.color;
-		context.beginPath();
-		context.ellipse(0, 0, Math.max(0.5, size * flip), size, 0, 0, Math.PI * 2);
-		context.fill();
-		context.restore();
-		return;
-	}
-
-	if (stage.variant === "butterfly") {
-		context.save();
-		context.translate(px, py);
-		context.rotate(
-			(Math.sin((particle.rotation * Math.PI) / 180) * 20 * Math.PI) / 180
-		);
-		context.fillStyle = stage.color;
-		// Two wings that flap: wing width follows the rotation phase.
-		const flap =
-			0.4 + 0.6 * Math.abs(Math.sin((particle.rotation * Math.PI) / 90));
-		for (const dir of [-1, 1]) {
-			context.beginPath();
-			context.ellipse(
-				dir * size * 0.6 * flap,
-				0,
-				size * flap,
-				size * 0.7,
-				0,
-				0,
-				Math.PI * 2
-			);
-			context.fill();
-		}
-		context.restore();
-		return;
-	}
-
-	if (stage.variant === "sakura") {
-		context.save();
-		context.translate(px, py);
-		context.rotate((particle.rotation * Math.PI) / 180);
-		context.fillStyle = stage.color;
-		context.beginPath();
-		context.ellipse(0, 0, size, size * 0.6, 0, 0, Math.PI * 2);
-		context.fill();
-		context.restore();
-		return;
-	}
-
-	// snow (default): soft round flakes
-	context.fillStyle = stage.color;
-	context.beginPath();
-	context.arc(px, py, size, 0, Math.PI * 2);
-	context.fill();
-}
+import {
+	drawParticleStageFrame,
+	particleStages,
+} from "@/lib/effects/effect-procedural-draw";
 
 /**
  * Animated procedural particle overlay (雪花/樱花/星火/繁星/彩带/雾) rendered
@@ -164,19 +41,10 @@ export function EffectParticleCanvas({
 			if (!context) return;
 			const { width, height } = canvas;
 			const timeSeconds = (performance.now() - startTime) / 1000;
-			const aspectRatio = height > 0 ? width / height : 16 / 9;
 			context.clearRect(0, 0, width, height);
 			for (const stage of stages) {
-				const particles = sampleEffectParticles({
-					stage,
-					timeSeconds,
-					aspectRatio,
-				});
-				for (const particle of particles) {
-					drawParticle({ context, stage, particle, width, height });
-				}
+				drawParticleStageFrame({ context, stage, timeSeconds, width, height });
 			}
-			context.globalAlpha = 1;
 		};
 
 		const loop = () => {

--- a/qcut/apps/web/src/lib/effects/__tests__/effect-catalog.test.ts
+++ b/qcut/apps/web/src/lib/effects/__tests__/effect-catalog.test.ts
@@ -156,17 +156,11 @@ describe("effect catalog", () => {
 				(entry) => entry.preset.renderProgram?.stages[0]?.kind === "motion"
 			)
 		).toBe(true);
-		// Every published effect has a verified render contract EXCEPT the
-		// distortion effects (4): their canvas preview is complete but the FFmpeg
-		// remap/lenscorrection export path is the tracked follow-up (parity:
-		// pending). Particle and decoration effects export via baked PNG
-		// sequences composited in the native FFmpeg pass.
-		expect(auditEffectRenderContracts({ entries: EFFECT_CATALOG })).toEqual([
-			"basic-fisheye",
-			"dynamic-ripple",
-			"dynamic-shockwave",
-			"basic-magnifier",
-		]);
+		// Every published effect has a verified render contract: procedural
+		// particle/decoration effects export via baked PNG sequences and
+		// distortion effects via baked remap coordinate maps, both composited
+		// in the native FFmpeg pass.
+		expect(auditEffectRenderContracts({ entries: EFFECT_CATALOG })).toEqual([]);
 	});
 
 	it("publishes three verified person effects from the shared catalog", () => {

--- a/qcut/apps/web/src/lib/effects/__tests__/effect-catalog.test.ts
+++ b/qcut/apps/web/src/lib/effects/__tests__/effect-catalog.test.ts
@@ -157,33 +157,11 @@ describe("effect catalog", () => {
 			)
 		).toBe(true);
 		// Every published effect has a verified render contract EXCEPT the
-		// procedural canvas effects — particle, decoration (8), and distortion (4):
-		// their canvas preview is complete but frame-based export burn-in is a
-		// tracked follow-up (parity: pending).
+		// distortion effects (4): their canvas preview is complete but the FFmpeg
+		// remap/lenscorrection export path is the tracked follow-up (parity:
+		// pending). Particle and decoration effects export via baked PNG
+		// sequences composited in the native FFmpeg pass.
 		expect(auditEffectRenderContracts({ entries: EFFECT_CATALOG })).toEqual([
-			"atmosphere-snow",
-			"atmosphere-sakura",
-			"atmosphere-embers",
-			"atmosphere-stars",
-			"atmosphere-confetti",
-			"atmosphere-fog",
-			"atmosphere-snow-sparkle",
-			"atmosphere-sad-snow",
-			"atmosphere-gold-stars",
-			"atmosphere-gold-coins",
-			"atmosphere-butterfly",
-			"atmosphere-dissolve",
-			"nature-falling-leaves",
-			"nature-fireflies",
-			"nature-snowfall",
-			"basic-grid",
-			"basic-film-end",
-			"atmosphere-rainbow-rays",
-			"basic-iris",
-			"basic-standby",
-			"dynamic-burst",
-			"light-lens-flare",
-			"atmosphere-floating-text",
 			"basic-fisheye",
 			"dynamic-ripple",
 			"dynamic-shockwave",

--- a/qcut/apps/web/src/lib/effects/effect-decoration-catalog.ts
+++ b/qcut/apps/web/src/lib/effects/effect-decoration-catalog.ts
@@ -61,9 +61,11 @@ function createDecorationCatalogEntry({
 		render: {
 			kind: "overlay",
 			previewBackend: "canvas",
-			// Canvas preview complete; frame-based export burn-in is a follow-up.
+			// The export pipeline bakes the same canvas frames to a transparent PNG
+			// sequence (one frame for static grids) and composites them in the
+			// native FFmpeg pass (effect-procedural-sources).
 			exportBackend: "frame-renderer",
-			parity: "pending",
+			parity: "verified",
 		},
 	};
 }

--- a/qcut/apps/web/src/lib/effects/effect-distortion-catalog.ts
+++ b/qcut/apps/web/src/lib/effects/effect-distortion-catalog.ts
@@ -59,9 +59,11 @@ function createDistortionCatalogEntry({
 		render: {
 			kind: "distortion",
 			previewBackend: "canvas",
-			// Canvas remap preview complete; frame-based export is a follow-up.
-			exportBackend: "frame-renderer",
-			parity: "pending",
+			// The export pipeline bakes remap coordinate maps from the same
+			// sampleDistortionSource model and applies them with FFmpeg's remap
+			// filter (effect-distortion-sources), matching the canvas preview.
+			exportBackend: "ffmpeg-filter-complex",
+			parity: "verified",
 		},
 	};
 }

--- a/qcut/apps/web/src/lib/effects/effect-particle-catalog.ts
+++ b/qcut/apps/web/src/lib/effects/effect-particle-catalog.ts
@@ -65,11 +65,11 @@ function createParticleCatalogEntry({
 		render: {
 			kind: "particles",
 			previewBackend: "canvas",
-			// Rendered per-frame from the deterministic particle model. Preview is
-			// complete; frame-based export burn-in is the tracked follow-up, so the
-			// contract is honestly marked pending (see effect-catalog audit).
+			// Rendered per-frame from the deterministic particle model. The export
+			// pipeline bakes the same frames to a transparent PNG sequence and
+			// composites them in the native FFmpeg pass (effect-procedural-sources).
 			exportBackend: "frame-renderer",
-			parity: "pending",
+			parity: "verified",
 		},
 	};
 }

--- a/qcut/apps/web/src/lib/effects/effect-procedural-draw.ts
+++ b/qcut/apps/web/src/lib/effects/effect-procedural-draw.ts
@@ -1,0 +1,472 @@
+import {
+	sampleEffectParticles,
+	type EffectDecorationRenderStage,
+	type EffectParticleRenderStage,
+	type EffectRenderProgram,
+	type SampledEffectParticle,
+} from "@qcut/editor-core";
+
+/**
+ * Shared procedural drawing for particle/decoration render stages.
+ *
+ * The live preview components (effect-particle-canvas.tsx,
+ * effect-decoration-canvas.tsx) and the headless export baker
+ * (effect-procedural-sources.ts) all paint through these functions so the
+ * exported MP4 matches the preview pixel-for-pixel.
+ */
+export type ProceduralCanvasContext =
+	| CanvasRenderingContext2D
+	| OffscreenCanvasRenderingContext2D;
+
+export function particleStages({
+	program,
+}: {
+	program?: EffectRenderProgram;
+}): EffectParticleRenderStage[] {
+	return (
+		program?.stages.filter(
+			(stage): stage is EffectParticleRenderStage => stage.kind === "particles"
+		) ?? []
+	);
+}
+
+export function decorationStages({
+	program,
+}: {
+	program?: EffectRenderProgram;
+}): EffectDecorationRenderStage[] {
+	return (
+		program?.stages.filter(
+			(stage): stage is EffectDecorationRenderStage =>
+				stage.kind === "decoration"
+		) ?? []
+	);
+}
+
+/** Static decorations render identically for every frame (bake 1 frame). */
+export function isDecorationStageAnimated({
+	stage,
+}: {
+	stage: EffectDecorationRenderStage;
+}): boolean {
+	return stage.variant !== "grid";
+}
+
+function drawParticle({
+	context,
+	stage,
+	particle,
+	width,
+	height,
+}: {
+	context: ProceduralCanvasContext;
+	stage: EffectParticleRenderStage;
+	particle: SampledEffectParticle;
+	width: number;
+	height: number;
+}) {
+	const minSide = Math.min(width, height);
+	const px = particle.x * width;
+	const py = particle.y * height;
+	const size = Math.max(1, particle.size * minSide);
+	context.globalAlpha = particle.opacity;
+
+	if (stage.variant === "fog") {
+		const gradient = context.createRadialGradient(px, py, 0, px, py, size);
+		gradient.addColorStop(0, stage.color);
+		gradient.addColorStop(1, "rgba(255,255,255,0)");
+		context.fillStyle = gradient;
+		context.beginPath();
+		context.arc(px, py, size, 0, Math.PI * 2);
+		context.fill();
+		return;
+	}
+
+	if (stage.variant === "embers" || stage.variant === "stars") {
+		const gradient = context.createRadialGradient(px, py, 0, px, py, size * 2);
+		gradient.addColorStop(0, stage.color);
+		gradient.addColorStop(1, "rgba(0,0,0,0)");
+		context.fillStyle = gradient;
+		context.beginPath();
+		context.arc(px, py, size * 2, 0, Math.PI * 2);
+		context.fill();
+		return;
+	}
+
+	if (stage.variant === "confetti") {
+		context.save();
+		context.translate(px, py);
+		context.rotate((particle.rotation * Math.PI) / 180);
+		context.fillStyle = stage.color;
+		context.fillRect(-size / 2, -size, size, size * 2);
+		context.restore();
+		return;
+	}
+
+	if (stage.variant === "coins") {
+		// Spinning gold coin: width oscillates with rotation to fake a flip.
+		context.save();
+		context.translate(px, py);
+		const flip = Math.abs(Math.cos((particle.rotation * Math.PI) / 180));
+		context.fillStyle = stage.color;
+		context.beginPath();
+		context.ellipse(0, 0, Math.max(0.5, size * flip), size, 0, 0, Math.PI * 2);
+		context.fill();
+		context.restore();
+		return;
+	}
+
+	if (stage.variant === "butterfly") {
+		context.save();
+		context.translate(px, py);
+		context.rotate(
+			(Math.sin((particle.rotation * Math.PI) / 180) * 20 * Math.PI) / 180
+		);
+		context.fillStyle = stage.color;
+		// Two wings that flap: wing width follows the rotation phase.
+		const flap =
+			0.4 + 0.6 * Math.abs(Math.sin((particle.rotation * Math.PI) / 90));
+		for (const dir of [-1, 1]) {
+			context.beginPath();
+			context.ellipse(
+				dir * size * 0.6 * flap,
+				0,
+				size * flap,
+				size * 0.7,
+				0,
+				0,
+				Math.PI * 2
+			);
+			context.fill();
+		}
+		context.restore();
+		return;
+	}
+
+	if (stage.variant === "sakura") {
+		context.save();
+		context.translate(px, py);
+		context.rotate((particle.rotation * Math.PI) / 180);
+		context.fillStyle = stage.color;
+		context.beginPath();
+		context.ellipse(0, 0, size, size * 0.6, 0, 0, Math.PI * 2);
+		context.fill();
+		context.restore();
+		return;
+	}
+
+	// snow (default): soft round flakes
+	context.fillStyle = stage.color;
+	context.beginPath();
+	context.arc(px, py, size, 0, Math.PI * 2);
+	context.fill();
+}
+
+/** Draws one particle stage for one point in time. Caller clears the canvas. */
+export function drawParticleStageFrame({
+	context,
+	stage,
+	timeSeconds,
+	width,
+	height,
+}: {
+	context: ProceduralCanvasContext;
+	stage: EffectParticleRenderStage;
+	timeSeconds: number;
+	width: number;
+	height: number;
+}) {
+	const aspectRatio = height > 0 ? width / height : 16 / 9;
+	const particles = sampleEffectParticles({ stage, timeSeconds, aspectRatio });
+	for (const particle of particles) {
+		drawParticle({ context, stage, particle, width, height });
+	}
+	context.globalAlpha = 1;
+}
+
+interface DecorationDrawArgs {
+	context: ProceduralCanvasContext;
+	stage: EffectDecorationRenderStage;
+	width: number;
+	height: number;
+	timeSeconds: number;
+}
+
+function drawGrid({
+	context,
+	stage,
+	width,
+	height,
+}: Omit<DecorationDrawArgs, "timeSeconds">) {
+	const rows = 4;
+	const columns = 6;
+	context.globalAlpha = stage.opacity;
+	context.strokeStyle = stage.color;
+	context.lineWidth = Math.max(1, Math.round(Math.min(width, height) / 220));
+	context.beginPath();
+	for (let row = 1; row < rows; row += 1) {
+		const y = Math.round((row / rows) * height);
+		context.moveTo(0, y);
+		context.lineTo(width, y);
+	}
+	for (let column = 1; column < columns; column += 1) {
+		const x = Math.round((column / columns) * width);
+		context.moveTo(x, 0);
+		context.lineTo(x, height);
+	}
+	context.stroke();
+	context.globalAlpha = 1;
+}
+
+function drawRainbowRays({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	const centerX = width / 2;
+	const centerY = height / 2;
+	const radius = Math.hypot(width, height);
+	const rayCount = 14;
+	const rotation = timeSeconds * 0.25;
+	const hueBase = (timeSeconds * 30) % 360;
+	context.globalAlpha = stage.opacity;
+	context.globalCompositeOperation = "screen";
+	for (let index = 0; index < rayCount; index += 1) {
+		const start = rotation + (index / rayCount) * Math.PI * 2;
+		const end = start + (Math.PI * 2) / rayCount / 2;
+		const hue = (hueBase + (index / rayCount) * 360) % 360;
+		context.beginPath();
+		context.moveTo(centerX, centerY);
+		context.arc(centerX, centerY, radius, start, end);
+		context.closePath();
+		context.fillStyle = `hsla(${hue}, 90%, 60%, 0.5)`;
+		context.fill();
+	}
+	context.globalCompositeOperation = "source-over";
+	context.globalAlpha = 1;
+}
+
+function drawFilmEnd({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// Letterbox bars + a centered "全剧终" title that fades in.
+	const barHeight = Math.round(height * 0.14);
+	context.globalAlpha = stage.opacity;
+	context.fillStyle = "#000000";
+	context.fillRect(0, 0, width, barHeight);
+	context.fillRect(0, height - barHeight, width, barHeight);
+	const fade = Math.min(1, timeSeconds / 1.2);
+	context.globalAlpha = stage.opacity * (0.35 + 0.4 * fade);
+	context.fillRect(0, 0, width, height);
+	context.globalAlpha = fade * stage.opacity;
+	context.fillStyle = stage.color;
+	context.textAlign = "center";
+	context.textBaseline = "middle";
+	context.font = `600 ${Math.round(height * 0.14)}px "Noto Sans SC", sans-serif`;
+	context.fillText("全剧终", width / 2, height / 2);
+	context.globalAlpha = 1;
+}
+
+function drawIris({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// 开幕: black closes in around a growing circular reveal.
+	const progress = Math.min(1, timeSeconds / 1.6);
+	const maxRadius = Math.hypot(width, height) / 2;
+	const radius = progress * maxRadius;
+	context.save();
+	context.globalAlpha = stage.opacity;
+	context.fillStyle = "#000000";
+	context.fillRect(0, 0, width, height);
+	context.globalCompositeOperation = "destination-out";
+	context.beginPath();
+	context.arc(width / 2, height / 2, radius, 0, Math.PI * 2);
+	context.fill();
+	context.restore();
+}
+
+function drawStandby({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// 悬浮待机: viewfinder corner brackets, REC dot, and a sweeping scanline.
+	context.globalAlpha = stage.opacity;
+	context.strokeStyle = stage.color;
+	context.lineWidth = Math.max(1, Math.round(Math.min(width, height) / 90));
+	const margin = Math.round(Math.min(width, height) * 0.06);
+	const armX = Math.round(width * 0.08);
+	const armY = Math.round(height * 0.12);
+	const corners = [
+		[margin, margin, 1, 1],
+		[width - margin, margin, -1, 1],
+		[margin, height - margin, 1, -1],
+		[width - margin, height - margin, -1, -1],
+	] as const;
+	for (const [cx, cy, sx, sy] of corners) {
+		context.beginPath();
+		context.moveTo(cx + sx * armX, cy);
+		context.lineTo(cx, cy);
+		context.lineTo(cx, cy + sy * armY);
+		context.stroke();
+	}
+	const scanY = (timeSeconds * 0.35 * height) % height;
+	context.globalAlpha = stage.opacity * 0.5;
+	context.beginPath();
+	context.moveTo(0, scanY);
+	context.lineTo(width, scanY);
+	context.stroke();
+	context.globalAlpha = stage.opacity;
+	context.fillStyle = "#ff3b3b";
+	const dot = Math.max(2, Math.round(Math.min(width, height) / 45));
+	context.beginPath();
+	context.arc(margin + dot * 2, margin + dot * 2, dot, 0, Math.PI * 2);
+	context.fill();
+	context.globalAlpha = 1;
+}
+
+function drawBurst({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// 射线爆闪: bright radial rays that pulse.
+	const pulse = 0.4 + 0.6 * Math.abs(Math.sin(timeSeconds * 6));
+	const centerX = width / 2;
+	const centerY = height / 2;
+	const radius = Math.hypot(width, height);
+	const rayCount = 24;
+	context.save();
+	context.globalCompositeOperation = "screen";
+	context.globalAlpha = stage.opacity * pulse;
+	context.fillStyle = stage.color;
+	for (let index = 0; index < rayCount; index += 1) {
+		const start = (index / rayCount) * Math.PI * 2;
+		const end = start + (Math.PI * 2) / rayCount / 3;
+		context.beginPath();
+		context.moveTo(centerX, centerY);
+		context.arc(centerX, centerY, radius, start, end);
+		context.closePath();
+		context.fill();
+	}
+	context.restore();
+}
+
+function drawLensFlare({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// 超大光斑: a bright core plus flare circles along a slow-moving diagonal.
+	const t = (Math.sin(timeSeconds * 0.4) + 1) / 2;
+	const sourceX = width * (0.2 + t * 0.6);
+	const sourceY = height * 0.28;
+	const centerX = width / 2;
+	const centerY = height / 2;
+	context.save();
+	context.globalCompositeOperation = "screen";
+	context.globalAlpha = stage.opacity;
+	const core = context.createRadialGradient(
+		sourceX,
+		sourceY,
+		0,
+		sourceX,
+		sourceY,
+		Math.min(width, height) * 0.35
+	);
+	core.addColorStop(0, stage.color);
+	core.addColorStop(1, "rgba(255,255,255,0)");
+	context.fillStyle = core;
+	context.fillRect(0, 0, width, height);
+	for (const offset of [-0.4, 0.3, 0.7, 1.2]) {
+		const fx = sourceX + (centerX - sourceX) * offset;
+		const fy = sourceY + (centerY - sourceY) * offset;
+		const r = Math.min(width, height) * (0.03 + 0.05 * Math.abs(offset));
+		const flare = context.createRadialGradient(fx, fy, 0, fx, fy, r);
+		flare.addColorStop(0, stage.color);
+		flare.addColorStop(1, "rgba(255,255,255,0)");
+		context.globalAlpha = stage.opacity * 0.5;
+		context.fillStyle = flare;
+		context.beginPath();
+		context.arc(fx, fy, r, 0, Math.PI * 2);
+		context.fill();
+	}
+	context.restore();
+}
+
+function drawFloatingText({
+	context,
+	stage,
+	width,
+	height,
+	timeSeconds,
+}: DecorationDrawArgs) {
+	// 文字悬浮 / 祝福环绕: drifting sparkle glyphs for a festive floating layer.
+	const glyphCount = 10;
+	const size = Math.round(Math.min(width, height) * 0.09);
+	context.globalAlpha = stage.opacity;
+	context.fillStyle = stage.color;
+	context.font = `600 ${size}px "Noto Sans SC", sans-serif`;
+	context.textAlign = "center";
+	context.textBaseline = "middle";
+	for (let index = 0; index < glyphCount; index += 1) {
+		const seed = Math.sin(index * 51.3) * 0.5 + 0.5;
+		const drift = (timeSeconds * (0.02 + seed * 0.03)) % 1;
+		const x = (Math.sin(index * 12.9 + timeSeconds * 0.5) * 0.5 + 0.5) * width;
+		const y = ((seed + 1 - drift) % 1) * height;
+		context.globalAlpha =
+			stage.opacity * (0.5 + 0.5 * Math.abs(Math.sin(timeSeconds + index)));
+		context.fillText("✦", x, y);
+	}
+	context.globalAlpha = 1;
+}
+
+/** Draws one decoration stage for one point in time. Caller clears the canvas. */
+export function drawDecorationStageFrame({
+	context,
+	stage,
+	timeSeconds,
+	width,
+	height,
+}: {
+	context: ProceduralCanvasContext;
+	stage: EffectDecorationRenderStage;
+	timeSeconds: number;
+	width: number;
+	height: number;
+}) {
+	const args = { context, stage, width, height, timeSeconds };
+	if (stage.variant === "grid") {
+		drawGrid({ context, stage, width, height });
+	} else if (stage.variant === "rainbow-rays") {
+		drawRainbowRays(args);
+	} else if (stage.variant === "film-end") {
+		drawFilmEnd(args);
+	} else if (stage.variant === "iris") {
+		drawIris(args);
+	} else if (stage.variant === "standby") {
+		drawStandby(args);
+	} else if (stage.variant === "burst") {
+		drawBurst(args);
+	} else if (stage.variant === "lens-flare") {
+		drawLensFlare(args);
+	} else {
+		drawFloatingText(args);
+	}
+}

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-distortion-sources.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-distortion-sources.test.ts
@@ -118,13 +118,13 @@ describe("extractEffectDistortionSources", () => {
 		// One xmap + one ymap, regardless of the element duration.
 		expect(saveEffectSequenceFrame).toHaveBeenCalledTimes(2);
 		expect(saveEffectSequenceFrame).toHaveBeenCalledWith(
-			expect.objectContaining({ sequenceId: "clip-a-s0x", extension: "pgm" })
+			expect.objectContaining({ sequenceId: "p-clip-a-s0x", extension: "pgm" })
 		);
 		expect(result.get("clip-a")).toEqual([
 			{
 				stageIndex: 0,
-				xmapPath: "/tmp/effect-sequences/clip-a-s0x/f_00000.pgm",
-				ymapPath: "/tmp/effect-sequences/clip-a-s0y/f_00000.pgm",
+				xmapPath: "/tmp/effect-sequences/p-clip-a-s0x/f_00000.pgm",
+				ymapPath: "/tmp/effect-sequences/p-clip-a-s0y/f_00000.pgm",
 				animated: false,
 			},
 		]);
@@ -151,8 +151,8 @@ describe("extractEffectDistortionSources", () => {
 		expect(result.get("clip-a")).toEqual([
 			{
 				stageIndex: 0,
-				xmapPath: "/tmp/effect-sequences/clip-a-s0x/f_%05d.pgm",
-				ymapPath: "/tmp/effect-sequences/clip-a-s0y/f_%05d.pgm",
+				xmapPath: "/tmp/effect-sequences/p-clip-a-s0x/f_%05d.pgm",
+				ymapPath: "/tmp/effect-sequences/p-clip-a-s0y/f_%05d.pgm",
 				animated: true,
 				sequence: { framerate: 10 },
 			},

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-distortion-sources.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-distortion-sources.test.ts
@@ -1,0 +1,178 @@
+import type { EffectRenderProgram, TimelineTrack } from "@qcut/editor-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	extractEffectDistortionSources,
+	renderDistortionMapPair,
+} from "../effect-distortion-sources";
+
+function distortionProgram({
+	variant,
+}: {
+	variant: "fisheye" | "ripple" | "shockwave" | "magnifier";
+}): EffectRenderProgram {
+	return {
+		version: 1,
+		stages: [{ kind: "distortion", variant, strength: 1 }],
+	};
+}
+
+function tracksWithElement({
+	elementId,
+	duration,
+}: {
+	elementId: string;
+	duration: number;
+}): TimelineTrack[] {
+	return [
+		{
+			id: "track-1",
+			elements: [{ id: elementId, duration, trimStart: 0, trimEnd: 0 }],
+		},
+	] as unknown as TimelineTrack[];
+}
+
+function createSaveMock() {
+	return vi.fn(
+		async ({
+			sequenceId,
+			frameIndex,
+			extension,
+		}: {
+			sessionId: string;
+			sequenceId: string;
+			frameIndex: number;
+			imageData: Uint8Array;
+			extension?: string;
+		}) => ({
+			success: true,
+			path: `/tmp/effect-sequences/${sequenceId}/f_${String(frameIndex).padStart(5, "0")}.${extension}`,
+			patternPath: `/tmp/effect-sequences/${sequenceId}/f_%05d.${extension}`,
+		})
+	);
+}
+
+describe("renderDistortionMapPair", () => {
+	it("writes 16-bit big-endian PGM maps with full-res coordinates", () => {
+		const { xmap, ymap } = renderDistortionMapPair({
+			stage: { kind: "distortion", variant: "fisheye", strength: 1 },
+			timeSeconds: 0,
+			mapWidth: 4,
+			mapHeight: 2,
+			sourceWidth: 1920,
+			sourceHeight: 1080,
+		});
+
+		const header = "P5\n4 2\n65535\n";
+		const decoder = new TextDecoder();
+		expect(decoder.decode(xmap.slice(0, header.length))).toBe(header);
+		expect(decoder.decode(ymap.slice(0, header.length))).toBe(header);
+		expect(xmap.length).toBe(header.length + 4 * 2 * 2);
+		expect(ymap.length).toBe(header.length + 4 * 2 * 2);
+
+		// Every stored coordinate must stay within the source bounds.
+		for (let i = header.length; i < xmap.length; i += 2) {
+			const x = (xmap[i] << 8) | xmap[i + 1];
+			const y = (ymap[i] << 8) | ymap[i + 1];
+			expect(x).toBeGreaterThanOrEqual(0);
+			expect(x).toBeLessThanOrEqual(1919);
+			expect(y).toBeGreaterThanOrEqual(0);
+			expect(y).toBeLessThanOrEqual(1079);
+		}
+	});
+
+	it("keeps the untouched region an identity map for the magnifier", () => {
+		const width = 64;
+		const height = 64;
+		const { xmap } = renderDistortionMapPair({
+			stage: { kind: "distortion", variant: "magnifier", strength: 1 },
+			timeSeconds: 0,
+			mapWidth: width,
+			mapHeight: height,
+			sourceWidth: width,
+			sourceHeight: height,
+		});
+		const headerLength = xmap.length - width * height * 2;
+		// Top-left corner is outside the loupe: expect identity sampling.
+		const cornerX = (xmap[headerLength] << 8) | xmap[headerLength + 1];
+		expect(cornerX).toBe(0);
+	});
+});
+
+describe("extractEffectDistortionSources", () => {
+	it("bakes one map pair for static variants", async () => {
+		const saveEffectSequenceFrame = createSaveMock();
+
+		const result = await extractEffectDistortionSources({
+			programsByElementId: new Map([
+				["clip-a", distortionProgram({ variant: "fisheye" })],
+			]),
+			tracks: tracksWithElement({ elementId: "clip-a", duration: 30 }),
+			sessionId: "session-1",
+			canvasWidth: 640,
+			canvasHeight: 360,
+			fps: 30,
+			api: { saveEffectSequenceFrame },
+			logger: vi.fn(),
+		});
+
+		// One xmap + one ymap, regardless of the element duration.
+		expect(saveEffectSequenceFrame).toHaveBeenCalledTimes(2);
+		expect(saveEffectSequenceFrame).toHaveBeenCalledWith(
+			expect.objectContaining({ sequenceId: "clip-a-s0x", extension: "pgm" })
+		);
+		expect(result.get("clip-a")).toEqual([
+			{
+				stageIndex: 0,
+				xmapPath: "/tmp/effect-sequences/clip-a-s0x/f_00000.pgm",
+				ymapPath: "/tmp/effect-sequences/clip-a-s0y/f_00000.pgm",
+				animated: false,
+			},
+		]);
+	});
+
+	it("bakes per-frame map pairs for animated variants", async () => {
+		const saveEffectSequenceFrame = createSaveMock();
+
+		const result = await extractEffectDistortionSources({
+			programsByElementId: new Map([
+				["clip-a", distortionProgram({ variant: "ripple" })],
+			]),
+			tracks: tracksWithElement({ elementId: "clip-a", duration: 0.5 }),
+			sessionId: "session-1",
+			canvasWidth: 640,
+			canvasHeight: 360,
+			fps: 10,
+			api: { saveEffectSequenceFrame },
+			logger: vi.fn(),
+		});
+
+		// 0.5s at 10fps → 5 frames × 2 maps.
+		expect(saveEffectSequenceFrame).toHaveBeenCalledTimes(10);
+		expect(result.get("clip-a")).toEqual([
+			{
+				stageIndex: 0,
+				xmapPath: "/tmp/effect-sequences/clip-a-s0x/f_%05d.pgm",
+				ymapPath: "/tmp/effect-sequences/clip-a-s0y/f_%05d.pgm",
+				animated: true,
+				sequence: { framerate: 10 },
+			},
+		]);
+	});
+
+	it("throws when the target element is missing from the timeline", async () => {
+		await expect(
+			extractEffectDistortionSources({
+				programsByElementId: new Map([
+					["ghost", distortionProgram({ variant: "fisheye" })],
+				]),
+				tracks: tracksWithElement({ elementId: "clip-a", duration: 1 }),
+				sessionId: "session-1",
+				canvasWidth: 640,
+				canvasHeight: 360,
+				fps: 30,
+				api: { saveEffectSequenceFrame: createSaveMock() },
+				logger: vi.fn(),
+			})
+		).rejects.toThrow(/missing from the timeline: ghost/);
+	});
+});

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-procedural-sources.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-procedural-sources.test.ts
@@ -126,7 +126,7 @@ describe("extractEffectProceduralSources", () => {
 			1,
 			expect.objectContaining({
 				sessionId: "session-1",
-				sequenceId: "clip-a-s0",
+				sequenceId: "p-clip-a-s0",
 				frameIndex: 0,
 			})
 		);
@@ -135,7 +135,7 @@ describe("extractEffectProceduralSources", () => {
 			{
 				resourceId: "procedural:particles:snow",
 				stageIndex: 0,
-				path: "/tmp/effect-sequences/clip-a-s0/f_%05d.png",
+				path: "/tmp/effect-sequences/p-clip-a-s0/f_%05d.png",
 				animated: true,
 				sequence: { framerate: 10 },
 			},
@@ -162,7 +162,7 @@ describe("extractEffectProceduralSources", () => {
 			{
 				resourceId: "procedural:decoration:grid",
 				stageIndex: 0,
-				path: "/tmp/effect-sequences/clip-b-s0/f_00000.png",
+				path: "/tmp/effect-sequences/p-clip-b-s0/f_00000.png",
 				animated: false,
 			},
 		]);

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-procedural-sources.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-procedural-sources.test.ts
@@ -1,0 +1,207 @@
+import type { EffectRenderProgram, TimelineTrack } from "@qcut/editor-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	extractEffectProceduralSources,
+	type CreateProceduralFrameCanvas,
+} from "../effect-procedural-sources";
+
+function particleProgram(): EffectRenderProgram {
+	return {
+		version: 1,
+		stages: [
+			{
+				kind: "particles",
+				variant: "snow",
+				density: 0.5,
+				speed: 1,
+				color: "#ffffff",
+				opacity: 1,
+			},
+		],
+	};
+}
+
+function gridProgram(): EffectRenderProgram {
+	return {
+		version: 1,
+		stages: [
+			{
+				kind: "decoration",
+				variant: "grid",
+				color: "#ffffff",
+				opacity: 0.6,
+			},
+		],
+	};
+}
+
+function tracksWithElement({
+	elementId,
+	duration,
+	trimStart = 0,
+	trimEnd = 0,
+}: {
+	elementId: string;
+	duration: number;
+	trimStart?: number;
+	trimEnd?: number;
+}): TimelineTrack[] {
+	return [
+		{
+			id: "track-1",
+			elements: [{ id: elementId, duration, trimStart, trimEnd }],
+		},
+	] as unknown as TimelineTrack[];
+}
+
+function createStubCanvas(): CreateProceduralFrameCanvas {
+	const gradient = { addColorStop: () => {} };
+	const context = new Proxy(
+		{},
+		{
+			get: (_target, prop) => {
+				if (
+					prop === "createRadialGradient" ||
+					prop === "createLinearGradient"
+				) {
+					return () => gradient;
+				}
+				return () => {};
+			},
+			set: () => true,
+		}
+	) as unknown as OffscreenCanvasRenderingContext2D;
+	return ({ width, height }) => ({
+		width,
+		height,
+		getContext: () => context,
+		convertToBlob: async () =>
+			new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }),
+	});
+}
+
+function createSaveMock() {
+	return vi.fn(
+		async ({
+			sequenceId,
+			frameIndex,
+		}: {
+			sessionId: string;
+			sequenceId: string;
+			frameIndex: number;
+			imageData: Uint8Array;
+		}) => ({
+			success: true,
+			path: `/tmp/effect-sequences/${sequenceId}/f_${String(frameIndex).padStart(5, "0")}.png`,
+			patternPath: `/tmp/effect-sequences/${sequenceId}/f_%05d.png`,
+		})
+	);
+}
+
+describe("extractEffectProceduralSources", () => {
+	it("bakes animated stages to one PNG per output frame", async () => {
+		const saveEffectSequenceFrame = createSaveMock();
+		const progress: number[] = [];
+
+		const result = await extractEffectProceduralSources({
+			programsByElementId: new Map([["clip-a", particleProgram()]]),
+			tracks: tracksWithElement({
+				elementId: "clip-a",
+				duration: 1,
+				trimEnd: 0.5,
+			}),
+			sessionId: "session-1",
+			canvasWidth: 640,
+			canvasHeight: 360,
+			fps: 10,
+			api: { saveEffectSequenceFrame },
+			createCanvas: createStubCanvas(),
+			logger: vi.fn(),
+			onProgress: ({ bakedFrames }) => progress.push(bakedFrames),
+		});
+
+		// 0.5s visible at 10fps → 5 frames.
+		expect(saveEffectSequenceFrame).toHaveBeenCalledTimes(5);
+		expect(saveEffectSequenceFrame).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				sessionId: "session-1",
+				sequenceId: "clip-a-s0",
+				frameIndex: 0,
+			})
+		);
+		expect(progress).toEqual([1, 2, 3, 4, 5]);
+		expect(result.get("clip-a")).toEqual([
+			{
+				resourceId: "procedural:particles:snow",
+				stageIndex: 0,
+				path: "/tmp/effect-sequences/clip-a-s0/f_%05d.png",
+				animated: true,
+				sequence: { framerate: 10 },
+			},
+		]);
+	});
+
+	it("bakes static decorations to a single looped frame", async () => {
+		const saveEffectSequenceFrame = createSaveMock();
+
+		const result = await extractEffectProceduralSources({
+			programsByElementId: new Map([["clip-b", gridProgram()]]),
+			tracks: tracksWithElement({ elementId: "clip-b", duration: 30 }),
+			sessionId: "session-1",
+			canvasWidth: 640,
+			canvasHeight: 360,
+			fps: 30,
+			api: { saveEffectSequenceFrame },
+			createCanvas: createStubCanvas(),
+			logger: vi.fn(),
+		});
+
+		expect(saveEffectSequenceFrame).toHaveBeenCalledTimes(1);
+		expect(result.get("clip-b")).toEqual([
+			{
+				resourceId: "procedural:decoration:grid",
+				stageIndex: 0,
+				path: "/tmp/effect-sequences/clip-b-s0/f_00000.png",
+				animated: false,
+			},
+		]);
+	});
+
+	it("throws when the target element is missing from the timeline", async () => {
+		await expect(
+			extractEffectProceduralSources({
+				programsByElementId: new Map([["ghost", particleProgram()]]),
+				tracks: tracksWithElement({ elementId: "clip-a", duration: 1 }),
+				sessionId: "session-1",
+				canvasWidth: 640,
+				canvasHeight: 360,
+				fps: 30,
+				api: { saveEffectSequenceFrame: createSaveMock() },
+				createCanvas: createStubCanvas(),
+				logger: vi.fn(),
+			})
+		).rejects.toThrow(/missing from the timeline: ghost/);
+	});
+
+	it("surfaces frame save failures with the sequence id", async () => {
+		const saveEffectSequenceFrame = vi.fn(async () => ({
+			success: false,
+			error: "disk full",
+		}));
+
+		await expect(
+			extractEffectProceduralSources({
+				programsByElementId: new Map([["clip-a", particleProgram()]]),
+				tracks: tracksWithElement({ elementId: "clip-a", duration: 1 }),
+				sessionId: "session-1",
+				canvasWidth: 640,
+				canvasHeight: 360,
+				fps: 30,
+				api: { saveEffectSequenceFrame },
+				createCanvas: createStubCanvas(),
+				logger: vi.fn(),
+			})
+		).rejects.toThrow("disk full");
+	});
+});

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { sanitizeSequenceElementId } from "../effect-sequence-shared";
 
 describe("sanitizeSequenceElementId", () => {
-	it("returns already-safe ids unchanged", () => {
+	it("keeps already-safe ids readable in the plain namespace", () => {
 		expect(sanitizeSequenceElementId({ elementId: "clip-a_1.b" })).toBe(
-			"clip-a_1.b"
+			"p-clip-a_1.b"
 		);
 	});
 
@@ -13,14 +13,23 @@ describe("sanitizeSequenceElementId", () => {
 		expect(sanitized).toMatch(/^[a-zA-Z0-9._-]+$/);
 	});
 
-	it("keeps distinct ids distinct after sanitizing", () => {
-		// Both would collapse to "clip_a" under plain charset replacement.
-		const slash = sanitizeSequenceElementId({ elementId: "clip/a" });
-		const underscore = sanitizeSequenceElementId({ elementId: "clip_a" });
-		const colon = sanitizeSequenceElementId({ elementId: "clip:a" });
-		expect(slash).not.toBe(underscore);
-		expect(slash).not.toBe(colon);
+	it("is injective: distinct ids never share a directory", () => {
+		// All of these would collapse to "clip_a" under charset replacement,
+		// and the last one tries to impersonate an encoded name directly.
+		const ids = [
+			"clip/a",
+			"clip_a",
+			"clip:a",
+			"e-clip_a-636c69702f61",
+			"p-clip_a",
+		];
+		const mapped = ids.map((elementId) =>
+			sanitizeSequenceElementId({ elementId })
+		);
+		expect(new Set(mapped).size).toBe(ids.length);
 		// Deterministic: same input always maps to the same directory.
-		expect(sanitizeSequenceElementId({ elementId: "clip/a" })).toBe(slash);
+		expect(sanitizeSequenceElementId({ elementId: "clip/a" })).toBe(mapped[0]);
+		// Encoded ids end with the full hex of the original id ("clip/a").
+		expect(mapped[0]).toBe("e-clip_a-636c69702f61");
 	});
 });

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSequenceElementId } from "../effect-sequence-shared";
+
+describe("sanitizeSequenceElementId", () => {
+	it("returns already-safe ids unchanged", () => {
+		expect(sanitizeSequenceElementId({ elementId: "clip-a_1.b" })).toBe(
+			"clip-a_1.b"
+		);
+	});
+
+	it("keeps sanitized ids filesystem-safe", () => {
+		const sanitized = sanitizeSequenceElementId({ elementId: "clip/😀 a" });
+		expect(sanitized).toMatch(/^[a-zA-Z0-9._-]+$/);
+	});
+
+	it("keeps distinct ids distinct after sanitizing", () => {
+		// Both would collapse to "clip_a" under plain charset replacement.
+		const slash = sanitizeSequenceElementId({ elementId: "clip/a" });
+		const underscore = sanitizeSequenceElementId({ elementId: "clip_a" });
+		const colon = sanitizeSequenceElementId({ elementId: "clip:a" });
+		expect(slash).not.toBe(underscore);
+		expect(slash).not.toBe(colon);
+		// Deterministic: same input always maps to the same directory.
+		expect(sanitizeSequenceElementId({ elementId: "clip/a" })).toBe(slash);
+	});
+});

--- a/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/__tests__/effect-sequence-shared.test.ts
@@ -14,14 +14,17 @@ describe("sanitizeSequenceElementId", () => {
 	});
 
 	it("is injective: distinct ids never share a directory", () => {
-		// All of these would collapse to "clip_a" under charset replacement,
-		// and the last one tries to impersonate an encoded name directly.
+		// The first three would collapse to "clip_a" under charset replacement,
+		// the next two impersonate encoded/plain names directly, and the lone
+		// surrogates would fold together under a UTF-8 (TextEncoder) round trip.
 		const ids = [
 			"clip/a",
 			"clip_a",
 			"clip:a",
-			"e-clip_a-636c69702f61",
+			"e-clip_a-0063006c00690070002f0061",
 			"p-clip_a",
+			"clip/\uD800",
+			"clip/\uD801",
 		];
 		const mapped = ids.map((elementId) =>
 			sanitizeSequenceElementId({ elementId })
@@ -29,7 +32,7 @@ describe("sanitizeSequenceElementId", () => {
 		expect(new Set(mapped).size).toBe(ids.length);
 		// Deterministic: same input always maps to the same directory.
 		expect(sanitizeSequenceElementId({ elementId: "clip/a" })).toBe(mapped[0]);
-		// Encoded ids end with the full hex of the original id ("clip/a").
-		expect(mapped[0]).toBe("e-clip_a-636c69702f61");
+		// Encoded ids end with the fixed-width UTF-16 hex of the original id.
+		expect(mapped[0]).toBe("e-clip_a-0063006c00690070002f0061");
 	});
 });

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
@@ -142,8 +142,16 @@ export function renderDistortionMapPair({
 				v: (y + 0.5) / mapHeight,
 				timeSeconds,
 			});
-			const sx = Math.round(sample.u * (sourceWidth - 1));
-			const sy = Math.round(sample.v * (sourceHeight - 1));
+			// Clamp so a future non-clamping sampler variant cannot wrap the
+			// unsigned 16-bit PGM values out of the source bounds.
+			const sx = Math.max(
+				0,
+				Math.min(sourceWidth - 1, Math.round(sample.u * (sourceWidth - 1)))
+			);
+			const sy = Math.max(
+				0,
+				Math.min(sourceHeight - 1, Math.round(sample.v * (sourceHeight - 1)))
+			);
 			// PGM P5 with maxval 65535 stores big-endian 16-bit samples.
 			xmap[offset] = (sx >> 8) & 0xff;
 			xmap[offset + 1] = sx & 0xff;
@@ -268,6 +276,11 @@ export async function extractEffectDistortionSources({
 	}
 	if (!(fps > 0)) {
 		throw new Error(`Distortion map bake requires a positive fps: ${fps}`);
+	}
+	if (!(canvasWidth > 0) || !(canvasHeight > 0)) {
+		throw new Error(
+			`Distortion map bake requires positive canvas dimensions: ${canvasWidth}x${canvasHeight}`
+		);
 	}
 
 	const sourcesByElementId = new Map<string, EffectDistortionSourceInput[]>();

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
@@ -1,0 +1,299 @@
+import {
+	sampleDistortionSource,
+	type EffectDistortionRenderStage,
+	type EffectRenderProgram,
+	type TimelineTrack,
+} from "@qcut/editor-core";
+import { platform } from "@qcut/platform-core";
+import type { EffectDistortionSourceInput } from "../types";
+
+type LogFn = (...args: unknown[]) => void;
+
+interface DistortionStageReference {
+	elementId: string;
+	stageIndex: number;
+	stage: EffectDistortionRenderStage;
+}
+
+interface EffectSequenceExportAPI {
+	saveEffectSequenceFrame: (params: {
+		sessionId: string;
+		sequenceId: string;
+		frameIndex: number;
+		imageData: Uint8Array;
+		extension?: string;
+	}) => Promise<{
+		success: boolean;
+		path?: string;
+		patternPath?: string;
+		error?: string;
+	}>;
+}
+
+/**
+ * Remap coordinate maps are sampled at a reduced resolution and scaled back
+ * up inside the FFmpeg graph (mirrors the preview's capped remap buffer).
+ */
+const MAP_MAX_SIDE = 480;
+
+function collectDistortionStageReferences({
+	programsByElementId,
+}: {
+	programsByElementId: ReadonlyMap<string, EffectRenderProgram>;
+}): DistortionStageReference[] {
+	const references: DistortionStageReference[] = [];
+	for (const [elementId, program] of programsByElementId) {
+		for (const [stageIndex, stage] of program.stages.entries()) {
+			if (stage.kind !== "distortion") continue;
+			references.push({ elementId, stageIndex, stage });
+		}
+	}
+	return references;
+}
+
+/** Fisheye and magnifier ignore time; ripple and shockwave animate. */
+function isDistortionStageAnimated({
+	stage,
+}: {
+	stage: EffectDistortionRenderStage;
+}): boolean {
+	return stage.variant === "ripple" || stage.variant === "shockwave";
+}
+
+function sequenceId({
+	elementId,
+	stageIndex,
+	axis,
+}: {
+	elementId: string;
+	stageIndex: number;
+	axis: "x" | "y";
+}): string {
+	return `${elementId.replace(/[^a-zA-Z0-9._-]/g, "_")}-s${stageIndex}${axis}`;
+}
+
+function elementTimelineDurationSeconds({
+	tracks,
+	elementId,
+}: {
+	tracks: readonly TimelineTrack[];
+	elementId: string;
+}): number | undefined {
+	for (const track of tracks) {
+		for (const element of track.elements) {
+			if (element.id !== elementId) continue;
+			return Math.max(
+				0,
+				element.duration - element.trimStart - element.trimEnd
+			);
+		}
+	}
+	return undefined;
+}
+
+function mapDimensions({
+	canvasWidth,
+	canvasHeight,
+}: {
+	canvasWidth: number;
+	canvasHeight: number;
+}): { mapWidth: number; mapHeight: number } {
+	const scale = Math.min(1, MAP_MAX_SIDE / Math.max(canvasWidth, canvasHeight));
+	return {
+		mapWidth: Math.max(2, Math.round(canvasWidth * scale)),
+		mapHeight: Math.max(2, Math.round(canvasHeight * scale)),
+	};
+}
+
+/**
+ * Renders one xmap/ymap pair for FFmpeg's remap filter as 16-bit P5 PGM
+ * buffers. Values are absolute source coordinates in full-resolution pixel
+ * units, so the maps can be generated small and scaled up in-graph.
+ */
+export function renderDistortionMapPair({
+	stage,
+	timeSeconds,
+	mapWidth,
+	mapHeight,
+	sourceWidth,
+	sourceHeight,
+}: {
+	stage: EffectDistortionRenderStage;
+	timeSeconds: number;
+	mapWidth: number;
+	mapHeight: number;
+	sourceWidth: number;
+	sourceHeight: number;
+}): { xmap: Uint8Array; ymap: Uint8Array } {
+	const header = new TextEncoder().encode(
+		`P5\n${mapWidth} ${mapHeight}\n65535\n`
+	);
+	const xmap = new Uint8Array(header.length + mapWidth * mapHeight * 2);
+	const ymap = new Uint8Array(header.length + mapWidth * mapHeight * 2);
+	xmap.set(header);
+	ymap.set(header);
+
+	let offset = header.length;
+	for (let y = 0; y < mapHeight; y += 1) {
+		for (let x = 0; x < mapWidth; x += 1) {
+			const sample = sampleDistortionSource({
+				stage,
+				u: (x + 0.5) / mapWidth,
+				v: (y + 0.5) / mapHeight,
+				timeSeconds,
+			});
+			const sx = Math.round(sample.u * (sourceWidth - 1));
+			const sy = Math.round(sample.v * (sourceHeight - 1));
+			// PGM P5 with maxval 65535 stores big-endian 16-bit samples.
+			xmap[offset] = (sx >> 8) & 0xff;
+			xmap[offset + 1] = sx & 0xff;
+			ymap[offset] = (sy >> 8) & 0xff;
+			ymap[offset + 1] = sy & 0xff;
+			offset += 2;
+		}
+	}
+	return { xmap, ymap };
+}
+
+async function bakeDistortionStage({
+	api,
+	canvasHeight,
+	canvasWidth,
+	fps,
+	durationSeconds,
+	logger,
+	reference,
+	sessionId,
+}: {
+	api: EffectSequenceExportAPI;
+	canvasHeight: number;
+	canvasWidth: number;
+	fps: number;
+	durationSeconds: number;
+	logger: LogFn;
+	reference: DistortionStageReference;
+	sessionId: string;
+}): Promise<EffectDistortionSourceInput> {
+	const animated = isDistortionStageAnimated({ stage: reference.stage });
+	const frameCount = animated
+		? Math.max(1, Math.ceil(durationSeconds * fps))
+		: 1;
+	const { mapWidth, mapHeight } = mapDimensions({ canvasWidth, canvasHeight });
+
+	const xSequenceId = sequenceId({ ...reference, axis: "x" });
+	const ySequenceId = sequenceId({ ...reference, axis: "y" });
+	let xmapPath: string | undefined;
+	let ymapPath: string | undefined;
+	for (let frame = 0; frame < frameCount; frame += 1) {
+		const pair = renderDistortionMapPair({
+			stage: reference.stage,
+			timeSeconds: frame / fps,
+			mapWidth,
+			mapHeight,
+			sourceWidth: canvasWidth,
+			sourceHeight: canvasHeight,
+		});
+		const [xResult, yResult] = await Promise.all([
+			api.saveEffectSequenceFrame({
+				sessionId,
+				sequenceId: xSequenceId,
+				frameIndex: frame,
+				imageData: pair.xmap,
+				extension: "pgm",
+			}),
+			api.saveEffectSequenceFrame({
+				sessionId,
+				sequenceId: ySequenceId,
+				frameIndex: frame,
+				imageData: pair.ymap,
+				extension: "pgm",
+			}),
+		]);
+		for (const result of [xResult, yResult]) {
+			if (!result.success) {
+				throw new Error(
+					result.error ||
+						`Failed to save distortion map frame ${frame} for ${xSequenceId}`
+				);
+			}
+		}
+		xmapPath ??= animated ? xResult.patternPath : xResult.path;
+		ymapPath ??= animated ? yResult.patternPath : yResult.path;
+	}
+
+	if (!xmapPath || !ymapPath) {
+		throw new Error(`Distortion maps saved without paths: ${xSequenceId}`);
+	}
+	logger(
+		`[EffectDistortionSources] Baked ${frameCount} map pair(s) for ${xSequenceId} (${mapWidth}x${mapHeight})`
+	);
+	return {
+		stageIndex: reference.stageIndex,
+		xmapPath,
+		ymapPath,
+		animated,
+		...(animated ? { sequence: { framerate: fps } } : {}),
+	};
+}
+
+/**
+ * Bakes distortion render stages (鱼眼/放大镜/水波纹/冲击波) into remap
+ * coordinate-map files so native FFmpeg reproduces the preview's per-pixel
+ * source remapping. Static variants bake one map pair; animated variants
+ * bake one pair per output frame.
+ */
+export async function extractEffectDistortionSources({
+	programsByElementId,
+	tracks,
+	sessionId,
+	canvasWidth,
+	canvasHeight,
+	fps,
+	api = platform().ffmpeg as unknown as EffectSequenceExportAPI,
+	logger = console.log,
+}: {
+	programsByElementId: ReadonlyMap<string, EffectRenderProgram>;
+	tracks: readonly TimelineTrack[];
+	sessionId: string;
+	canvasWidth: number;
+	canvasHeight: number;
+	fps: number;
+	api?: EffectSequenceExportAPI;
+	logger?: LogFn;
+}): Promise<ReadonlyMap<string, EffectDistortionSourceInput[]>> {
+	const references = collectDistortionStageReferences({ programsByElementId });
+	if (references.length === 0) return new Map();
+	if (!api?.saveEffectSequenceFrame) {
+		throw new Error("Distortion effect export API is unavailable");
+	}
+	if (!(fps > 0)) {
+		throw new Error(`Distortion map bake requires a positive fps: ${fps}`);
+	}
+
+	const sourcesByElementId = new Map<string, EffectDistortionSourceInput[]>();
+	for (const reference of references) {
+		const durationSeconds = elementTimelineDurationSeconds({
+			tracks,
+			elementId: reference.elementId,
+		});
+		if (durationSeconds === undefined) {
+			throw new Error(
+				`Distortion effect target is missing from the timeline: ${reference.elementId}`
+			);
+		}
+		const source = await bakeDistortionStage({
+			api,
+			canvasHeight,
+			canvasWidth,
+			fps,
+			durationSeconds,
+			logger,
+			reference,
+			sessionId,
+		});
+		const sources = sourcesByElementId.get(reference.elementId) ?? [];
+		sources.push(source);
+		sourcesByElementId.set(reference.elementId, sources);
+	}
+	return sourcesByElementId;
+}

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-distortion-sources.ts
@@ -4,30 +4,19 @@ import {
 	type EffectRenderProgram,
 	type TimelineTrack,
 } from "@qcut/editor-core";
-import { platform } from "@qcut/platform-core";
 import type { EffectDistortionSourceInput } from "../types";
-
-type LogFn = (...args: unknown[]) => void;
+import {
+	defaultEffectSequenceExportAPI,
+	elementTimelineDurationSeconds,
+	sanitizeSequenceElementId,
+	type EffectSequenceExportAPI,
+	type LogFn,
+} from "./effect-sequence-shared";
 
 interface DistortionStageReference {
 	elementId: string;
 	stageIndex: number;
 	stage: EffectDistortionRenderStage;
-}
-
-interface EffectSequenceExportAPI {
-	saveEffectSequenceFrame: (params: {
-		sessionId: string;
-		sequenceId: string;
-		frameIndex: number;
-		imageData: Uint8Array;
-		extension?: string;
-	}) => Promise<{
-		success: boolean;
-		path?: string;
-		patternPath?: string;
-		error?: string;
-	}>;
 }
 
 /**
@@ -69,26 +58,7 @@ function sequenceId({
 	stageIndex: number;
 	axis: "x" | "y";
 }): string {
-	return `${elementId.replace(/[^a-zA-Z0-9._-]/g, "_")}-s${stageIndex}${axis}`;
-}
-
-function elementTimelineDurationSeconds({
-	tracks,
-	elementId,
-}: {
-	tracks: readonly TimelineTrack[];
-	elementId: string;
-}): number | undefined {
-	for (const track of tracks) {
-		for (const element of track.elements) {
-			if (element.id !== elementId) continue;
-			return Math.max(
-				0,
-				element.duration - element.trimStart - element.trimEnd
-			);
-		}
-	}
-	return undefined;
+	return `${sanitizeSequenceElementId({ elementId })}-s${stageIndex}${axis}`;
 }
 
 function mapDimensions({
@@ -257,7 +227,7 @@ export async function extractEffectDistortionSources({
 	canvasWidth,
 	canvasHeight,
 	fps,
-	api = platform().ffmpeg as unknown as EffectSequenceExportAPI,
+	api = defaultEffectSequenceExportAPI(),
 	logger = console.log,
 }: {
 	programsByElementId: ReadonlyMap<string, EffectRenderProgram>;

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
@@ -1,0 +1,312 @@
+import type {
+	EffectDecorationRenderStage,
+	EffectParticleRenderStage,
+	EffectRenderProgram,
+	TimelineTrack,
+} from "@qcut/editor-core";
+import { platform } from "@qcut/platform-core";
+import {
+	drawDecorationStageFrame,
+	drawParticleStageFrame,
+	isDecorationStageAnimated,
+} from "@/lib/effects/effect-procedural-draw";
+import type { EffectOverlaySourceInput } from "../types";
+
+type LogFn = (...args: unknown[]) => void;
+
+type ProceduralRenderStage =
+	| EffectParticleRenderStage
+	| EffectDecorationRenderStage;
+
+interface ProceduralStageReference {
+	elementId: string;
+	stageIndex: number;
+	stage: ProceduralRenderStage;
+}
+
+interface EffectSequenceExportAPI {
+	saveEffectSequenceFrame: (params: {
+		sessionId: string;
+		sequenceId: string;
+		frameIndex: number;
+		imageData: Uint8Array;
+	}) => Promise<{
+		success: boolean;
+		path?: string;
+		patternPath?: string;
+		error?: string;
+	}>;
+}
+
+interface ProceduralFrameCanvas {
+	width: number;
+	height: number;
+	getContext(kind: "2d"): OffscreenCanvasRenderingContext2D | null;
+	convertToBlob(options?: { type?: string }): Promise<Blob>;
+}
+
+export type CreateProceduralFrameCanvas = ({
+	width,
+	height,
+}: {
+	width: number;
+	height: number;
+}) => ProceduralFrameCanvas;
+
+function collectProceduralStageReferences({
+	programsByElementId,
+}: {
+	programsByElementId: ReadonlyMap<string, EffectRenderProgram>;
+}): ProceduralStageReference[] {
+	const references: ProceduralStageReference[] = [];
+	for (const [elementId, program] of programsByElementId) {
+		for (const [stageIndex, stage] of program.stages.entries()) {
+			if (stage.kind !== "particles" && stage.kind !== "decoration") continue;
+			references.push({ elementId, stageIndex, stage });
+		}
+	}
+	return references;
+}
+
+function proceduralResourceId({
+	stage,
+}: {
+	stage: ProceduralRenderStage;
+}): string {
+	return `procedural:${stage.kind}:${stage.variant}`;
+}
+
+function sequenceId({
+	elementId,
+	stageIndex,
+}: {
+	elementId: string;
+	stageIndex: number;
+}): string {
+	return `${elementId.replace(/[^a-zA-Z0-9._-]/g, "_")}-s${stageIndex}`;
+}
+
+function isStageAnimated({ stage }: { stage: ProceduralRenderStage }): boolean {
+	if (stage.kind === "particles") return true;
+	return isDecorationStageAnimated({ stage });
+}
+
+function elementTimelineDurationSeconds({
+	tracks,
+	elementId,
+}: {
+	tracks: readonly TimelineTrack[];
+	elementId: string;
+}): number | undefined {
+	for (const track of tracks) {
+		for (const element of track.elements) {
+			if (element.id !== elementId) continue;
+			return Math.max(
+				0,
+				element.duration - element.trimStart - element.trimEnd
+			);
+		}
+	}
+	return undefined;
+}
+
+function drawProceduralFrame({
+	context,
+	stage,
+	timeSeconds,
+	width,
+	height,
+}: {
+	context: OffscreenCanvasRenderingContext2D;
+	stage: ProceduralRenderStage;
+	timeSeconds: number;
+	width: number;
+	height: number;
+}) {
+	context.clearRect(0, 0, width, height);
+	if (stage.kind === "particles") {
+		drawParticleStageFrame({ context, stage, timeSeconds, width, height });
+		return;
+	}
+	drawDecorationStageFrame({ context, stage, timeSeconds, width, height });
+}
+
+async function bakeStageSequence({
+	api,
+	canvasHeight,
+	canvasWidth,
+	createCanvas,
+	fps,
+	durationSeconds,
+	logger,
+	onFrameBaked,
+	reference,
+	sessionId,
+}: {
+	api: EffectSequenceExportAPI;
+	canvasHeight: number;
+	canvasWidth: number;
+	createCanvas: CreateProceduralFrameCanvas;
+	fps: number;
+	durationSeconds: number;
+	logger: LogFn;
+	onFrameBaked?: () => void;
+	reference: ProceduralStageReference;
+	sessionId: string;
+}): Promise<EffectOverlaySourceInput> {
+	const animated = isStageAnimated({ stage: reference.stage });
+	const frameCount = animated
+		? Math.max(1, Math.ceil(durationSeconds * fps))
+		: 1;
+	const canvas = createCanvas({ width: canvasWidth, height: canvasHeight });
+	const context = canvas.getContext("2d");
+	if (!context) {
+		throw new Error("Procedural effect bake could not create a 2D context");
+	}
+
+	const id = sequenceId(reference);
+	let firstPath: string | undefined;
+	let patternPath: string | undefined;
+	for (let frame = 0; frame < frameCount; frame += 1) {
+		drawProceduralFrame({
+			context,
+			stage: reference.stage,
+			timeSeconds: frame / fps,
+			width: canvasWidth,
+			height: canvasHeight,
+		});
+		const blob = await canvas.convertToBlob({ type: "image/png" });
+		const result = await api.saveEffectSequenceFrame({
+			sessionId,
+			sequenceId: id,
+			frameIndex: frame,
+			imageData: new Uint8Array(await blob.arrayBuffer()),
+		});
+		if (!result.success) {
+			throw new Error(
+				result.error ||
+					`Failed to save procedural effect frame ${frame} for ${id}`
+			);
+		}
+		firstPath ??= result.path;
+		patternPath ??= result.patternPath;
+		onFrameBaked?.();
+	}
+
+	if (animated) {
+		if (!patternPath) {
+			throw new Error(`Procedural effect sequence has no pattern path: ${id}`);
+		}
+		logger(
+			`[EffectProceduralSources] Baked ${frameCount} frames for ${id}: ${patternPath}`
+		);
+		return {
+			resourceId: proceduralResourceId({ stage: reference.stage }),
+			stageIndex: reference.stageIndex,
+			path: patternPath,
+			animated: true,
+			sequence: { framerate: fps },
+		};
+	}
+
+	if (!firstPath) {
+		throw new Error(`Procedural effect frame saved without a path: ${id}`);
+	}
+	logger(
+		`[EffectProceduralSources] Baked static frame for ${id}: ${firstPath}`
+	);
+	return {
+		resourceId: proceduralResourceId({ stage: reference.stage }),
+		stageIndex: reference.stageIndex,
+		path: firstPath,
+		animated: false,
+	};
+}
+
+/**
+ * Bakes particle/decoration render stages into transparent RGBA frame
+ * sequences on disk so the native FFmpeg export composites the exact frames
+ * the preview draws. Static decorations bake a single frame (looped by
+ * FFmpeg); animated stages bake one PNG per output frame.
+ */
+export async function extractEffectProceduralSources({
+	programsByElementId,
+	tracks,
+	sessionId,
+	canvasWidth,
+	canvasHeight,
+	fps,
+	api = platform().ffmpeg as unknown as EffectSequenceExportAPI,
+	createCanvas = ({ width, height }) => new OffscreenCanvas(width, height),
+	logger = console.log,
+	onProgress,
+}: {
+	programsByElementId: ReadonlyMap<string, EffectRenderProgram>;
+	tracks: readonly TimelineTrack[];
+	sessionId: string;
+	canvasWidth: number;
+	canvasHeight: number;
+	fps: number;
+	api?: EffectSequenceExportAPI;
+	createCanvas?: CreateProceduralFrameCanvas;
+	logger?: LogFn;
+	onProgress?: ({
+		bakedFrames,
+		totalFrames,
+	}: {
+		bakedFrames: number;
+		totalFrames: number;
+	}) => void;
+}): Promise<ReadonlyMap<string, EffectOverlaySourceInput[]>> {
+	const references = collectProceduralStageReferences({ programsByElementId });
+	if (references.length === 0) return new Map();
+	if (!api?.saveEffectSequenceFrame) {
+		throw new Error("Procedural effect export API is unavailable");
+	}
+	if (!(fps > 0)) {
+		throw new Error(`Procedural effect bake requires a positive fps: ${fps}`);
+	}
+
+	const jobs = references.map((reference) => {
+		const durationSeconds = elementTimelineDurationSeconds({
+			tracks,
+			elementId: reference.elementId,
+		});
+		if (durationSeconds === undefined) {
+			throw new Error(
+				`Procedural effect target is missing from the timeline: ${reference.elementId}`
+			);
+		}
+		const frames = isStageAnimated({ stage: reference.stage })
+			? Math.max(1, Math.ceil(durationSeconds * fps))
+			: 1;
+		return { reference, durationSeconds, frames };
+	});
+	const totalFrames = jobs.reduce((sum, job) => sum + job.frames, 0);
+	let bakedFrames = 0;
+
+	// Bake sequentially: each frame already saturates canvas rasterize + PNG
+	// encode, and sequential IPC keeps memory flat for long timelines.
+	const sourcesByElementId = new Map<string, EffectOverlaySourceInput[]>();
+	for (const job of jobs) {
+		const source = await bakeStageSequence({
+			api,
+			canvasHeight,
+			canvasWidth,
+			createCanvas,
+			fps,
+			durationSeconds: job.durationSeconds,
+			logger,
+			onFrameBaked: () => {
+				bakedFrames += 1;
+				onProgress?.({ bakedFrames, totalFrames });
+			},
+			reference: job.reference,
+			sessionId,
+		});
+		const sources = sourcesByElementId.get(job.reference.elementId) ?? [];
+		sources.push(source);
+		sourcesByElementId.set(job.reference.elementId, sources);
+	}
+	return sourcesByElementId;
+}

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
@@ -4,15 +4,19 @@ import type {
 	EffectRenderProgram,
 	TimelineTrack,
 } from "@qcut/editor-core";
-import { platform } from "@qcut/platform-core";
 import {
 	drawDecorationStageFrame,
 	drawParticleStageFrame,
 	isDecorationStageAnimated,
 } from "@/lib/effects/effect-procedural-draw";
 import type { EffectOverlaySourceInput } from "../types";
-
-type LogFn = (...args: unknown[]) => void;
+import {
+	defaultEffectSequenceExportAPI,
+	elementTimelineDurationSeconds,
+	sanitizeSequenceElementId,
+	type EffectSequenceExportAPI,
+	type LogFn,
+} from "./effect-sequence-shared";
 
 type ProceduralRenderStage =
 	| EffectParticleRenderStage
@@ -22,20 +26,6 @@ interface ProceduralStageReference {
 	elementId: string;
 	stageIndex: number;
 	stage: ProceduralRenderStage;
-}
-
-interface EffectSequenceExportAPI {
-	saveEffectSequenceFrame: (params: {
-		sessionId: string;
-		sequenceId: string;
-		frameIndex: number;
-		imageData: Uint8Array;
-	}) => Promise<{
-		success: boolean;
-		path?: string;
-		patternPath?: string;
-		error?: string;
-	}>;
 }
 
 interface ProceduralFrameCanvas {
@@ -83,31 +73,12 @@ function sequenceId({
 	elementId: string;
 	stageIndex: number;
 }): string {
-	return `${elementId.replace(/[^a-zA-Z0-9._-]/g, "_")}-s${stageIndex}`;
+	return `${sanitizeSequenceElementId({ elementId })}-s${stageIndex}`;
 }
 
 function isStageAnimated({ stage }: { stage: ProceduralRenderStage }): boolean {
 	if (stage.kind === "particles") return true;
 	return isDecorationStageAnimated({ stage });
-}
-
-function elementTimelineDurationSeconds({
-	tracks,
-	elementId,
-}: {
-	tracks: readonly TimelineTrack[];
-	elementId: string;
-}): number | undefined {
-	for (const track of tracks) {
-		for (const element of track.elements) {
-			if (element.id !== elementId) continue;
-			return Math.max(
-				0,
-				element.duration - element.trimStart - element.trimEnd
-			);
-		}
-	}
-	return undefined;
 }
 
 function drawProceduralFrame({
@@ -236,7 +207,7 @@ export async function extractEffectProceduralSources({
 	canvasWidth,
 	canvasHeight,
 	fps,
-	api = platform().ffmpeg as unknown as EffectSequenceExportAPI,
+	api = defaultEffectSequenceExportAPI(),
 	createCanvas = ({ width, height }) => new OffscreenCanvas(width, height),
 	logger = console.log,
 	onProgress,

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-procedural-sources.ts
@@ -266,6 +266,11 @@ export async function extractEffectProceduralSources({
 	if (!(fps > 0)) {
 		throw new Error(`Procedural effect bake requires a positive fps: ${fps}`);
 	}
+	if (!(canvasWidth > 0) || !(canvasHeight > 0)) {
+		throw new Error(
+			`Procedural effect bake requires positive canvas dimensions: ${canvasWidth}x${canvasHeight}`
+		);
+	}
 
 	const jobs = references.map((reference) => {
 		const durationSeconds = elementTimelineDurationSeconds({

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
@@ -27,13 +27,30 @@ export function defaultEffectSequenceExportAPI(): EffectSequenceExportAPI {
 	return platform().ffmpeg as unknown as EffectSequenceExportAPI;
 }
 
-/** Matches the main-process charset validation in save-effect-sequence-frame. */
+function fnv1a32({ value }: { value: string }): string {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < value.length; index += 1) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Maps an element id to a filesystem-safe sequence directory name, matching
+ * the main-process charset validation in save-effect-sequence-frame. Charset
+ * replacement alone is lossy ("clip/a" and "clip_a" both map to "clip_a"),
+ * so ids that needed sanitizing get a hash of the original id appended to
+ * keep distinct elements in distinct sequence directories.
+ */
 export function sanitizeSequenceElementId({
 	elementId,
 }: {
 	elementId: string;
 }): string {
-	return elementId.replace(/[^a-zA-Z0-9._-]/g, "_");
+	const sanitized = elementId.replace(/[^a-zA-Z0-9._-]/g, "_");
+	if (sanitized === elementId) return sanitized;
+	return `${sanitized}-h${fnv1a32({ value: elementId })}`;
 }
 
 export function elementTimelineDurationSeconds({

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
@@ -27,10 +27,15 @@ export function defaultEffectSequenceExportAPI(): EffectSequenceExportAPI {
 	return platform().ffmpeg as unknown as EffectSequenceExportAPI;
 }
 
-function utf8Hex({ value }: { value: string }): string {
+/**
+ * Fixed-width hex of the raw UTF-16 code units. Unlike a TextEncoder round
+ * trip (which folds every lone surrogate into U+FFFD), this is injective
+ * over the entire JS string domain.
+ */
+function utf16Hex({ value }: { value: string }): string {
 	let hex = "";
-	for (const byte of new TextEncoder().encode(value)) {
-		hex += byte.toString(16).padStart(2, "0");
+	for (let index = 0; index < value.length; index += 1) {
+		hex += value.charCodeAt(index).toString(16).padStart(4, "0");
 	}
 	return hex;
 }
@@ -42,10 +47,10 @@ function utf8Hex({ value }: { value: string }): string {
  * The mapping is injective by construction: already-safe ids keep their name
  * inside the "p-" (plain) namespace, while ids that need sanitizing move to
  * the "e-" (encoded) namespace carrying a readable prefix plus the full
- * UTF-8 hex of the original id as the final hyphen-separated segment. Hex
- * never contains a hyphen, so the original id is always recoverable, and the
- * two namespaces cannot collide — distinct elements always get distinct
- * sequence directories.
+ * fixed-width UTF-16 hex of the original id as the final hyphen-separated
+ * segment. Hex never contains a hyphen, so the original id is always
+ * recoverable, and the two namespaces cannot collide — distinct elements
+ * always get distinct sequence directories.
  */
 export function sanitizeSequenceElementId({
 	elementId,
@@ -54,7 +59,7 @@ export function sanitizeSequenceElementId({
 }): string {
 	const sanitized = elementId.replace(/[^a-zA-Z0-9._-]/g, "_");
 	if (sanitized === elementId) return `p-${elementId}`;
-	return `e-${sanitized.slice(0, 24)}-${utf8Hex({ value: elementId })}`;
+	return `e-${sanitized.slice(0, 24)}-${utf16Hex({ value: elementId })}`;
 }
 
 export function elementTimelineDurationSeconds({

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
@@ -1,0 +1,56 @@
+import type { TimelineTrack } from "@qcut/editor-core";
+import { platform } from "@qcut/platform-core";
+
+/**
+ * Shared contract for the baked effect-sequence extractors
+ * (effect-procedural-sources.ts, effect-distortion-sources.ts).
+ */
+export type LogFn = (...args: unknown[]) => void;
+
+export interface EffectSequenceExportAPI {
+	saveEffectSequenceFrame: (params: {
+		sessionId: string;
+		sequenceId: string;
+		frameIndex: number;
+		imageData: Uint8Array;
+		/** File extension for the frame ("png" default, "pgm" for remap maps). */
+		extension?: string;
+	}) => Promise<{
+		success: boolean;
+		path?: string;
+		patternPath?: string;
+		error?: string;
+	}>;
+}
+
+export function defaultEffectSequenceExportAPI(): EffectSequenceExportAPI {
+	return platform().ffmpeg as unknown as EffectSequenceExportAPI;
+}
+
+/** Matches the main-process charset validation in save-effect-sequence-frame. */
+export function sanitizeSequenceElementId({
+	elementId,
+}: {
+	elementId: string;
+}): string {
+	return elementId.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+export function elementTimelineDurationSeconds({
+	tracks,
+	elementId,
+}: {
+	tracks: readonly TimelineTrack[];
+	elementId: string;
+}): number | undefined {
+	for (const track of tracks) {
+		for (const element of track.elements) {
+			if (element.id !== elementId) continue;
+			return Math.max(
+				0,
+				element.duration - element.trimStart - element.trimEnd
+			);
+		}
+	}
+	return undefined;
+}

--- a/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/effect-sequence-shared.ts
@@ -27,21 +27,25 @@ export function defaultEffectSequenceExportAPI(): EffectSequenceExportAPI {
 	return platform().ffmpeg as unknown as EffectSequenceExportAPI;
 }
 
-function fnv1a32({ value }: { value: string }): string {
-	let hash = 0x811c9dc5;
-	for (let index = 0; index < value.length; index += 1) {
-		hash ^= value.charCodeAt(index);
-		hash = Math.imul(hash, 0x01000193);
+function utf8Hex({ value }: { value: string }): string {
+	let hex = "";
+	for (const byte of new TextEncoder().encode(value)) {
+		hex += byte.toString(16).padStart(2, "0");
 	}
-	return (hash >>> 0).toString(16).padStart(8, "0");
+	return hex;
 }
 
 /**
  * Maps an element id to a filesystem-safe sequence directory name, matching
- * the main-process charset validation in save-effect-sequence-frame. Charset
- * replacement alone is lossy ("clip/a" and "clip_a" both map to "clip_a"),
- * so ids that needed sanitizing get a hash of the original id appended to
- * keep distinct elements in distinct sequence directories.
+ * the main-process charset validation in save-effect-sequence-frame.
+ *
+ * The mapping is injective by construction: already-safe ids keep their name
+ * inside the "p-" (plain) namespace, while ids that need sanitizing move to
+ * the "e-" (encoded) namespace carrying a readable prefix plus the full
+ * UTF-8 hex of the original id as the final hyphen-separated segment. Hex
+ * never contains a hyphen, so the original id is always recoverable, and the
+ * two namespaces cannot collide — distinct elements always get distinct
+ * sequence directories.
  */
 export function sanitizeSequenceElementId({
 	elementId,
@@ -49,8 +53,8 @@ export function sanitizeSequenceElementId({
 	elementId: string;
 }): string {
 	const sanitized = elementId.replace(/[^a-zA-Z0-9._-]/g, "_");
-	if (sanitized === elementId) return sanitized;
-	return `${sanitized}-h${fnv1a32({ value: elementId })}`;
+	if (sanitized === elementId) return `p-${elementId}`;
+	return `e-${sanitized.slice(0, 24)}-${utf8Hex({ value: elementId })}`;
 }
 
 export function elementTimelineDurationSeconds({

--- a/qcut/apps/web/src/lib/export-cli/sources/index.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/index.ts
@@ -17,6 +17,7 @@ export { extractStickerSources } from "./sticker-sources";
 // Effect resource extraction
 export { extractEffectOverlaySources } from "./effect-overlay-sources";
 export { extractEffectProceduralSources } from "./effect-procedural-sources";
+export { extractEffectDistortionSources } from "./effect-distortion-sources";
 export { extractEffectPersonSources } from "./effect-person-sources";
 export { extractEffectCompanionAudioSources } from "./effect-companion-audio-sources";
 export { extractEffectAudioReactiveEnvelopes } from "./effect-audio-reactive-sources";

--- a/qcut/apps/web/src/lib/export-cli/sources/index.ts
+++ b/qcut/apps/web/src/lib/export-cli/sources/index.ts
@@ -16,6 +16,7 @@ export { extractStickerSources } from "./sticker-sources";
 
 // Effect resource extraction
 export { extractEffectOverlaySources } from "./effect-overlay-sources";
+export { extractEffectProceduralSources } from "./effect-procedural-sources";
 export { extractEffectPersonSources } from "./effect-person-sources";
 export { extractEffectCompanionAudioSources } from "./effect-companion-audio-sources";
 export { extractEffectAudioReactiveEnvelopes } from "./effect-audio-reactive-sources";

--- a/qcut/apps/web/src/lib/export-cli/types.ts
+++ b/qcut/apps/web/src/lib/export-cli/types.ts
@@ -209,6 +209,11 @@ export interface EffectOverlaySourceInput {
 	stageIndex: number;
 	path: string;
 	animated: boolean;
+	/**
+	 * Present for baked procedural frame sequences: `path` is then an image2
+	 * pattern (…/f_%05d.png) consumed with -framerate instead of -loop.
+	 */
+	sequence?: { framerate: number };
 }
 
 export interface EffectPersonSourceInput {

--- a/qcut/apps/web/src/lib/export-cli/types.ts
+++ b/qcut/apps/web/src/lib/export-cli/types.ts
@@ -201,6 +201,7 @@ export interface VideoSourceInput {
 	effectRenderProgram?: EffectRenderProgram;
 	effectOverlaySources?: EffectOverlaySourceInput[];
 	effectPersonSources?: EffectPersonSourceInput[];
+	effectDistortionSources?: EffectDistortionSourceInput[];
 	effectAudioReactiveEnvelopes?: EffectAudioReactiveEnvelope[];
 }
 
@@ -220,6 +221,19 @@ export interface EffectPersonSourceInput {
 	stageIndex: number;
 	path: string;
 	animated: boolean;
+}
+
+/**
+ * Baked remap coordinate maps for one distortion render stage. Paths are
+ * concrete PGM files for static variants or image2 patterns (…/f_%05d.pgm)
+ * for animated ones.
+ */
+export interface EffectDistortionSourceInput {
+	stageIndex: number;
+	xmapPath: string;
+	ymapPath: string;
+	animated: boolean;
+	sequence?: { framerate: number };
 }
 
 /**
@@ -275,6 +289,7 @@ export interface ImageSourceInput {
 	effectRenderProgram?: EffectRenderProgram;
 	effectOverlaySources?: EffectOverlaySourceInput[];
 	effectPersonSources?: EffectPersonSourceInput[];
+	effectDistortionSources?: EffectDistortionSourceInput[];
 	effectAudioReactiveEnvelopes?: EffectAudioReactiveEnvelope[];
 }
 

--- a/qcut/apps/web/src/lib/export/export-engine-cli.ts
+++ b/qcut/apps/web/src/lib/export/export-engine-cli.ts
@@ -46,6 +46,7 @@ import {
 	extractAudioMixConfig,
 	extractEffectOverlaySources,
 	extractEffectProceduralSources,
+	extractEffectDistortionSources,
 	extractEffectPersonSources,
 	extractEffectCompanionAudioSources,
 	extractEffectAudioReactiveEnvelopes,
@@ -450,6 +451,11 @@ export class CLIExportEngine extends ExportEngine {
 				(stage) => stage.kind === "particles" || stage.kind === "decoration"
 			)
 		);
+		const hasEffectDistortionStages = Array.from(
+			elementRenderPrograms.values()
+		).some((program) =>
+			program.stages.some((stage) => stage.kind === "distortion")
+		);
 		if (hasEffectOverlayStages && !this.sessionId) {
 			throw new Error("Effect overlay export requires an active session");
 		}
@@ -458,6 +464,9 @@ export class CLIExportEngine extends ExportEngine {
 		}
 		if (hasEffectProceduralStages && !this.sessionId) {
 			throw new Error("Procedural effect export requires an active session");
+		}
+		if (hasEffectDistortionStages && !this.sessionId) {
+			throw new Error("Distortion effect export requires an active session");
 		}
 		const effectOverlaySourcesByElementId = new Map(
 			this.sessionId
@@ -499,6 +508,24 @@ export class CLIExportEngine extends ExportEngine {
 				]);
 			}
 		}
+		const distortionSessionId = this.sessionId;
+		const effectDistortionSourcesByElementId =
+			hasEffectDistortionStages && distortionSessionId
+				? await (async () => {
+						// Bake remap coordinate maps so native FFmpeg reproduces the
+						// preview's per-pixel distortion (鱼眼/放大镜/水波纹/冲击波).
+						progressCallback?.(18, "Baking distortion maps...");
+						return extractEffectDistortionSources({
+							programsByElementId: elementRenderPrograms,
+							tracks: this.tracks,
+							sessionId: distortionSessionId,
+							canvasWidth: this.canvas.width,
+							canvasHeight: this.canvas.height,
+							fps: this.getFrameRate(),
+							logger: debugLog,
+						});
+					})()
+				: new Map();
 		const effectPersonSourcesByElementId = this.sessionId
 			? await extractEffectPersonSources({
 					programsByElementId: elementRenderPrograms,
@@ -643,6 +670,9 @@ export class CLIExportEngine extends ExportEngine {
 					effectPersonSources: effectPersonSourcesByElementId.get(
 						source.elementId
 					),
+					effectDistortionSources: effectDistortionSourcesByElementId.get(
+						source.elementId
+					),
 					effectAudioReactiveEnvelopes:
 						effectAudioReactiveEnvelopesByElementId.get(source.elementId),
 				}));
@@ -755,6 +785,9 @@ export class CLIExportEngine extends ExportEngine {
 				source.elementId
 			),
 			effectPersonSources: effectPersonSourcesByElementId.get(source.elementId),
+			effectDistortionSources: effectDistortionSourcesByElementId.get(
+				source.elementId
+			),
 			effectAudioReactiveEnvelopes: effectAudioReactiveEnvelopesByElementId.get(
 				source.elementId
 			),

--- a/qcut/apps/web/src/lib/export/export-engine-cli.ts
+++ b/qcut/apps/web/src/lib/export/export-engine-cli.ts
@@ -45,6 +45,7 @@ import {
 	extractImageSources,
 	extractAudioMixConfig,
 	extractEffectOverlaySources,
+	extractEffectProceduralSources,
 	extractEffectPersonSources,
 	extractEffectCompanionAudioSources,
 	extractEffectAudioReactiveEnvelopes,
@@ -442,21 +443,62 @@ export class CLIExportEngine extends ExportEngine {
 		).some((program) =>
 			program.stages.some((stage) => stage.kind === "person-tracking")
 		);
+		const hasEffectProceduralStages = Array.from(
+			elementRenderPrograms.values()
+		).some((program) =>
+			program.stages.some(
+				(stage) => stage.kind === "particles" || stage.kind === "decoration"
+			)
+		);
 		if (hasEffectOverlayStages && !this.sessionId) {
 			throw new Error("Effect overlay export requires an active session");
 		}
 		if (hasEffectPersonStages && !this.sessionId) {
 			throw new Error("Person effect export requires an active session");
 		}
-		const effectOverlaySourcesByElementId = this.sessionId
-			? await extractEffectOverlaySources({
+		if (hasEffectProceduralStages && !this.sessionId) {
+			throw new Error("Procedural effect export requires an active session");
+		}
+		const effectOverlaySourcesByElementId = new Map(
+			this.sessionId
+				? await extractEffectOverlaySources({
+						programsByElementId: elementRenderPrograms,
+						sessionId: this.sessionId,
+						canvasWidth: this.canvas.width,
+						canvasHeight: this.canvas.height,
+						logger: debugLog,
+					})
+				: []
+		);
+		if (hasEffectProceduralStages && this.sessionId) {
+			// Bake particle/decoration stages to transparent PNG sequences so the
+			// native FFmpeg pass composites the exact frames the preview draws.
+			const proceduralSourcesByElementId = await extractEffectProceduralSources(
+				{
 					programsByElementId: elementRenderPrograms,
+					tracks: this.tracks,
 					sessionId: this.sessionId,
 					canvasWidth: this.canvas.width,
 					canvasHeight: this.canvas.height,
+					fps: this.getFrameRate(),
 					logger: debugLog,
-				})
-			: new Map();
+					onProgress: ({ bakedFrames, totalFrames }) => {
+						const ratio = totalFrames > 0 ? bakedFrames / totalFrames : 1;
+						progressCallback?.(
+							10 + Math.round(ratio * 8),
+							`Baking effect frames (${bakedFrames}/${totalFrames})...`
+						);
+					},
+				}
+			);
+			for (const [elementId, sources] of proceduralSourcesByElementId) {
+				const existing = effectOverlaySourcesByElementId.get(elementId) ?? [];
+				effectOverlaySourcesByElementId.set(elementId, [
+					...existing,
+					...sources,
+				]);
+			}
+		}
 		const effectPersonSourcesByElementId = this.sessionId
 			? await extractEffectPersonSources({
 					programsByElementId: elementRenderPrograms,

--- a/qcut/apps/web/src/test/mocks/electron.ts
+++ b/qcut/apps/web/src/test/mocks/electron.ts
@@ -87,6 +87,11 @@ export const mockElectronAPI: ElectronAPI = {
 			success: true,
 			path: "/tmp/sticker.png",
 		}),
+		saveEffectSequenceFrame: vi.fn().mockResolvedValue({
+			success: true,
+			path: "/tmp/effect-sequences/seq/f_00000.png",
+			patternPath: "/tmp/effect-sequences/seq/f_%05d.png",
+		}),
 		exportVideoCLI: vi.fn().mockResolvedValue({
 			success: true,
 			outputFile: "output.mp4",

--- a/qcut/apps/web/src/types/electron/api-ffmpeg.ts
+++ b/qcut/apps/web/src/types/electron/api-ffmpeg.ts
@@ -46,6 +46,7 @@ export interface ElectronFFmpegOps {
 			sequenceId: string;
 			frameIndex: number;
 			imageData: Uint8Array;
+			extension?: string;
 		}) => Promise<{
 			success: boolean;
 			path?: string;

--- a/qcut/apps/web/src/types/electron/api-ffmpeg.ts
+++ b/qcut/apps/web/src/types/electron/api-ffmpeg.ts
@@ -41,6 +41,17 @@ export interface ElectronFFmpegOps {
 			imageData: Uint8Array;
 			format?: string;
 		}) => Promise<{ success: boolean; path?: string; error?: string }>;
+		saveEffectSequenceFrame: (data: {
+			sessionId: string;
+			sequenceId: string;
+			frameIndex: number;
+			imageData: Uint8Array;
+		}) => Promise<{
+			success: boolean;
+			path?: string;
+			patternPath?: string;
+			error?: string;
+		}>;
 		exportVideoCLI: (options: {
 			sessionId: string;
 			width: number;

--- a/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
@@ -225,6 +225,53 @@ describe("buildFFmpegArgs", () => {
 			]);
 		});
 
+		it("feeds baked procedural sequences as image2 pattern inputs", () => {
+			const args = buildFFmpegArgs(
+				createBaseOptions({
+					videoSources: [
+						{
+							path: "/source.mp4",
+							startTime: 0,
+							duration: 10,
+							trimStart: 0,
+							trimEnd: 0,
+							playbackRate: 1,
+							freezeFrameDuration: 0,
+							effectOverlaySources: [
+								{
+									resourceId: "procedural:particles:snow",
+									stageIndex: 0,
+									path: "/frames/effect-sequences/el-s0/f_%05d.png",
+									animated: true,
+									sequence: { framerate: 30 },
+								},
+							],
+						},
+					],
+				})
+			);
+
+			// Existence is checked against the first concrete frame, not the pattern.
+			expect(existsSyncMock).toHaveBeenCalledWith(
+				"/frames/effect-sequences/el-s0/f_00000.png"
+			);
+			const patternInput = args.indexOf(
+				"/frames/effect-sequences/el-s0/f_%05d.png"
+			);
+			expect(args.slice(patternInput - 5, patternInput + 1)).toEqual([
+				"-framerate",
+				"30",
+				"-start_number",
+				"0",
+				"-i",
+				"/frames/effect-sequences/el-s0/f_%05d.png",
+			]);
+			// Sequence inputs must not loop or clamp with -t.
+			expect(args.slice(patternInput - 7, patternInput - 5)).not.toContain(
+				"-stream_loop"
+			);
+		});
+
 		it("applies per-clip audio processing before mixing", () => {
 			const args = buildFFmpegArgs(
 				createBaseOptions({

--- a/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
@@ -272,6 +272,95 @@ describe("buildFFmpegArgs", () => {
 			);
 		});
 
+		it("feeds baked distortion maps as xmap/ymap inputs", () => {
+			const args = buildFFmpegArgs(
+				createBaseOptions({
+					videoSources: [
+						{
+							path: "/source.mp4",
+							startTime: 0,
+							duration: 10,
+							trimStart: 0,
+							trimEnd: 0,
+							playbackRate: 1,
+							freezeFrameDuration: 0,
+							effectDistortionSources: [
+								{
+									stageIndex: 0,
+									xmapPath: "/frames/effect-sequences/el-s0x/f_00000.pgm",
+									ymapPath: "/frames/effect-sequences/el-s0y/f_00000.pgm",
+									animated: false,
+								},
+							],
+						},
+					],
+					audioFiles: [{ path: "/voice.wav", startTime: 0, volume: 1 }],
+				})
+			);
+
+			// Static maps loop a single PGM bounded by the source duration.
+			const xmapInput = args.indexOf(
+				"/frames/effect-sequences/el-s0x/f_00000.pgm"
+			);
+			expect(args.slice(xmapInput - 5, xmapInput + 1)).toEqual([
+				"-loop",
+				"1",
+				"-t",
+				"10",
+				"-i",
+				"/frames/effect-sequences/el-s0x/f_00000.pgm",
+			]);
+			// ymap follows xmap, and audio inputs come after every map input.
+			expect(xmapInput).toBeLessThan(
+				args.indexOf("/frames/effect-sequences/el-s0y/f_00000.pgm")
+			);
+			expect(
+				args.indexOf("/frames/effect-sequences/el-s0y/f_00000.pgm")
+			).toBeLessThan(args.indexOf("/voice.wav"));
+		});
+
+		it("feeds animated distortion maps as image2 patterns", () => {
+			const args = buildFFmpegArgs(
+				createBaseOptions({
+					videoSources: [
+						{
+							path: "/source.mp4",
+							startTime: 0,
+							duration: 10,
+							trimStart: 0,
+							trimEnd: 0,
+							playbackRate: 1,
+							freezeFrameDuration: 0,
+							effectDistortionSources: [
+								{
+									stageIndex: 0,
+									xmapPath: "/frames/effect-sequences/el-s0x/f_%05d.pgm",
+									ymapPath: "/frames/effect-sequences/el-s0y/f_%05d.pgm",
+									animated: true,
+									sequence: { framerate: 30 },
+								},
+							],
+						},
+					],
+				})
+			);
+
+			expect(existsSyncMock).toHaveBeenCalledWith(
+				"/frames/effect-sequences/el-s0x/f_00000.pgm"
+			);
+			const xmapInput = args.indexOf(
+				"/frames/effect-sequences/el-s0x/f_%05d.pgm"
+			);
+			expect(args.slice(xmapInput - 5, xmapInput + 1)).toEqual([
+				"-framerate",
+				"30",
+				"-start_number",
+				"0",
+				"-i",
+				"/frames/effect-sequences/el-s0x/f_%05d.pgm",
+			]);
+		});
+
 		it("applies per-clip audio processing before mixing", () => {
 			const args = buildFFmpegArgs(
 				createBaseOptions({

--- a/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
@@ -295,6 +295,73 @@ describe("FFmpeg video transform filters", () => {
 		}
 	});
 
+	it("remaps baked distortion maps with window-gated blending", () => {
+		const result = buildVideoTimelineFilters({
+			videoSources: [
+				{
+					path: "/source.mp4",
+					startTime: 0,
+					duration: 4,
+					effectRenderProgram: {
+						version: 1,
+						stages: [
+							{
+								kind: "distortion",
+								variant: "ripple",
+								strength: 1,
+								window: { startSeconds: 1, endSeconds: 3 },
+							},
+						],
+					},
+					effectDistortionSources: [
+						{
+							stageIndex: 0,
+							xmapPath: "/frames/effect-sequences/el-s0x/f_%05d.pgm",
+							ymapPath: "/frames/effect-sequences/el-s0y/f_%05d.pgm",
+							animated: true,
+							sequence: { framerate: 30 },
+							xmapInputIndex: 1,
+							ymapInputIndex: 2,
+						},
+					],
+				},
+			],
+			width: 640,
+			height: 360,
+			fps: 30,
+			totalDuration: 4,
+		});
+		const filter = result.filterSteps.join(";");
+
+		expect(filter).toContain("[1:v]scale=640:360,fps=30,trim=duration=");
+		expect(filter).toContain("[2:v]scale=640:360,fps=30,trim=duration=");
+		expect(filter).toContain("remap=fill=black");
+		// Window gating splits the base and re-blends with a time expression.
+		expect(filter).toContain("if(gte(T,1)*lt(T,3),B,A)");
+	});
+
+	it("throws when a distortion stage is missing its FFmpeg input", () => {
+		expect(() =>
+			buildVideoTimelineFilters({
+				videoSources: [
+					{
+						path: "/source.mp4",
+						startTime: 0,
+						duration: 4,
+						effectRenderProgram: {
+							version: 1,
+							stages: [{ kind: "distortion", variant: "fisheye", strength: 1 }],
+						},
+					},
+				],
+				width: 640,
+				height: 360,
+				fps: 30,
+				totalDuration: 4,
+			})
+		).toThrow(/Missing FFmpeg input for distortion effect/);
+	});
+
 	it("throws when a procedural stage is missing its FFmpeg input", () => {
 		expect(() =>
 			buildVideoTimelineFilters({

--- a/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
@@ -227,6 +227,105 @@ describe("FFmpeg video transform filters", () => {
 		expect(filter).toContain("if(gte(T,2.5)*lt(T,3.5),B,A)");
 	});
 
+	it("composites baked procedural sequences with a plain alpha overlay", () => {
+		const result = buildVideoTimelineFilters({
+			videoSources: [
+				{
+					path: "/source.mp4",
+					startTime: 0,
+					duration: 4,
+					effectRenderProgram: {
+						version: 1,
+						stages: [
+							{
+								kind: "particles",
+								variant: "snow",
+								density: 0.5,
+								speed: 1,
+								color: "#ffffff",
+								opacity: 1,
+								window: { startSeconds: 1, endSeconds: 3 },
+							},
+							{
+								kind: "decoration",
+								variant: "grid",
+								color: "#ffffff",
+								opacity: 0.6,
+							},
+						],
+					},
+					effectOverlaySources: [
+						{
+							resourceId: "procedural:particles:snow",
+							stageIndex: 0,
+							path: "/frames/effect-sequences/el-s0/f_%05d.png",
+							animated: true,
+							sequence: { framerate: 30 },
+							inputIndex: 1,
+						},
+						{
+							resourceId: "procedural:decoration:grid",
+							stageIndex: 1,
+							path: "/frames/effect-sequences/el-s1/f_00000.png",
+							animated: false,
+							inputIndex: 2,
+						},
+					],
+				},
+			],
+			width: 640,
+			height: 360,
+			fps: 30,
+			totalDuration: 4,
+		});
+		const filter = result.filterSteps.join(";");
+
+		expect(filter).toContain(
+			"[1:v]scale=640:360,format=rgba,fps=30,trim=duration="
+		);
+		expect(filter).toContain("[2:v]scale=640:360,format=rgba,fps=30");
+		expect(filter).toContain("enable='gte(t,1)*lt(t,3)'");
+		// Finite sequences must not use shortest=1 (it would truncate the clip).
+		const proceduralSteps = result.filterSteps.filter((step) =>
+			step.includes("effect_procedural")
+		);
+		expect(proceduralSteps.length).toBeGreaterThan(0);
+		for (const step of proceduralSteps) {
+			expect(step).not.toContain("shortest=1");
+		}
+	});
+
+	it("throws when a procedural stage is missing its FFmpeg input", () => {
+		expect(() =>
+			buildVideoTimelineFilters({
+				videoSources: [
+					{
+						path: "/source.mp4",
+						startTime: 0,
+						duration: 4,
+						effectRenderProgram: {
+							version: 1,
+							stages: [
+								{
+									kind: "particles",
+									variant: "snow",
+									density: 0.5,
+									speed: 1,
+									color: "#ffffff",
+									opacity: 1,
+								},
+							],
+						},
+					},
+				],
+				width: 640,
+				height: 360,
+				fps: 30,
+				totalDuration: 4,
+			})
+		).toThrow(/Missing FFmpeg input for procedural effect/);
+	});
+
 	it("composites ordered video tracks from bottom to top", () => {
 		const sources: VideoSource[] = [
 			{

--- a/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-video-transform.test.ts
@@ -333,8 +333,13 @@ describe("FFmpeg video transform filters", () => {
 		});
 		const filter = result.filterSteps.join(";");
 
-		expect(filter).toContain("[1:v]scale=640:360,fps=30,trim=duration=");
-		expect(filter).toContain("[2:v]scale=640:360,fps=30,trim=duration=");
+		// tpad holds the last map frame so finite sequences cover the segment.
+		expect(filter).toContain(
+			"[1:v]scale=640:360,fps=30,tpad=stop_mode=clone:stop=-1,trim=duration="
+		);
+		expect(filter).toContain(
+			"[2:v]scale=640:360,fps=30,tpad=stop_mode=clone:stop=-1,trim=duration="
+		);
 		expect(filter).toContain("remap=fill=black");
 		// Window gating splits the base and re-blends with a time expression.
 		expect(filter).toContain("if(gte(T,1)*lt(T,3),B,A)");

--- a/qcut/electron/ffmpeg-args-builder.ts
+++ b/qcut/electron/ffmpeg-args-builder.ts
@@ -13,6 +13,7 @@ import fs from "fs";
 import type {
 	AudioCrossfade,
 	AudioFile,
+	EffectDistortionSource,
 	EffectOverlaySource,
 	EffectPersonSource,
 	VideoSource,
@@ -210,6 +211,106 @@ function appendEffectOverlayInputs<T extends EffectOverlayCarrier>({
 	};
 }
 
+interface EffectDistortionCarrier {
+	duration: number;
+	trimStart?: number;
+	trimEnd?: number;
+	playbackRate?: number;
+	speedKeyframes?: VideoSource["speedKeyframes"];
+	freezeFrameDuration?: number;
+	effectDistortionSources?: EffectDistortionSource[];
+}
+
+/**
+ * Appends xmap/ymap coordinate-map inputs for baked distortion stages. Static
+ * variants loop a single PGM; animated variants read an image2 pattern.
+ */
+function appendEffectDistortionInputs<T extends EffectDistortionCarrier>({
+	args,
+	fps,
+	fallbackDuration,
+	sources,
+	startInputIndex,
+}: {
+	args: string[];
+	fps: number;
+	fallbackDuration: number;
+	sources: readonly T[];
+	startInputIndex: number;
+}): { sources: T[]; inputCount: number } {
+	let nextInputIndex = startInputIndex;
+	const appendMapInput = ({
+		mapPath,
+		animated,
+		sequence,
+		inputDuration,
+	}: {
+		mapPath: string;
+		animated: boolean;
+		sequence?: { framerate: number };
+		inputDuration: number;
+	}): number => {
+		if (animated && sequence) {
+			const firstFramePath = mapPath.replace("%05d", "00000");
+			if (!fs.existsSync(firstFramePath)) {
+				throw new Error(`Distortion map sequence not found: ${firstFramePath}`);
+			}
+			args.push(
+				"-framerate",
+				String(sequence.framerate),
+				"-start_number",
+				"0",
+				"-i",
+				mapPath
+			);
+			return nextInputIndex++;
+		}
+		if (!fs.existsSync(mapPath)) {
+			throw new Error(`Distortion map not found: ${mapPath}`);
+		}
+		const boundedInputDuration = Math.max(1 / Math.max(1, fps), inputDuration);
+		args.push(
+			"-loop",
+			"1",
+			"-t",
+			Number(boundedInputDuration.toFixed(6)).toString(),
+			"-i",
+			mapPath
+		);
+		return nextInputIndex++;
+	};
+
+	const resolvedSources = sources.map((source) => {
+		const resolvedDuration = getVideoSourceTimelineDuration({ source, fps });
+		const inputDuration =
+			Number.isFinite(resolvedDuration) && resolvedDuration > 0
+				? resolvedDuration
+				: fallbackDuration;
+		const effectDistortionSources = source.effectDistortionSources?.map(
+			(distortion) => ({
+				...distortion,
+				xmapInputIndex: appendMapInput({
+					mapPath: distortion.xmapPath,
+					animated: distortion.animated,
+					sequence: distortion.sequence,
+					inputDuration,
+				}),
+				ymapInputIndex: appendMapInput({
+					mapPath: distortion.ymapPath,
+					animated: distortion.animated,
+					sequence: distortion.sequence,
+					inputDuration,
+				}),
+			})
+		);
+		return { ...source, effectDistortionSources };
+	});
+	return {
+		sources: resolvedSources,
+		inputCount: nextInputIndex - startInputIndex,
+	};
+}
+
 function appendEffectPersonInputs<T extends EffectPersonCarrier>({
 	args,
 	sources,
@@ -296,6 +397,7 @@ function buildCanonicalVisualFilters({
 		effectRenderProgram: image.effectRenderProgram,
 		effectOverlaySources: image.effectOverlaySources,
 		effectPersonSources: image.effectPersonSources,
+		effectDistortionSources: image.effectDistortionSources,
 		effectAudioReactiveEnvelopes: image.effectAudioReactiveEnvelopes,
 	}));
 	const timelineSources = [...videoSources, ...imageSources];
@@ -566,10 +668,31 @@ function buildCompositeEncodeArgs(
 		startInputIndex:
 			effectPersonInputStartIndex + resolvedVideoPersonInputs.inputCount,
 	});
-	const resolvedVideoSources = resolvedVideoPersonInputs.sources;
-	const resolvedImages = resolvedImagePersonInputs.sources;
 	const effectPersonInputCount =
 		resolvedVideoPersonInputs.inputCount + resolvedImagePersonInputs.inputCount;
+	const effectDistortionInputStartIndex =
+		effectPersonInputStartIndex + effectPersonInputCount;
+	const resolvedVideoDistortionInputs = appendEffectDistortionInputs({
+		args,
+		fps,
+		fallbackDuration: duration,
+		sources: resolvedVideoPersonInputs.sources,
+		startInputIndex: effectDistortionInputStartIndex,
+	});
+	const resolvedImageDistortionInputs = appendEffectDistortionInputs({
+		args,
+		fps,
+		fallbackDuration: duration,
+		sources: resolvedImagePersonInputs.sources,
+		startInputIndex:
+			effectDistortionInputStartIndex +
+			resolvedVideoDistortionInputs.inputCount,
+	});
+	const resolvedVideoSources = resolvedVideoDistortionInputs.sources;
+	const resolvedImages = resolvedImageDistortionInputs.sources;
+	const effectDistortionInputCount =
+		resolvedVideoDistortionInputs.inputCount +
+		resolvedImageDistortionInputs.inputCount;
 
 	for (const audioFile of audioFiles) {
 		if (!fs.existsSync(audioFile.path)) {
@@ -781,7 +904,8 @@ function buildCompositeEncodeArgs(
 		validImages.length +
 		validStickers.length +
 		effectOverlayInputCount +
-		effectPersonInputCount;
+		effectPersonInputCount +
+		effectDistortionInputCount;
 	const audioResult = buildTimelineAudioFilters({
 		audioFiles,
 		audioCrossfades,

--- a/qcut/electron/ffmpeg-args-builder.ts
+++ b/qcut/electron/ffmpeg-args-builder.ts
@@ -163,6 +163,25 @@ function appendEffectOverlayInputs<T extends EffectOverlayCarrier>({
 				? resolvedDuration
 				: fallbackDuration;
 		const effectOverlaySources = source.effectOverlaySources?.map((overlay) => {
+			if (overlay.sequence) {
+				// Baked procedural frame sequence: image2 pattern input timed by
+				// -framerate; the frame count already bounds its duration.
+				const firstFramePath = overlay.path.replace("%05d", "00000");
+				if (!fs.existsSync(firstFramePath)) {
+					throw new Error(
+						`Effect sequence source not found: ${firstFramePath}`
+					);
+				}
+				args.push(
+					"-framerate",
+					String(overlay.sequence.framerate),
+					"-start_number",
+					"0",
+					"-i",
+					overlay.path
+				);
+				return { ...overlay, inputIndex: nextInputIndex++ };
+			}
 			if (!fs.existsSync(overlay.path)) {
 				throw new Error(`Effect overlay source not found: ${overlay.path}`);
 			}

--- a/qcut/electron/ffmpeg-utility-handlers.ts
+++ b/qcut/electron/ffmpeg-utility-handlers.ts
@@ -386,11 +386,13 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 				sequenceId,
 				frameIndex,
 				imageData,
+				extension = "png",
 			}: {
 				sessionId: string;
 				sequenceId: string;
 				frameIndex: number;
 				imageData: Uint8Array;
+				extension?: string;
 			}
 		): Promise<{
 			success: boolean;
@@ -404,6 +406,9 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 				if (!Number.isInteger(frameIndex) || frameIndex < 0) {
 					throw new Error(`Invalid effect frame index: ${frameIndex}`);
 				}
+				if (extension !== "png" && extension !== "pgm") {
+					throw new Error(`Invalid effect frame extension: ${extension}`);
+				}
 				const sequenceDir = path.join(
 					tempManager.getFrameDir(sessionId),
 					"effect-sequences",
@@ -414,7 +419,7 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 					await fs.promises.mkdir(sequenceDir, { recursive: true });
 				}
 
-				const filename = `f_${String(frameIndex).padStart(5, "0")}.png`;
+				const filename = `f_${String(frameIndex).padStart(5, "0")}.${extension}`;
 				const framePath = path.join(sequenceDir, filename);
 
 				// Verify resolved path stays within the sequence directory
@@ -428,7 +433,7 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 				return {
 					success: true,
 					path: framePath,
-					patternPath: path.join(sequenceDir, "f_%05d.png"),
+					patternPath: path.join(sequenceDir, `f_%05d.${extension}`),
 				};
 			} catch (error: any) {
 				console.error(

--- a/qcut/electron/ffmpeg-utility-handlers.ts
+++ b/qcut/electron/ffmpeg-utility-handlers.ts
@@ -375,6 +375,74 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 		}
 	);
 
+	// Save one baked procedural-effect frame (PNG) into a per-sequence
+	// directory laid out for FFmpeg's image2 pattern input (f_%05d.png).
+	ipcMain.handle(
+		"save-effect-sequence-frame",
+		async (
+			event: IpcMainInvokeEvent,
+			{
+				sessionId,
+				sequenceId,
+				frameIndex,
+				imageData,
+			}: {
+				sessionId: string;
+				sequenceId: string;
+				frameIndex: number;
+				imageData: Uint8Array;
+			}
+		): Promise<{
+			success: boolean;
+			path?: string;
+			patternPath?: string;
+			error?: string;
+		}> => {
+			try {
+				// Sanitize inputs to prevent path traversal
+				const safeSequenceId = path.basename(sequenceId);
+				if (!Number.isInteger(frameIndex) || frameIndex < 0) {
+					throw new Error(`Invalid effect frame index: ${frameIndex}`);
+				}
+				const sequenceDir = path.join(
+					tempManager.getFrameDir(sessionId),
+					"effect-sequences",
+					safeSequenceId
+				);
+
+				if (!fs.existsSync(sequenceDir)) {
+					await fs.promises.mkdir(sequenceDir, { recursive: true });
+				}
+
+				const filename = `f_${String(frameIndex).padStart(5, "0")}.png`;
+				const framePath = path.join(sequenceDir, filename);
+
+				// Verify resolved path stays within the sequence directory
+				const resolvedPath = path.resolve(framePath);
+				if (!resolvedPath.startsWith(path.resolve(sequenceDir))) {
+					throw new Error("Invalid effect frame path: path traversal detected");
+				}
+
+				await fs.promises.writeFile(framePath, Buffer.from(imageData));
+
+				return {
+					success: true,
+					path: framePath,
+					patternPath: path.join(sequenceDir, "f_%05d.png"),
+				};
+			} catch (error: any) {
+				console.error(
+					`[FFmpeg] Failed to save effect sequence frame ${sequenceId}#${frameIndex}:`,
+					error
+				);
+				return {
+					success: false,
+					error: error.message,
+				};
+			}
+		}
+	);
+
 	// Save sticker image for export
 	ipcMain.handle(
 		"save-sticker-for-export",

--- a/qcut/electron/ffmpeg-utility-handlers.ts
+++ b/qcut/electron/ffmpeg-utility-handlers.ts
@@ -401,8 +401,16 @@ export function setupUtilityHandlers(tempManager: TempManager): void {
 			error?: string;
 		}> => {
 			try {
-				// Sanitize inputs to prevent path traversal
+				// Sanitize inputs to prevent path traversal: basename alone can
+				// still yield "." or "..", so require an explicit safe charset.
 				const safeSequenceId = path.basename(sequenceId);
+				if (
+					safeSequenceId === "." ||
+					safeSequenceId === ".." ||
+					!/^[a-zA-Z0-9._-]+$/.test(safeSequenceId)
+				) {
+					throw new Error(`Invalid effect sequence id: ${sequenceId}`);
+				}
 				if (!Number.isInteger(frameIndex) || frameIndex < 0) {
 					throw new Error(`Invalid effect frame index: ${frameIndex}`);
 				}

--- a/qcut/electron/ffmpeg-video-transform.ts
+++ b/qcut/electron/ffmpeg-video-transform.ts
@@ -858,6 +858,66 @@ function buildEffectOverlayFilters({
 	return { filterSteps, outputLabel };
 }
 
+/**
+ * Composites baked procedural particle/decoration frame sequences over the
+ * segment. Opacity and blending are already baked into the RGBA frames, so
+ * every stage composites with a plain alpha overlay. Unlike asset overlays,
+ * baked sequences are finite: rely on overlay's default eof_action=repeat
+ * (hold last frame) instead of shortest=1, which would truncate the segment.
+ */
+function buildEffectProceduralFilters({
+	currentLabel,
+	duration,
+	fps,
+	height,
+	segmentIndex,
+	source,
+	width,
+}: {
+	currentLabel: string;
+	duration: number;
+	fps: number;
+	height: number;
+	segmentIndex: number;
+	source: VideoSource;
+	width: number;
+}): { filterSteps: string[]; outputLabel: string } {
+	const program = source.effectRenderProgram;
+	if (!program) return { filterSteps: [], outputLabel: currentLabel };
+
+	const filterSteps: string[] = [];
+	let outputLabel = currentLabel;
+	for (const [stageIndex, stage] of program.stages.entries()) {
+		if (stage.kind !== "particles" && stage.kind !== "decoration") continue;
+		const overlaySource = source.effectOverlaySources?.find(
+			(candidate) => candidate.stageIndex === stageIndex
+		);
+		if (overlaySource?.inputIndex === undefined) {
+			throw new Error(
+				`Missing FFmpeg input for procedural effect ${stage.kind}:${stage.variant} at stage ${stageIndex}`
+			);
+		}
+
+		const prefix = `video_${segmentIndex}_effect_procedural_${stageIndex}`;
+		const enabled = effectWindowExpression({
+			window: stage.window,
+			timeVariable: "t",
+		});
+		const enableOption = enabled ? `:enable='${enabled}'` : "";
+		const prepared = `${prefix}_prepared`;
+		filterSteps.push(
+			`[${overlaySource.inputIndex}:v]scale=${width}:${height},format=rgba,` +
+				`fps=${fps},trim=duration=${duration},setpts=PTS-STARTPTS[${prepared}]`
+		);
+		const composed = `${prefix}_composed`;
+		filterSteps.push(
+			`[${outputLabel}][${prepared}]overlay=x=0:y=0:format=auto${enableOption}[${composed}]`
+		);
+		outputLabel = composed;
+	}
+	return { filterSteps, outputLabel };
+}
+
 function buildTimedVideoInput({
 	inputLabel,
 	prefix,
@@ -1221,6 +1281,17 @@ function buildSegmentFilters({
 	});
 	steps.push(...effectOverlayGraph.filterSteps);
 	current = effectOverlayGraph.outputLabel;
+	const effectProceduralGraph = buildEffectProceduralFilters({
+		currentLabel: current,
+		duration,
+		fps,
+		height,
+		segmentIndex,
+		source,
+		width,
+	});
+	steps.push(...effectProceduralGraph.filterSteps);
+	current = effectProceduralGraph.outputLabel;
 	const crop = visual.crop;
 	const left = buildVideoKeyframeExpression({
 		visual,

--- a/qcut/electron/ffmpeg-video-transform.ts
+++ b/qcut/electron/ffmpeg-video-transform.ts
@@ -859,6 +859,83 @@ function buildEffectOverlayFilters({
 }
 
 /**
+ * Applies baked distortion stages through FFmpeg's remap filter. The xmap and
+ * ymap inputs are 16-bit PGM coordinate maps sampled from the same
+ * sampleDistortionSource model the preview uses, generated at reduced
+ * resolution and scaled up in-graph. Window gating splits the base stream and
+ * re-blends because remap has no timeline (enable) support.
+ */
+function buildEffectDistortionFilters({
+	currentLabel,
+	duration,
+	fps,
+	height,
+	segmentIndex,
+	source,
+	width,
+}: {
+	currentLabel: string;
+	duration: number;
+	fps: number;
+	height: number;
+	segmentIndex: number;
+	source: VideoSource;
+	width: number;
+}): { filterSteps: string[]; outputLabel: string } {
+	const program = source.effectRenderProgram;
+	if (!program) return { filterSteps: [], outputLabel: currentLabel };
+
+	const filterSteps: string[] = [];
+	let outputLabel = currentLabel;
+	for (const [stageIndex, stage] of program.stages.entries()) {
+		if (stage.kind !== "distortion") continue;
+		const distortionSource = source.effectDistortionSources?.find(
+			(candidate) => candidate.stageIndex === stageIndex
+		);
+		if (
+			distortionSource?.xmapInputIndex === undefined ||
+			distortionSource?.ymapInputIndex === undefined
+		) {
+			throw new Error(
+				`Missing FFmpeg input for distortion effect ${stage.variant} at stage ${stageIndex}`
+			);
+		}
+
+		const prefix = `video_${segmentIndex}_effect_distortion_${stageIndex}`;
+		let stageInput = outputLabel;
+		let baseLabel: string | undefined;
+		if (stage.window) {
+			baseLabel = `${prefix}_base`;
+			stageInput = `${prefix}_input`;
+			filterSteps.push(`[${outputLabel}]split=2[${baseLabel}][${stageInput}]`);
+		}
+		const xmapLabel = `${prefix}_xmap`;
+		const ymapLabel = `${prefix}_ymap`;
+		filterSteps.push(
+			`[${distortionSource.xmapInputIndex}:v]scale=${width}:${height},fps=${fps},` +
+				`trim=duration=${duration},setpts=PTS-STARTPTS[${xmapLabel}]`
+		);
+		filterSteps.push(
+			`[${distortionSource.ymapInputIndex}:v]scale=${width}:${height},fps=${fps},` +
+				`trim=duration=${duration},setpts=PTS-STARTPTS[${ymapLabel}]`
+		);
+		const remapped = `${prefix}_remapped`;
+		filterSteps.push(
+			`[${stageInput}][${xmapLabel}][${ymapLabel}]remap=fill=black[${prefix}_raw]`
+		);
+		filterSteps.push(`[${prefix}_raw]format=rgba[${remapped}]`);
+		outputLabel = blendEffectWindow({
+			baseLabel,
+			effectLabel: remapped,
+			filterSteps,
+			outputLabel: `${prefix}_windowed`,
+			window: stage.window,
+		});
+	}
+	return { filterSteps, outputLabel };
+}
+
+/**
  * Composites baked procedural particle/decoration frame sequences over the
  * segment. Opacity and blending are already baked into the RGBA frames, so
  * every stage composites with a plain alpha overlay. Unlike asset overlays,
@@ -1281,6 +1358,17 @@ function buildSegmentFilters({
 	});
 	steps.push(...effectOverlayGraph.filterSteps);
 	current = effectOverlayGraph.outputLabel;
+	const effectDistortionGraph = buildEffectDistortionFilters({
+		currentLabel: current,
+		duration,
+		fps,
+		height,
+		segmentIndex,
+		source,
+		width,
+	});
+	steps.push(...effectDistortionGraph.filterSteps);
+	current = effectDistortionGraph.outputLabel;
 	const effectProceduralGraph = buildEffectProceduralFilters({
 		currentLabel: current,
 		duration,

--- a/qcut/electron/ffmpeg-video-transform.ts
+++ b/qcut/electron/ffmpeg-video-transform.ts
@@ -911,13 +911,18 @@ function buildEffectDistortionFilters({
 		}
 		const xmapLabel = `${prefix}_xmap`;
 		const ymapLabel = `${prefix}_ymap`;
+		// tpad clones the last map frame indefinitely before trim closes the
+		// stream, so a finite baked sequence always covers the full segment
+		// even when speed keyframes or freeze frames stretch it beyond the
+		// baked duration (remap would otherwise end the stream early).
+		const mapCoverageFilter =
+			`scale=${width}:${height},fps=${fps},tpad=stop_mode=clone:stop=-1,` +
+			`trim=duration=${duration},setpts=PTS-STARTPTS`;
 		filterSteps.push(
-			`[${distortionSource.xmapInputIndex}:v]scale=${width}:${height},fps=${fps},` +
-				`trim=duration=${duration},setpts=PTS-STARTPTS[${xmapLabel}]`
+			`[${distortionSource.xmapInputIndex}:v]${mapCoverageFilter}[${xmapLabel}]`
 		);
 		filterSteps.push(
-			`[${distortionSource.ymapInputIndex}:v]scale=${width}:${height},fps=${fps},` +
-				`trim=duration=${duration},setpts=PTS-STARTPTS[${ymapLabel}]`
+			`[${distortionSource.ymapInputIndex}:v]${mapCoverageFilter}[${ymapLabel}]`
 		);
 		const remapped = `${prefix}_remapped`;
 		filterSteps.push(

--- a/qcut/electron/ffmpeg/effect-render-types.ts
+++ b/qcut/electron/ffmpeg/effect-render-types.ts
@@ -57,6 +57,32 @@ export interface EffectPersonTrackingRenderStage {
 	window?: EffectRenderWindow;
 }
 
+export interface EffectParticleRenderStage {
+	kind: "particles";
+	variant: string;
+	density: number;
+	speed: number;
+	color: string;
+	opacity: number;
+	window?: EffectRenderWindow;
+}
+
+export interface EffectDecorationRenderStage {
+	kind: "decoration";
+	variant: string;
+	color: string;
+	opacity: number;
+	window?: EffectRenderWindow;
+}
+
+export interface EffectDistortionRenderStage {
+	kind: "distortion";
+	variant: string;
+	/** Distortion amount, 0–1. */
+	strength: number;
+	window?: EffectRenderWindow;
+}
+
 export type EffectRenderStage =
 	| { kind: "filter"; window?: EffectRenderWindow }
 	| EffectMotionRenderStage
@@ -73,7 +99,10 @@ export type EffectRenderStage =
 			releaseMs: number;
 			window?: EffectRenderWindow;
 	  }
-	| EffectPersonTrackingRenderStage;
+	| EffectPersonTrackingRenderStage
+	| EffectParticleRenderStage
+	| EffectDecorationRenderStage
+	| EffectDistortionRenderStage;
 
 export interface EffectRenderProgram {
 	version: 1;

--- a/qcut/electron/ffmpeg/types.ts
+++ b/qcut/electron/ffmpeg/types.ts
@@ -194,6 +194,7 @@ export interface VideoSource {
 	effectRenderProgram?: EffectRenderProgram;
 	effectOverlaySources?: EffectOverlaySource[];
 	effectPersonSources?: EffectPersonSource[];
+	effectDistortionSources?: EffectDistortionSource[];
 	effectAudioReactiveEnvelopes?: EffectAudioReactiveEnvelope[];
 }
 
@@ -208,6 +209,21 @@ export interface EffectOverlaySource {
 	 */
 	sequence?: { framerate: number };
 	inputIndex?: number;
+}
+
+/**
+ * Baked remap coordinate maps for one distortion render stage. Paths are
+ * concrete PGM files for static variants or image2 patterns (…/f_%05d.pgm)
+ * for animated ones.
+ */
+export interface EffectDistortionSource {
+	stageIndex: number;
+	xmapPath: string;
+	ymapPath: string;
+	animated: boolean;
+	sequence?: { framerate: number };
+	xmapInputIndex?: number;
+	ymapInputIndex?: number;
 }
 
 export interface VideoTransition {
@@ -466,6 +482,7 @@ export interface ImageSource {
 	effectRenderProgram?: EffectRenderProgram;
 	effectOverlaySources?: EffectOverlaySource[];
 	effectPersonSources?: EffectPersonSource[];
+	effectDistortionSources?: EffectDistortionSource[];
 	effectAudioReactiveEnvelopes?: EffectAudioReactiveEnvelope[];
 }
 

--- a/qcut/electron/ffmpeg/types.ts
+++ b/qcut/electron/ffmpeg/types.ts
@@ -202,6 +202,11 @@ export interface EffectOverlaySource {
 	stageIndex: number;
 	path: string;
 	animated: boolean;
+	/**
+	 * Present for baked procedural frame sequences: `path` is then an image2
+	 * pattern (…/f_%05d.png) consumed with -framerate instead of -loop.
+	 */
+	sequence?: { framerate: number };
 	inputIndex?: number;
 }
 

--- a/qcut/electron/preload-types/api-types/ffmpeg-export-api.ts
+++ b/qcut/electron/preload-types/api-types/ffmpeg-export-api.ts
@@ -94,6 +94,17 @@ export interface FFmpegExportAPI {
 			imageData: Uint8Array;
 			format?: string;
 		}) => Promise<{ success: boolean; path?: string; error?: string }>;
+		saveEffectSequenceFrame: (data: {
+			sessionId: string;
+			sequenceId: string;
+			frameIndex: number;
+			imageData: Uint8Array;
+		}) => Promise<{
+			success: boolean;
+			path?: string;
+			patternPath?: string;
+			error?: string;
+		}>;
 		getFFmpegResourcePath: (filename: string) => Promise<string>;
 		checkFFmpegResource: (filename: string) => Promise<boolean>;
 		getPath: () => Promise<string>;

--- a/qcut/electron/preload-types/api-types/ffmpeg-export-api.ts
+++ b/qcut/electron/preload-types/api-types/ffmpeg-export-api.ts
@@ -99,6 +99,7 @@ export interface FFmpegExportAPI {
 			sequenceId: string;
 			frameIndex: number;
 			imageData: Uint8Array;
+			extension?: string;
 		}) => Promise<{
 			success: boolean;
 			path?: string;

--- a/qcut/electron/preload.ts
+++ b/qcut/electron/preload.ts
@@ -353,6 +353,7 @@ const electronAPI: ElectronAPI & Record<string, unknown> = {
 			sequenceId: string;
 			frameIndex: number;
 			imageData: Uint8Array;
+			extension?: string;
 		}): Promise<{
 			success: boolean;
 			path?: string;

--- a/qcut/electron/preload.ts
+++ b/qcut/electron/preload.ts
@@ -348,6 +348,17 @@ const electronAPI: ElectronAPI & Record<string, unknown> = {
 			format?: string;
 		}): Promise<{ success: boolean; path?: string; error?: string }> =>
 			ipcRenderer.invoke("save-sticker-for-export", data),
+		saveEffectSequenceFrame: (data: {
+			sessionId: string;
+			sequenceId: string;
+			frameIndex: number;
+			imageData: Uint8Array;
+		}): Promise<{
+			success: boolean;
+			path?: string;
+			patternPath?: string;
+			error?: string;
+		}> => ipcRenderer.invoke("save-effect-sequence-frame", data),
 		processFrame: (options: {
 			sessionId: string;
 			inputFrameName: string;


### PR DESCRIPTION
## Summary

Closes the WYSIWYG gap tracked in #333: the ~18 procedural effects (particles / decorations / distortion) previously rendered only in the canvas preview (`parity: "pending"`). This PR burns them into the primary Electron FFmpeg export via Plan B — **bake procedural frames, feed native FFmpeg** — keeping full native encoding speed and zero changes to the text/audio/transition pipelines.

**Stacked on** `effectsv1` (#333) — merge that first.

### How it works

**Particles + decorations (14 effects)** — these are pure `f(t, size) → transparent RGBA` with no dependency on the underlying video:
- `effect-procedural-draw.ts`: draw logic extracted from the two preview canvas components into shared pure functions — preview and export paint through the same code, so output matches the preview pixel-for-pixel
- `effect-procedural-sources.ts`: headless OffscreenCanvas baker → transparent PNG frame sequence (static decorations like 上下网格 bake **one** looped frame)
- New `save-effect-sequence-frame` IPC writes frames into the export session dir
- `ffmpeg-args-builder.ts`: sequences enter as `image2` pattern inputs (`-framerate N -i …/f_%05d.png`); downstream they are ordinary video streams
- `ffmpeg-video-transform.ts`: new per-stage handler composites them with a plain alpha overlay (opacity/blend already baked). Finite sequences deliberately avoid `shortest=1` (would truncate the clip) and rely on `eof_action=repeat`

**Distortion (4 effects: 鱼眼/放大镜/水波纹/冲击波)** — per-pixel source remapping, expressed with FFmpeg's `remap` filter:
- `effect-distortion-sources.ts`: bakes 16-bit big-endian PGM xmap/ymap coordinate maps sampled from the **same** `sampleDistortionSource` model the preview uses, at reduced resolution (≤480px side) and scaled up in-graph
- Static variants (fisheye/magnifier) bake 1 map pair; animated ones (ripple/shockwave) bake one pair per frame
- Window gating splits the base stream and re-blends (`remap` has no timeline support), mirroring the composite-stage pattern

All 18 catalog entries flip to `parity: "verified"`; the catalog audit's pending list is now empty.

### Verification

- 1747 tests pass (166 files), incl. new suites for the baker, distortion map renderer, args-builder inputs, and filter-graph handlers
- `tsc --noEmit` clean in `apps/web` + `packages/editor-core`
- **Real-binary smoke test**: production `buildFFmpegArgs` output (particles sequence + fisheye maps) run through the app's bundled darwin-arm64 FFmpeg → MP4 encodes; extracted frame shows fisheye barrel distortion on the source with the undistorted overlay on top, matching preview semantics

### Notes

- Export progress surfaces a "Baking effect frames (n/N)…" phase during the bake
- New code paths execute only when a timeline contains procedural stages — zero change to existing exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end export support for particle, decoration, and distortion effects, including baked procedural frame sequences and distortion remap maps (for both video and image).
  * Updated the export pipeline to composite procedural stages and apply distortion remapping with window-gated timing.
  * Marked supported effect render parity as **verified** for particle/decoration and distortion exports.
* **Bug Fixes**
  * Improved alignment between canvas previews and exported results, with more robust validation for missing frames/maps and export assets.
* **Tests**
  * Expanded tests for procedural baking, distortion map generation, FFmpeg composite behavior, and export/input error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->