### PR TITLE
test(adjustments): expect addElementToTrack options argument

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
@@ -125,7 +125,8 @@ describe("AdjustmentsView", () => {
 				name: "自定义调节",
 				startTime: 2,
 				duration: 10,
-			})
+			}),
+			{ pushHistory: false, selectElement: true }
 		);
 		expect(toast.success).toHaveBeenCalledWith("已新建调节层");
 	});
@@ -177,7 +178,8 @@ describe("AdjustmentsView", () => {
 				expect.objectContaining({
 					name: "LUT - Panel LUT",
 					type: "adjustment",
-				})
+				}),
+				{ pushHistory: false, selectElement: true }
 			);
 			expect(timeline.updateAdjustmentElement).toHaveBeenCalledWith(
 				"adjustment-track",


### PR DESCRIPTION
## Summary

Fixes the two `adjustments.test.tsx` cases failing on a clean master checkout ("creates an adjustment layer at the playhead" / "creates an adjustment layer before importing a LUT when none is selected").

**Root cause**: the adjustment-layer workflow (a46a4b5ca) passes a third options argument — `{ pushHistory: false, selectElement: true }` — to `addElementToTrack`, but the test assertions still listed only two arguments; `toHaveBeenCalledWith` requires an exact argument-count match, so both assertions failed even though the component behavior is intentional (select the new layer, merge the history entry).

**Fix**: the two assertions now include the options argument. Suite passes 4/4; test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)