### PR TITLE
fix(effects): expose saveEffectSequenceFrame through platform layer

### DIFF
--- a/qcut/packages/platform-core/src/types/media-api.ts
+++ b/qcut/packages/platform-core/src/types/media-api.ts
@@ -330,6 +330,18 @@ export interface PlatformFFmpegAPI {
 		imageData: Uint8Array;
 		format?: string;
 	}): Promise<{ success: boolean; path?: string; error?: string }>;
+	saveEffectSequenceFrame(data: {
+		sessionId: string;
+		sequenceId: string;
+		frameIndex: number;
+		imageData: Uint8Array;
+		extension?: string;
+	}): Promise<{
+		success: boolean;
+		path?: string;
+		patternPath?: string;
+		error?: string;
+	}>;
 	processFrame(options: {
 		sessionId: string;
 		inputFrameName: string;

--- a/qcut/packages/platform-desktop/src/index.ts
+++ b/qcut/packages/platform-desktop/src/index.ts
@@ -128,7 +128,13 @@ const ffmpegAdapter = {
 	exportAudioCLI: (o: any) => api().ffmpeg.exportAudioCLI(o),
 	convertVideoToGif: (o: any) => api().ffmpeg.convertVideoToGif(o),
 	saveStickerForExport: (d: any) => api().ffmpeg.saveStickerForExport(d),
-	saveEffectSequenceFrame: (d: any) => api().ffmpeg.saveEffectSequenceFrame(d),
+	saveEffectSequenceFrame: (d: {
+		sessionId: string;
+		sequenceId: string;
+		frameIndex: number;
+		imageData: Uint8Array;
+		extension?: string;
+	}) => api().ffmpeg.saveEffectSequenceFrame(d),
 	processFrame: (o: any) => api().ffmpeg.processFrame(o),
 	renderVideoFramePreview: (o: any) => api().ffmpeg.renderVideoFramePreview(o),
 	renderVideoCompositionFramePreview: (

--- a/qcut/packages/platform-desktop/src/index.ts
+++ b/qcut/packages/platform-desktop/src/index.ts
@@ -128,6 +128,7 @@ const ffmpegAdapter = {
 	exportAudioCLI: (o: any) => api().ffmpeg.exportAudioCLI(o),
 	convertVideoToGif: (o: any) => api().ffmpeg.convertVideoToGif(o),
 	saveStickerForExport: (d: any) => api().ffmpeg.saveStickerForExport(d),
+	saveEffectSequenceFrame: (d: any) => api().ffmpeg.saveEffectSequenceFrame(d),
 	processFrame: (o: any) => api().ffmpeg.processFrame(o),
 	renderVideoFramePreview: (o: any) => api().ffmpeg.renderVideoFramePreview(o),
 	renderVideoCompositionFramePreview: (


### PR DESCRIPTION
## Summary

Real in-app E2E of the procedural effects export (from #334) caught a release blocker: clicking Export on a timeline with particle/decoration/distortion effects failed with **“Procedural effect export API is unavailable”**.

Root cause: the baker calls the IPC through `platform().ffmpeg`, but `saveEffectSequenceFrame` was only added to the preload bridge — never to the `@qcut/platform-core` `PlatformFFmpegAPI` interface or the `@qcut/platform-desktop` passthrough, so the renderer-facing platform object had no such method. (The unit tests injected a mock `api`, which is why they never caught it; `platform-web`’s graceful Proxy namespace needs no change.)

**Affects v2026.07.21.1** — procedural effects still silently preview-only in that build’s export; worth a patch release.

## Fix

- `packages/platform-core/src/types/media-api.ts`: add `saveEffectSequenceFrame` to `PlatformFFmpegAPI`
- `packages/platform-desktop/src/index.ts`: add the one-line passthrough

## Verification (real UI end-to-end)

Full user path exercised in the packaged-equivalent build: new project → import 4s test clip → apply 雪花散落 (particles) + 鱼眼 (distortion) via the effects panel → Export (Native CLI engine, 1080p30). Export progress surfaced the new “Baking effect frames…” / “Baking distortion maps…” phases, and the output MP4 frame shows both effects burned in (fisheye-bulged color bars + snow particles) — matching the live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for saving individual frames from effect sequences.
  * Saved frames can include session and sequence identifiers, frame index, image data, and an optional file extension.
  * The save operation reports success or failure and may return generated file paths for the saved frame and its pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->