### PR TITLE
fix(test): make windows-flaky suites platform-safe

### DIFF
--- a/qcut/apps/web/scripts/__tests__/import-text-designer-assets.test.ts
+++ b/qcut/apps/web/scripts/__tests__/import-text-designer-assets.test.ts
@@ -395,12 +395,12 @@ describe("text designer asset import script", () => {
 			dryRun: true,
 			generatedManifestPath: "/tmp/generated.json",
 			marketplaceConfigPath: expect.stringContaining(
-				"text-assets/marketplace.json"
+				join("text-assets", "marketplace.json")
 			),
 			minDesignerAssets: 10,
 			minDesignerAssetsPerCategory: 5,
 			packDir: "/tmp/designer-pack",
-			packManifestPath: "/tmp/designer-pack/manifest.json",
+			packManifestPath: join("/tmp/designer-pack", "manifest.json"),
 			publicDir: "/tmp/public",
 			requiredDesignerCategories: ["red", "texture"],
 			syncMarketplace: true,

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/stickers-view.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/stickers-view.test.tsx
@@ -61,22 +61,27 @@ describe("StickersView", () => {
 		expect(screen.getByTestId("sticker-category-popular")).toBeInTheDocument();
 	});
 
-	it("renders at least five stickers in every creator category", () => {
-		render(<StickersView />);
+	// Iterates every creator category; slow Windows CI runners exceed the 5s default.
+	it(
+		"renders at least five stickers in every creator category",
+		{ timeout: 20_000 },
+		() => {
+			render(<StickersView />);
 
-		for (const category of STICKER_CATEGORIES) {
-			fireEvent.click(screen.getByTestId(`sticker-category-${category.id}`));
-			const items = within(
-				screen.getByTestId("sticker-category-grid")
-			).getAllByTestId("sticker-item");
-			expect(items.length, category.id).toBeGreaterThanOrEqual(
-				STICKER_CATEGORY_MINIMUM_SIZE
-			);
-			expect(
-				screen.getByTestId(`sticker-category-${category.id}`)
-			).toHaveAttribute("aria-pressed", "true");
+			for (const category of STICKER_CATEGORIES) {
+				fireEvent.click(screen.getByTestId(`sticker-category-${category.id}`));
+				const items = within(
+					screen.getByTestId("sticker-category-grid")
+				).getAllByTestId("sticker-item");
+				expect(items.length, category.id).toBeGreaterThanOrEqual(
+					STICKER_CATEGORY_MINIMUM_SIZE
+				);
+				expect(
+					screen.getByTestId(`sticker-category-${category.id}`)
+				).toHaveAttribute("aria-pressed", "true");
+			}
 		}
-	});
+	);
 
 	it("searches curated stickers in Chinese", () => {
 		render(<StickersView />);


### PR DESCRIPTION
## Summary

Two web tests fail on every Windows CI run; the failures are masked because the "Run tests with coverage" step has `continue-on-error: true`, so they only surface as annotations (e.g. on the v2026.07.26.3 release CI).

- `scripts/__tests__/import-text-designer-assets.test.ts` — the argument-parsing test asserted POSIX separators (`text-assets/marketplace.json`, `/tmp/designer-pack/manifest.json`) while the script derives these defaults with `node:path` `join`, which produces backslashes on win32. Expectations now use `join()` so they are platform-correct.
- `stickers-view.test.tsx` "renders at least five stickers in every creator category" — iterates every creator category with a full render per click and exceeds the 5s default timeout on slow Windows runners. Bumped that single test to 20s.

## Verification

- Both files pass locally (35 tests) on macOS; the Windows leg of this PR's CI is the real proof — check the "Run tests with coverage" step annotations show no failures for these two suites.
- biome clean.

Worth considering separately: whether the web test step should keep `continue-on-error: true` at all — it currently hides real regressions like these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability by allowing additional time for sticker category rendering checks.
  * Updated path expectations in asset import tests to work consistently across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->