### PR TITLE
fix(cli): audio track routing, batch-update nested changes, replicate long-video split

### DIFF
--- a/qcut/apps/web/src/lib/claude-bridge/__tests__/claude-audio-track-routing.test.ts
+++ b/qcut/apps/web/src/lib/claude-bridge/__tests__/claude-audio-track-routing.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addClaudeMediaElement } from "../claude-timeline-bridge-helpers";
+
+const storeMocks = vi.hoisted(() => {
+	const mediaItems = [
+		{
+			id: "m-audio",
+			name: "song.mp3",
+			type: "audio" as const,
+			duration: 164.2,
+		},
+		{
+			id: "m-video",
+			name: "clip.mp4",
+			type: "video" as const,
+			duration: 30,
+		},
+	];
+	return { mediaItems };
+});
+
+vi.mock("@/stores/timeline/timeline-store", () => ({
+	useTimelineStore: { getState: vi.fn(() => ({})) },
+}));
+
+vi.mock("@/stores/project-store", () => ({
+	useProjectStore: { getState: vi.fn(() => ({ activeProject: null })) },
+}));
+
+vi.mock("@/stores/media/media-store", () => ({
+	useMediaStore: {
+		getState: vi.fn(() => ({ mediaItems: storeMocks.mediaItems })),
+	},
+}));
+
+vi.mock("@qcut/platform-core", () => ({
+	platform: vi.fn(() => ({ projectFolder: undefined })),
+}));
+
+vi.mock("@/lib/debug/debug-config", () => ({
+	debugLog: vi.fn(),
+	debugWarn: vi.fn(),
+	debugError: vi.fn(),
+}));
+
+function makeTimelineStore() {
+	return {
+		findOrCreateTrack: vi.fn(() => "track-x"),
+		addElementToTrack: vi.fn(),
+	};
+}
+
+describe("Claude media element track routing", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("routes audio media to an audio track", async () => {
+		const timelineStore = makeTimelineStore();
+
+		await addClaudeMediaElement({
+			element: { type: "audio", sourceName: "song.mp3", startTime: 5 },
+			timelineStore: timelineStore as never,
+			projectId: undefined,
+		});
+
+		expect(timelineStore.findOrCreateTrack).toHaveBeenCalledWith("audio");
+		expect(timelineStore.addElementToTrack).toHaveBeenCalledWith(
+			"track-x",
+			expect.objectContaining({
+				type: "media",
+				mediaId: "m-audio",
+				startTime: 5,
+				// Element duration falls back to the media item's real duration,
+				// not the 10s default.
+				duration: 164.2,
+			})
+		);
+	});
+
+	it("routes video media to the media track", async () => {
+		const timelineStore = makeTimelineStore();
+
+		await addClaudeMediaElement({
+			element: { type: "video", sourceName: "clip.mp4", startTime: 0 },
+			timelineStore: timelineStore as never,
+			projectId: undefined,
+		});
+
+		expect(timelineStore.findOrCreateTrack).toHaveBeenCalledWith("media");
+		expect(timelineStore.addElementToTrack).toHaveBeenCalledWith(
+			"track-x",
+			expect.objectContaining({ mediaId: "m-video", duration: 30 })
+		);
+	});
+});

--- a/qcut/apps/web/src/lib/claude-bridge/__tests__/claude-timeline-bridge-batch.test.ts
+++ b/qcut/apps/web/src/lib/claude-bridge/__tests__/claude-timeline-bridge-batch.test.ts
@@ -23,6 +23,13 @@ const storeMocks = vi.hoisted(() => {
 		tracks: [track],
 		pushHistory: vi.fn(),
 		addElementToTrack: vi.fn(),
+		updateElementStartTime: vi.fn(),
+		updateElementTrim: vi.fn(),
+		updateElementDuration: vi.fn(),
+		updateMarkdownElement: vi.fn(),
+		updateTextElement: vi.fn(),
+		updateMediaElement: vi.fn(),
+		updateMediaTiming: vi.fn(),
 	};
 	return { state, track };
 });
@@ -129,6 +136,78 @@ describe("Claude timeline batch bridge", () => {
 		expect(sendResponse).toHaveBeenCalledWith("request-1", {
 			added: [{ index: 0, success: true, elementId: "element-1" }],
 			failedCount: 0,
+		});
+	});
+
+	it("applies batch updates in both nested-changes and flat shapes", () => {
+		storeMocks.track.elements = [
+			{
+				id: "clip",
+				type: "media",
+				startTime: 0,
+				duration: 8,
+				trimStart: 0,
+				trimEnd: 0,
+			},
+		];
+
+		let updateHandler:
+			| ((data: {
+					requestId: string;
+					updates: Array<Record<string, unknown>>;
+			  }) => void)
+			| undefined;
+		const sendResponse = vi.fn();
+		const claudeAPI = {
+			onBatchUpdateElements: vi.fn(
+				(
+					handler: (data: {
+						requestId: string;
+						updates: Array<Record<string, unknown>>;
+					}) => void
+				) => {
+					updateHandler = handler;
+				}
+			),
+			sendBatchUpdateElementsResponse: sendResponse,
+		} as unknown as ClaudeTimelineBridgeAPI;
+
+		setupBatchHandlers({
+			claudeAPI,
+			sharedUtils: {} as ClaudeTimelineBridgeSharedUtils,
+		});
+		expect(updateHandler).toBeDefined();
+		updateHandler?.({
+			requestId: "request-2",
+			updates: [
+				// Documented nested shape — previously silently ignored
+				{ elementId: "clip", changes: { startTime: 7 } },
+				// Legacy flat shape — must keep working
+				{ elementId: "clip", startTime: 9 },
+			],
+		});
+
+		expect(storeMocks.state.updateElementStartTime).toHaveBeenNthCalledWith(
+			1,
+			"track-1",
+			"clip",
+			7,
+			false
+		);
+		expect(storeMocks.state.updateElementStartTime).toHaveBeenNthCalledWith(
+			2,
+			"track-1",
+			"clip",
+			9,
+			false
+		);
+		expect(sendResponse).toHaveBeenCalledWith("request-2", {
+			updatedCount: 2,
+			failedCount: 0,
+			results: [
+				{ index: 0, success: true },
+				{ index: 1, success: true },
+			],
 		});
 	});
 });

--- a/qcut/apps/web/src/lib/claude-bridge/claude-timeline-bridge-batch.ts
+++ b/qcut/apps/web/src/lib/claude-bridge/claude-timeline-bridge-batch.ts
@@ -383,9 +383,17 @@ export function setupBatchHandlers({
 				let failedCount = 0;
 
 				for (const [index, update] of updates.entries()) {
+					// Accept both the documented nested shape
+					// {elementId, changes: {...}} and the legacy flat shape
+					// {elementId, startTime, ...} — nested `changes` used to be
+					// silently ignored while still reporting success.
+					const changes =
+						update.changes && typeof update.changes === "object"
+							? update.changes
+							: update;
 					const success = applyElementChanges({
 						elementId: update.elementId,
-						changes: update,
+						changes,
 						pushHistory: false,
 					});
 					if (success) {

--- a/qcut/apps/web/src/lib/claude-bridge/claude-timeline-bridge-helpers.ts
+++ b/qcut/apps/web/src/lib/claude-bridge/claude-timeline-bridge-helpers.ts
@@ -573,7 +573,11 @@ export async function addClaudeMediaElement({
 		return;
 	}
 
-	const trackId = timelineStore.findOrCreateTrack("media");
+	// Route audio files to an audio track, matching the app's own drag-drop
+	// behavior (timeline-add-ops), instead of stacking them on the media track.
+	const trackId = timelineStore.findOrCreateTrack(
+		mediaItem?.type === "audio" ? "audio" : "media"
+	);
 	const resolvedId = mediaItem?.id ?? element.mediaId ?? element.sourceId!;
 	const resolvedName = mediaItem?.name ?? element.sourceName ?? "Media";
 	const fallbackDuration =

--- a/qcut/apps/web/src/stores/media/__tests__/media-store-audio-duration.test.ts
+++ b/qcut/apps/web/src/stores/media/__tests__/media-store-audio-duration.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMediaStore } from "../media-store";
+import { getMediaDuration } from "../media-store-helpers";
+
+vi.mock("@/lib/storage/storage-service", () => ({
+	storageService: {
+		saveMediaItem: vi.fn(async () => {}),
+	},
+}));
+
+vi.mock("../media-store-helpers", () => ({
+	revokeMediaBlob: vi.fn(),
+	cloneFileForTemporaryUse: vi.fn((file: File) => file),
+	generateVideoThumbnailBrowser: vi.fn(),
+	getMediaDuration: vi.fn(async () => 164.2),
+	getFileType: vi.fn(() => "audio"),
+	getImageDimensions: vi.fn(),
+	getMediaAspectRatio: vi.fn(),
+}));
+
+vi.mock("@/lib/media/blob-manager", () => ({
+	getOrCreateObjectURL: vi.fn(() => "blob:mock"),
+}));
+
+vi.mock("@/lib/debug/debug-config", () => ({
+	debugLog: vi.fn(),
+	debugWarn: vi.fn(),
+	debugError: vi.fn(),
+}));
+
+vi.mock("@/lib/debug/error-handler", () => ({
+	handleStorageError: vi.fn(),
+	handleMediaProcessingError: vi.fn(),
+}));
+
+const makeAudioFile = () =>
+	new File(["audio-bytes"], "song.mp3", { type: "audio/mpeg" });
+
+describe("media store audio duration extraction", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useMediaStore.setState({ mediaItems: [] });
+	});
+
+	it("extracts and stores duration for imported audio", async () => {
+		const id = await useMediaStore.getState().addMediaItem("proj-1", {
+			name: "song.mp3",
+			type: "audio",
+			file: makeAudioFile(),
+			url: "blob:seed",
+		});
+
+		await vi.waitFor(() => {
+			const item = useMediaStore
+				.getState()
+				.mediaItems.find((candidate) => candidate.id === id);
+			expect(item?.duration).toBeCloseTo(164.2);
+		});
+		expect(getMediaDuration).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips extraction when the audio item already has a duration", async () => {
+		await useMediaStore.getState().addMediaItem("proj-1", {
+			name: "known.mp3",
+			type: "audio",
+			file: makeAudioFile(),
+			url: "blob:seed",
+			duration: 42,
+		});
+
+		expect(getMediaDuration).not.toHaveBeenCalled();
+	});
+});

--- a/qcut/apps/web/src/stores/media/media-store.ts
+++ b/qcut/apps/web/src/stores/media/media-store.ts
@@ -139,6 +139,26 @@ const updateMediaMetadataAndPersist = async (
 	}
 };
 
+// Background audio duration extraction without blocking UI. Audio items have
+// no thumbnail, so unlike the video path this only resolves the duration —
+// without it, timeline consumers fall back to a 10s default element length.
+const extractAudioMetadataBackground = async (
+	file: File,
+	itemId: string,
+	projectId: string
+) => {
+	try {
+		const fileClone = cloneFileForTemporaryUse(file);
+		const duration = await getMediaDurationImpl(fileClone);
+		await updateMediaMetadataAndPersist(itemId, projectId, { duration });
+	} catch (error) {
+		debugError(
+			`[MediaStore] Audio duration extraction failed for ${itemId}`,
+			error
+		);
+	}
+};
+
 // Background metadata extraction without blocking UI
 const extractVideoMetadataBackground = async (
 	file: File,
@@ -292,6 +312,16 @@ export const useMediaStore = create<MediaStore>((set, get) => ({
 			// Trigger thumbnail generation for videos AFTER storage save succeeds
 			if (newItem.type === "video" && newItem.file && !newItem.thumbnailUrl) {
 				extractVideoMetadataBackground(newItem.file, newItem.id, projectId);
+			} else if (
+				newItem.type === "audio" &&
+				newItem.file &&
+				typeof newItem.duration !== "number"
+			) {
+				void extractAudioMetadataBackground(
+					newItem.file,
+					newItem.id,
+					projectId
+				);
 			}
 
 			return newItem.id;
@@ -351,6 +381,13 @@ export const useMediaStore = create<MediaStore>((set, get) => ({
 				!updated.thumbnailUrl
 			) {
 				void extractVideoMetadataBackground(updated.file, id, projectId);
+			} else if (
+				updated.type === "audio" &&
+				updated.file &&
+				updated.file !== previous.file &&
+				typeof updated.duration !== "number"
+			) {
+				void extractAudioMetadataBackground(updated.file, id, projectId);
 			}
 			return true;
 		} catch (error) {

--- a/qcut/electron/native-pipeline/cli/cli-handlers-replicate.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-replicate.ts
@@ -104,6 +104,9 @@ export async function handleReplicateAnalyze(
 			outputDir: options.json ? undefined : outputDir,
 			model: options.llmModel,
 			signal,
+			onProgress: (stage, percent, message) => {
+				onProgress({ stage, percent, message });
+			},
 		});
 
 		const duration = (Date.now() - startTime) / 1000;

--- a/qcut/electron/native-pipeline/editorial/video-split.ts
+++ b/qcut/electron/native-pipeline/editorial/video-split.ts
@@ -1,0 +1,215 @@
+/**
+ * Generic local-video split utilities shared by payload-limited analysis flows
+ * (video review, replicate analysis). Splitting is decided by the estimated
+ * base64 data-URL size a video would occupy inside a single model request.
+ *
+ * @module electron/native-pipeline/editorial/video-split
+ */
+
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { getFFmpegPath, getFFprobePath } from "../../ffmpeg/paths.js";
+
+const execFileAsync = promisify(execFile);
+const DATA_URL_PREFIX_CHARS = "data:video/mp4;base64,".length;
+
+/** One evenly sized part of a split source video. */
+export interface VideoSplitPart {
+	index: number;
+	startSeconds: number;
+	durationSeconds: number;
+	filePath: string;
+	outputDir: string;
+}
+
+/** Injectable probe/split implementations (overridable in tests). */
+export interface VideoSplitter {
+	probeDurationSeconds: (args: { input: string }) => Promise<number>;
+	splitVideo: (args: {
+		input: string;
+		outputDir: string;
+		partCount: number;
+		durationSeconds: number;
+		subdirName: string;
+		partDirSuffix: string;
+	}) => Promise<VideoSplitPart[]>;
+}
+
+/**
+ * Determines whether a video input is a remote URL or an inline data URL.
+ * Those inputs cannot be split locally.
+ */
+export function isRemoteOrInlineVideo({ input }: { input: string }): boolean {
+	return /^https?:\/\//i.test(input) || input.startsWith("data:");
+}
+
+/**
+ * Estimates the character length of a base64 data URL for a file of the given size.
+ */
+export function estimatedBase64Chars({
+	fileBytes,
+}: {
+	fileBytes: number;
+}): number {
+	return Math.ceil(fileBytes / 3) * 4 + DATA_URL_PREFIX_CHARS;
+}
+
+/**
+ * Decides whether a local video must be split based on its estimated payload size.
+ * Remote/inline inputs and missing files are never split.
+ */
+export function shouldSplitVideoInput({
+	input,
+	maxPayloadChars,
+}: {
+	input: string;
+	maxPayloadChars: number;
+}): { shouldSplit: boolean; estimatedPayloadChars: number; fileBytes: number } {
+	if (isRemoteOrInlineVideo({ input }) || !existsSync(input)) {
+		return { shouldSplit: false, estimatedPayloadChars: 0, fileBytes: 0 };
+	}
+
+	const fileBytes = statSync(input).size;
+	const estimatedPayloadChars = estimatedBase64Chars({ fileBytes });
+	return {
+		shouldSplit: estimatedPayloadChars > maxPayloadChars,
+		estimatedPayloadChars,
+		fileBytes,
+	};
+}
+
+/**
+ * Computes how many parts a video must be split into to fit within the payload
+ * limit. Always at least 2.
+ */
+export function partCountForPayload({
+	estimatedPayloadChars,
+	maxPayloadChars,
+}: {
+	estimatedPayloadChars: number;
+	maxPayloadChars: number;
+}): number {
+	return Math.max(2, Math.ceil(estimatedPayloadChars / maxPayloadChars));
+}
+
+/** Builds the output file path for a single split part. */
+function outputPartFilePath({
+	outputDir,
+	index,
+	startSeconds,
+}: {
+	outputDir: string;
+	index: number;
+	startSeconds: number;
+}): string {
+	const paddedIndex = String(index + 1).padStart(3, "0");
+	const paddedStart = String(Math.round(startSeconds)).padStart(4, "0");
+	return join(outputDir, `part-${paddedIndex}-${paddedStart}s.mp4`);
+}
+
+/**
+ * Probes a video's duration in seconds via `ffprobe`.
+ *
+ * @throws If `ffprobe` cannot determine a valid positive duration.
+ */
+export async function probeVideoDurationSeconds({
+	input,
+}: {
+	input: string;
+}): Promise<number> {
+	const ffprobePath = await getFFprobePath();
+	const { stdout } = await execFileAsync(ffprobePath, [
+		"-v",
+		"error",
+		"-show_entries",
+		"format=duration",
+		"-of",
+		"default=noprint_wrappers=1:nokey=1",
+		input,
+	]);
+	const duration = Number.parseFloat(stdout.trim());
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error(`Unable to determine video duration for ${input}`);
+	}
+	return duration;
+}
+
+/**
+ * Splits a video into evenly sized parts using `ffmpeg` stream copy.
+ * Parts are written under `<outputDir>/<subdirName>` and produced in parallel.
+ */
+export async function splitVideoIntoParts({
+	input,
+	outputDir,
+	partCount,
+	durationSeconds,
+	subdirName,
+	partDirSuffix,
+}: {
+	input: string;
+	outputDir: string;
+	partCount: number;
+	durationSeconds: number;
+	subdirName: string;
+	partDirSuffix: string;
+}): Promise<VideoSplitPart[]> {
+	const ffmpegPath = getFFmpegPath();
+	const splitDir = join(outputDir, subdirName);
+	mkdirSync(splitDir, { recursive: true });
+	const partDuration = durationSeconds / partCount;
+	const parts = Array.from({ length: partCount }, (_, index) => {
+		const startSeconds = index * partDuration;
+		const isLastPart = index === partCount - 1;
+		return {
+			index,
+			startSeconds,
+			durationSeconds: isLastPart
+				? durationSeconds - startSeconds
+				: partDuration,
+			filePath: outputPartFilePath({
+				outputDir: splitDir,
+				index,
+				startSeconds,
+			}),
+			outputDir: join(
+				splitDir,
+				`part-${String(index + 1).padStart(3, "0")}-${partDirSuffix}`
+			),
+		};
+	});
+
+	await Promise.all(
+		parts.map((part) =>
+			execFileAsync(ffmpegPath, [
+				"-y",
+				"-hide_banner",
+				"-loglevel",
+				"error",
+				"-ss",
+				String(part.startSeconds),
+				"-i",
+				input,
+				"-t",
+				String(part.durationSeconds),
+				"-c",
+				"copy",
+				"-map",
+				"0:v:0",
+				"-map",
+				"0:a:0?",
+				"-movflags",
+				"+faststart",
+				part.filePath,
+			])
+		)
+	);
+
+	return parts;
+}
+
+export const defaultVideoSplitter: VideoSplitter = {
+	probeDurationSeconds: probeVideoDurationSeconds,
+	splitVideo: splitVideoIntoParts,
+};

--- a/qcut/electron/native-pipeline/replicate/__tests__/replicate-split.test.ts
+++ b/qcut/electron/native-pipeline/replicate/__tests__/replicate-split.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+	computeReplicatePartCount,
+	mergeVideoRecipes,
+} from "../replicate-split";
+import type { VideoRecipe } from "../replicate-types";
+
+function makeRecipe(overrides: {
+	shots: Array<{ startTime: number; endTime: number }>;
+	genre?: string;
+	mood?: string;
+	pacing?: "fast" | "medium" | "slow";
+	colorPalette?: string[];
+	hasBGM?: boolean;
+	hasVoiceover?: boolean;
+	transcript?: string;
+	bgmStyle?: string;
+}): VideoRecipe {
+	return {
+		version: 1,
+		source: {
+			filename: "part.mp4",
+			duration: 120,
+			resolution: { width: 1920, height: 1080 },
+			fps: 25,
+		},
+		style: {
+			genre: overrides.genre ?? "vlog",
+			mood: overrides.mood ?? "calm",
+			colorPalette: overrides.colorPalette ?? [],
+			pacing: overrides.pacing ?? "medium",
+		},
+		audio: {
+			hasBGM: overrides.hasBGM ?? false,
+			bgmStyle: overrides.bgmStyle,
+			hasVoiceover: overrides.hasVoiceover ?? false,
+			transcript: overrides.transcript,
+		},
+		shots: overrides.shots.map((shot, index) => ({
+			index,
+			startTime: shot.startTime,
+			endTime: shot.endTime,
+			duration: shot.endTime - shot.startTime,
+			type: "wide" as const,
+			camera: "static" as const,
+			description: `shot ${index}`,
+			prompt: `prompt ${index}`,
+			transition: "cut" as const,
+			hasText: false,
+			hasSubtitle: false,
+		})),
+	};
+}
+
+describe("computeReplicatePartCount", () => {
+	it("uses the payload-based count when it dominates", () => {
+		expect(
+			computeReplicatePartCount({
+				estimatedPayloadChars: 26 * 1024 * 1024,
+				maxPayloadChars: 8 * 1024 * 1024,
+				durationSeconds: 90,
+				maxPartSeconds: 120,
+			})
+		).toBe(4);
+	});
+
+	it("caps part length via the duration limit", () => {
+		// 7-minute video slightly over the payload limit still splits into
+		// ~2-minute parts, not two 3.5-minute halves.
+		expect(
+			computeReplicatePartCount({
+				estimatedPayloadChars: 13 * 1024 * 1024,
+				maxPayloadChars: 8 * 1024 * 1024,
+				durationSeconds: 444,
+				maxPartSeconds: 120,
+			})
+		).toBe(4);
+	});
+
+	it("never returns fewer than two parts", () => {
+		expect(
+			computeReplicatePartCount({
+				estimatedPayloadChars: 1,
+				maxPayloadChars: 100,
+				durationSeconds: 10,
+				maxPartSeconds: 120,
+			})
+		).toBe(2);
+	});
+});
+
+describe("mergeVideoRecipes", () => {
+	it("shifts shot times onto the original timeline and reindexes", () => {
+		const merged = mergeVideoRecipes({
+			parts: [
+				{
+					recipe: makeRecipe({
+						shots: [
+							{ startTime: 0, endTime: 3 },
+							{ startTime: 3, endTime: 7 },
+						],
+					}),
+					offsetSeconds: 0,
+				},
+				{
+					recipe: makeRecipe({ shots: [{ startTime: 0, endTime: 5 }] }),
+					offsetSeconds: 7,
+				},
+			],
+			filename: "full.mp4",
+			totalDuration: 12,
+		});
+
+		expect(merged.source.filename).toBe("full.mp4");
+		expect(merged.source.duration).toBe(12);
+		expect(merged.shots.map((shot) => shot.index)).toEqual([0, 1, 2]);
+		expect(merged.shots.map((shot) => [shot.startTime, shot.endTime])).toEqual([
+			[0, 3],
+			[3, 7],
+			[7, 12],
+		]);
+		expect(merged.shots[2].duration).toBe(5);
+	});
+
+	it("majority-votes style and unions audio across parts", () => {
+		const merged = mergeVideoRecipes({
+			parts: [
+				{
+					recipe: makeRecipe({
+						shots: [{ startTime: 0, endTime: 2 }],
+						genre: "vlog",
+						pacing: "fast",
+						colorPalette: ["#FFAA00", "#112233"],
+						hasBGM: true,
+						bgmStyle: "uplifting",
+						transcript: "part one",
+					}),
+					offsetSeconds: 0,
+				},
+				{
+					recipe: makeRecipe({
+						shots: [{ startTime: 0, endTime: 2 }],
+						genre: "cinematic",
+						pacing: "fast",
+						colorPalette: ["#ffaa00", "#445566"],
+						hasVoiceover: true,
+						transcript: "part two",
+					}),
+					offsetSeconds: 2,
+				},
+				{
+					recipe: makeRecipe({
+						shots: [{ startTime: 0, endTime: 2 }],
+						genre: "vlog",
+						pacing: "slow",
+					}),
+					offsetSeconds: 4,
+				},
+			],
+			filename: "full.mp4",
+			totalDuration: 6,
+		});
+
+		expect(merged.style.genre).toBe("vlog");
+		expect(merged.style.pacing).toBe("fast");
+		// Case-insensitive palette dedupe keeps first spelling
+		expect(merged.style.colorPalette).toEqual([
+			"#FFAA00",
+			"#112233",
+			"#445566",
+		]);
+		expect(merged.audio.hasBGM).toBe(true);
+		expect(merged.audio.hasVoiceover).toBe(true);
+		expect(merged.audio.bgmStyle).toBe("uplifting");
+		expect(merged.audio.transcript).toBe("part one\npart two");
+	});
+
+	it("rejects an empty part list", () => {
+		expect(() =>
+			mergeVideoRecipes({ parts: [], filename: "x.mp4", totalDuration: 0 })
+		).toThrow();
+	});
+});

--- a/qcut/electron/native-pipeline/replicate/replicate-analyzer.ts
+++ b/qcut/electron/native-pipeline/replicate/replicate-analyzer.ts
@@ -15,6 +15,16 @@ import {
 } from "./replicate-prompts.js";
 import { PipelineExecutor } from "../execution/executor.js";
 import type { PipelineStep } from "../execution/executor.js";
+import {
+	probeVideoDurationSeconds,
+	shouldSplitVideoInput,
+	splitVideoIntoParts,
+} from "../editorial/video-split.js";
+import {
+	computeReplicatePartCount,
+	mergeVideoRecipes,
+	resolveReplicateSplitConfig,
+} from "./replicate-split.js";
 
 const DEFAULT_MODEL = "openrouter_gemini_3_5_flash_video";
 
@@ -23,13 +33,18 @@ export interface AnalyzerOptions {
 	signal?: AbortSignal;
 	/** Optional pre-created executor (avoids creating a new one each call). */
 	executor?: PipelineExecutor;
+	/** Directory split parts are written to (defaults next to the source). */
+	outputDir?: string;
+	/** Progress callback for the split-analysis path. */
+	onProgress?: (stage: string, percent: number, message: string) => void;
 }
 
 /**
  * Analyze a source video and return a VideoRecipe.
  *
- * Uses PipelineExecutor with the image_understanding step type,
- * reusing the same infrastructure as the `analyze-video` CLI command.
+ * Local videos whose estimated base64 payload exceeds the replicate split
+ * limit are split into duration-bounded parts, analyzed per part, and merged
+ * back onto the original timeline; everything else runs as a single request.
  */
 export async function analyzeVideo(
 	videoPath: string,
@@ -37,6 +52,81 @@ export async function analyzeVideo(
 ): Promise<VideoRecipe> {
 	const absPath = path.resolve(videoPath);
 	const filename = path.basename(absPath);
+	const splitConfig = resolveReplicateSplitConfig();
+	const splitDecision = shouldSplitVideoInput({
+		input: absPath,
+		maxPayloadChars: splitConfig.maxPayloadChars,
+	});
+	if (!splitDecision.shouldSplit) {
+		return analyzeSingleVideo({ absPath, filename, options });
+	}
+
+	const durationSeconds = await probeVideoDurationSeconds({ input: absPath });
+	const partCount = computeReplicatePartCount({
+		estimatedPayloadChars: splitDecision.estimatedPayloadChars,
+		maxPayloadChars: splitConfig.maxPayloadChars,
+		durationSeconds,
+		maxPartSeconds: splitConfig.maxPartSeconds,
+	});
+	options.onProgress?.(
+		"analyze_split",
+		5,
+		`Splitting ${Math.round(durationSeconds)}s video into ${partCount} parts for analysis`
+	);
+	const parts = await splitVideoIntoParts({
+		input: absPath,
+		outputDir: options.outputDir ?? path.dirname(absPath),
+		partCount,
+		durationSeconds,
+		subdirName: "replicate-split-parts",
+		partDirSuffix: "replicate",
+	});
+
+	const partRecipes: Array<{ recipe: VideoRecipe; offsetSeconds: number }> = [];
+	for (const part of parts) {
+		options.onProgress?.(
+			"analyze_split_part",
+			10 + Math.round((80 * part.index) / parts.length),
+			`Analyzing part ${part.index + 1}/${parts.length}`
+		);
+		try {
+			const recipe = await analyzeSingleVideo({
+				absPath: part.filePath,
+				filename,
+				options,
+			});
+			partRecipes.push({ recipe, offsetSeconds: part.startSeconds });
+		} catch (error) {
+			throw new Error(
+				`Split analysis part ${part.index + 1}/${parts.length} failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
+		}
+	}
+
+	return mergeVideoRecipes({
+		parts: partRecipes,
+		filename,
+		totalDuration: durationSeconds,
+	});
+}
+
+/**
+ * Runs the replicate analysis prompt against one video file.
+ *
+ * Uses PipelineExecutor with the image_understanding step type,
+ * reusing the same infrastructure as the `analyze-video` CLI command.
+ */
+async function analyzeSingleVideo({
+	absPath,
+	filename,
+	options,
+}: {
+	absPath: string;
+	filename: string;
+	options: AnalyzerOptions;
+}): Promise<VideoRecipe> {
 	const model = options.model || DEFAULT_MODEL;
 	const executor = options.executor || new PipelineExecutor();
 

--- a/qcut/electron/native-pipeline/replicate/replicate-runner.ts
+++ b/qcut/electron/native-pipeline/replicate/replicate-runner.ts
@@ -78,6 +78,8 @@ export async function runReplicate(
 			model: options.analysisModel,
 			signal: options.signal,
 			executor,
+			outputDir,
+			onProgress,
 		};
 		recipe = await analyzeVideo(source, analyzerOpts);
 	} catch (err) {
@@ -121,11 +123,14 @@ export async function runAnalyzeOnly(
 		outputDir?: string;
 		model?: string;
 		signal?: AbortSignal;
+		onProgress?: (stage: string, percent: number, message: string) => void;
 	} = {}
 ): Promise<VideoRecipe> {
 	const recipe = await analyzeVideo(source, {
 		model: options.model,
 		signal: options.signal,
+		outputDir: options.outputDir,
+		onProgress: options.onProgress,
 	});
 
 	if (options.outputDir) {

--- a/qcut/electron/native-pipeline/replicate/replicate-split.ts
+++ b/qcut/electron/native-pipeline/replicate/replicate-split.ts
@@ -1,0 +1,175 @@
+/**
+ * Split configuration and recipe merging for long-video replicate analysis.
+ *
+ * Long local videos are split into payload- and duration-bounded parts (via the
+ * shared editorial/video-split utilities), analyzed per part, and merged back
+ * into a single VideoRecipe with shot timestamps shifted onto the original
+ * timeline.
+ *
+ * @module electron/native-pipeline/replicate/replicate-split
+ */
+
+import type { VideoRecipe, ShotRecipe } from "./replicate-types.js";
+
+/**
+ * OpenRouter starts failing (502) well below the review flow's 35M-char limit
+ * when a whole video rides in one base64 data URL, so replicate analysis uses
+ * a more conservative default (~6MB of source video per request).
+ */
+const DEFAULT_MAX_REPLICATE_PAYLOAD_CHARS = 8 * 1024 * 1024;
+/** Cap part length so each analysis request covers at most ~2 minutes. */
+const DEFAULT_MAX_PART_SECONDS = 120;
+
+export interface ReplicateSplitConfig {
+	maxPayloadChars: number;
+	maxPartSeconds: number;
+}
+
+/** Parses a positive integer env override, returning undefined otherwise. */
+function positiveIntFromEnv(name: string): number | undefined {
+	const raw = process.env[name];
+	if (!raw) return undefined;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Resolves split limits from env overrides
+ * (`QCUT_REPLICATE_SPLIT_MAX_PAYLOAD_CHARS`,
+ * `QCUT_REPLICATE_SPLIT_MAX_PART_SECONDS`) with built-in defaults.
+ */
+export function resolveReplicateSplitConfig(): ReplicateSplitConfig {
+	return {
+		maxPayloadChars:
+			positiveIntFromEnv("QCUT_REPLICATE_SPLIT_MAX_PAYLOAD_CHARS") ??
+			DEFAULT_MAX_REPLICATE_PAYLOAD_CHARS,
+		maxPartSeconds:
+			positiveIntFromEnv("QCUT_REPLICATE_SPLIT_MAX_PART_SECONDS") ??
+			DEFAULT_MAX_PART_SECONDS,
+	};
+}
+
+/**
+ * Computes the part count for a split analysis, honoring both the payload
+ * limit and the maximum per-part duration. Always at least 2 when called
+ * (callers only split when the payload limit is exceeded).
+ */
+export function computeReplicatePartCount({
+	estimatedPayloadChars,
+	maxPayloadChars,
+	durationSeconds,
+	maxPartSeconds,
+}: {
+	estimatedPayloadChars: number;
+	maxPayloadChars: number;
+	durationSeconds: number;
+	maxPartSeconds: number;
+}): number {
+	const payloadParts = Math.ceil(estimatedPayloadChars / maxPayloadChars);
+	const durationParts = Math.ceil(durationSeconds / maxPartSeconds);
+	return Math.max(2, payloadParts, durationParts);
+}
+
+/** Returns the most frequent value; earlier values win ties. */
+function majorityValue<T>(values: T[]): T {
+	const counts = new Map<T, number>();
+	for (const value of values) {
+		counts.set(value, (counts.get(value) ?? 0) + 1);
+	}
+	let best = values[0];
+	let bestCount = 0;
+	for (const value of values) {
+		const count = counts.get(value) ?? 0;
+		if (count > bestCount) {
+			best = value;
+			bestCount = count;
+		}
+	}
+	return best;
+}
+
+/** First defined, non-empty string among the given values. */
+function firstDefined(values: Array<string | undefined>): string | undefined {
+	return values.find((value) => typeof value === "string" && value.length > 0);
+}
+
+/**
+ * Merges per-part recipes back into one recipe on the original timeline.
+ *
+ * Shot times are shifted by each part's start offset and re-indexed
+ * sequentially; style fields use a majority vote across parts; audio flags are
+ * OR-ed and transcripts concatenated in order.
+ */
+export function mergeVideoRecipes({
+	parts,
+	filename,
+	totalDuration,
+}: {
+	parts: Array<{ recipe: VideoRecipe; offsetSeconds: number }>;
+	filename: string;
+	totalDuration: number;
+}): VideoRecipe {
+	if (parts.length === 0) {
+		throw new Error("Cannot merge an empty list of part recipes");
+	}
+
+	const recipes = parts.map((part) => part.recipe);
+	const first = recipes[0];
+
+	const colorPalette: string[] = [];
+	const seenColors = new Set<string>();
+	for (const recipe of recipes) {
+		for (const color of recipe.style.colorPalette) {
+			const key = color.toLowerCase();
+			if (seenColors.has(key)) continue;
+			seenColors.add(key);
+			colorPalette.push(color);
+			if (colorPalette.length >= 5) break;
+		}
+		if (colorPalette.length >= 5) break;
+	}
+
+	const transcripts = recipes
+		.map((recipe) => recipe.audio.transcript)
+		.filter(
+			(transcript): transcript is string =>
+				typeof transcript === "string" && transcript.length > 0
+		);
+
+	const shots: ShotRecipe[] = parts
+		.flatMap((part) =>
+			part.recipe.shots.map((shot) => {
+				const startTime = shot.startTime + part.offsetSeconds;
+				const endTime = shot.endTime + part.offsetSeconds;
+				return { ...shot, startTime, endTime, duration: endTime - startTime };
+			})
+		)
+		.sort((left, right) => left.startTime - right.startTime)
+		.map((shot, index) => ({ ...shot, index }));
+
+	return {
+		version: 1,
+		source: {
+			filename,
+			duration: totalDuration,
+			resolution: first.source.resolution,
+			fps: first.source.fps,
+		},
+		style: {
+			genre: majorityValue(recipes.map((recipe) => recipe.style.genre)),
+			mood: majorityValue(recipes.map((recipe) => recipe.style.mood)),
+			colorPalette,
+			pacing: majorityValue(recipes.map((recipe) => recipe.style.pacing)),
+		},
+		audio: {
+			hasBGM: recipes.some((recipe) => recipe.audio.hasBGM),
+			bgmStyle: firstDefined(recipes.map((recipe) => recipe.audio.bgmStyle)),
+			hasVoiceover: recipes.some((recipe) => recipe.audio.hasVoiceover),
+			voiceoverLanguage: firstDefined(
+				recipes.map((recipe) => recipe.audio.voiceoverLanguage)
+			),
+			transcript: transcripts.length > 0 ? transcripts.join("\n") : undefined,
+		},
+		shots,
+	};
+}

--- a/qcut/electron/native-pipeline/video-review/review-split-runner.ts
+++ b/qcut/electron/native-pipeline/video-review/review-split-runner.ts
@@ -1,19 +1,21 @@
-import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { getFFmpegPath, getFFprobePath } from "../../ffmpeg/paths.js";
 import type { PipelineExecutor, PipelineStep } from "../execution/executor.js";
 import type { StepOutput } from "../execution/step-executors.js";
+import type { VideoSplitPart } from "../editorial/video-split.js";
+import {
+	partCountForPayload,
+	probeVideoDurationSeconds,
+	shouldSplitVideoInput,
+	splitVideoIntoParts,
+} from "../editorial/video-split.js";
 import type { ReviewArtifactResult } from "./review-artifacts.js";
 import { writeReviewArtifacts } from "./review-artifacts.js";
 import type { ReviewComment } from "./review-normalize.js";
 import { parseReviewModelResponse } from "./review-normalize.js";
 import type { ReviewPromptSet } from "./review-prompts.js";
 
-const execFileAsync = promisify(execFile);
 const DEFAULT_MAX_REVIEW_PAYLOAD_CHARS = 35 * 1024 * 1024;
-const DATA_URL_PREFIX_CHARS = "data:video/mp4;base64,".length;
 
 type ProgressFn = (progress: {
 	stage: string;
@@ -22,13 +24,7 @@ type ProgressFn = (progress: {
 	model?: string;
 }) => void;
 
-export interface ReviewSplitPart {
-	index: number;
-	startSeconds: number;
-	durationSeconds: number;
-	filePath: string;
-	outputDir: string;
-}
+export type ReviewSplitPart = VideoSplitPart;
 
 export interface ReviewSplitPartResult {
 	part: ReviewSplitPart;
@@ -72,26 +68,6 @@ interface RunSplitReviewIfNeededOptions {
 }
 
 /**
- * Determines whether a video input is a remote URL or an inline data URL.
- *
- * @param input - The video source string to inspect.
- * @returns `true` for `http(s)://` URLs or `data:` URLs, which cannot be split locally.
- */
-function isRemoteOrInlineVideo({ input }: { input: string }): boolean {
-	return /^https?:\/\//i.test(input) || input.startsWith("data:");
-}
-
-/**
- * Estimates the character length of a base64 data URL for a file of the given size.
- *
- * @param fileBytes - Size of the video file in bytes.
- * @returns Approximate character count once base64-encoded and prefixed as a data URL.
- */
-function estimatedBase64Chars({ fileBytes }: { fileBytes: number }): number {
-	return Math.ceil(fileBytes / 3) * 4 + DATA_URL_PREFIX_CHARS;
-}
-
-/**
  * Resolves the maximum allowed review payload size in characters.
  *
  * Precedence: explicit `value` → `QCUT_REVIEW_SPLIT_MAX_PAYLOAD_CHARS` env var → built-in default.
@@ -107,52 +83,6 @@ function resolveMaxPayloadChars({ value }: { value?: number }): number {
 	return Number.isFinite(parsed) && parsed > 0
 		? parsed
 		: DEFAULT_MAX_REVIEW_PAYLOAD_CHARS;
-}
-
-/**
- * Decides whether a local video must be split before review based on its estimated payload size.
- *
- * Remote/inline inputs and missing files are never split.
- *
- * @param input - The video source path.
- * @param maxPayloadChars - Maximum payload size that a single review request may carry.
- * @returns Whether to split, plus the estimated payload size and file size used to decide.
- */
-function shouldSplitReviewInput({
-	input,
-	maxPayloadChars,
-}: {
-	input: string;
-	maxPayloadChars: number;
-}): { shouldSplit: boolean; estimatedPayloadChars: number; fileBytes: number } {
-	if (isRemoteOrInlineVideo({ input }) || !existsSync(input)) {
-		return { shouldSplit: false, estimatedPayloadChars: 0, fileBytes: 0 };
-	}
-
-	const fileBytes = statSync(input).size;
-	const estimatedPayloadChars = estimatedBase64Chars({ fileBytes });
-	return {
-		shouldSplit: estimatedPayloadChars > maxPayloadChars,
-		estimatedPayloadChars,
-		fileBytes,
-	};
-}
-
-/**
- * Computes how many parts a video must be split into to fit within the payload limit.
- *
- * @param estimatedPayloadChars - Estimated payload size of the whole video.
- * @param maxPayloadChars - Maximum payload size per part.
- * @returns The number of parts (at least 2).
- */
-function partCountForPayload({
-	estimatedPayloadChars,
-	maxPayloadChars,
-}: {
-	estimatedPayloadChars: number;
-	maxPayloadChars: number;
-}): number {
-	return Math.max(2, Math.ceil(estimatedPayloadChars / maxPayloadChars));
 }
 
 /**
@@ -212,136 +142,14 @@ function shiftCommentTimestamp({
 	};
 }
 
-/**
- * Builds the output file path for a single split part.
- *
- * @param outputDir - Directory the part file is written to.
- * @param index - Zero-based part index (rendered one-based and zero-padded in the name).
- * @param startSeconds - Start offset of the part, encoded into the filename.
- * @returns The absolute path for the part's `.mp4` file.
- */
-function outputPartFilePath({
-	outputDir,
-	index,
-	startSeconds,
-}: {
-	outputDir: string;
-	index: number;
-	startSeconds: number;
-}): string {
-	const paddedIndex = String(index + 1).padStart(3, "0");
-	const paddedStart = String(Math.round(startSeconds)).padStart(4, "0");
-	return join(outputDir, `part-${paddedIndex}-${paddedStart}s.mp4`);
-}
-
-/**
- * Probes a video's duration in seconds via `ffprobe`.
- *
- * @param input - Path to the video file.
- * @returns The duration in seconds.
- * @throws If `ffprobe` cannot determine a valid positive duration.
- */
-async function probeDurationSeconds({
-	input,
-}: {
-	input: string;
-}): Promise<number> {
-	const ffprobePath = await getFFprobePath();
-	const { stdout } = await execFileAsync(ffprobePath, [
-		"-v",
-		"error",
-		"-show_entries",
-		"format=duration",
-		"-of",
-		"default=noprint_wrappers=1:nokey=1",
-		input,
-	]);
-	const duration = Number.parseFloat(stdout.trim());
-	if (!Number.isFinite(duration) || duration <= 0) {
-		throw new Error(`Unable to determine video duration for ${input}`);
-	}
-	return duration;
-}
-
-/**
- * Splits a video into evenly sized parts using `ffmpeg` stream copy.
- *
- * Parts are written under a `review-split-parts` subdirectory and run in parallel.
- *
- * @param input - Path to the source video.
- * @param outputDir - Base output directory; parts are written to a subfolder within it.
- * @param partCount - Number of parts to produce.
- * @param durationSeconds - Total duration of the source video.
- * @returns Metadata describing each produced part.
- */
-async function splitVideo({
-	input,
-	outputDir,
-	partCount,
-	durationSeconds,
-}: {
-	input: string;
-	outputDir: string;
-	partCount: number;
-	durationSeconds: number;
-}): Promise<ReviewSplitPart[]> {
-	const ffmpegPath = getFFmpegPath();
-	const splitDir = join(outputDir, "review-split-parts");
-	mkdirSync(splitDir, { recursive: true });
-	const partDuration = durationSeconds / partCount;
-	const parts = Array.from({ length: partCount }, (_, index) => {
-		const startSeconds = index * partDuration;
-		const isLastPart = index === partCount - 1;
-		return {
-			index,
-			startSeconds,
-			durationSeconds: isLastPart
-				? durationSeconds - startSeconds
-				: partDuration,
-			filePath: outputPartFilePath({
-				outputDir: splitDir,
-				index,
-				startSeconds,
-			}),
-			outputDir: join(
-				splitDir,
-				`part-${String(index + 1).padStart(3, "0")}-review`
-			),
-		};
-	});
-
-	await Promise.all(
-		parts.map((part) =>
-			execFileAsync(ffmpegPath, [
-				"-y",
-				"-hide_banner",
-				"-loglevel",
-				"error",
-				"-ss",
-				String(part.startSeconds),
-				"-i",
-				input,
-				"-t",
-				String(part.durationSeconds),
-				"-c",
-				"copy",
-				"-map",
-				"0:v:0",
-				"-map",
-				"0:a:0?",
-				"-movflags",
-				"+faststart",
-				part.filePath,
-			])
-		)
-	);
-
-	return parts;
-}
-
 const defaultSplitter: ReviewVideoSplitter = {
-	probeDurationSeconds,
-	splitVideo,
+	probeDurationSeconds: probeVideoDurationSeconds,
+	splitVideo: (args) =>
+		splitVideoIntoParts({
+			...args,
+			subdirName: "review-split-parts",
+			partDirSuffix: "review",
+		}),
 };
 
 /**
@@ -610,7 +418,7 @@ export async function runSplitReviewIfNeeded({
 	const resolvedMaxPayloadChars = resolveMaxPayloadChars({
 		value: maxPayloadChars,
 	});
-	const splitDecision = shouldSplitReviewInput({
+	const splitDecision = shouldSplitVideoInput({
 		input: videoInput,
 		maxPayloadChars: resolvedMaxPayloadChars,
 	});


### PR DESCRIPTION
## Summary
- Route audio media to an audio track in the Claude bridge (was stacking on the media track alongside video) and extract real audio duration on import (was falling back to a 10s default for mp3s)
- `editor:timeline:batch-update` now accepts the documented nested `{elementId, changes:{...}}` shape (was silently ignored); flat shape keeps working
- `replicate:analyze` / `analyze video` now split long local videos into payload- and duration-bounded parts (shared editorial/video-split utilities extracted from the review split runner), analyze per part, and merge shot timelines — avoids OpenRouter 502s on whole-video base64 payloads

## Testing
- 46 targeted tests green (new: audio routing, media-store audio duration, batch nested/flat shapes, replicate part-count + recipe merge; existing: review split, bridge, replicate suites)
- apps/web + electron tsc clean, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long videos can now be analyzed in smaller parts when needed, with results combined into one timeline.
  * Added progress updates during video analysis and splitting.
  * Audio media is now routed to dedicated audio tracks.
  * Audio durations are automatically detected when not already available.

* **Bug Fixes**
  * Batch timeline updates now support both current and legacy payload formats.
  * Video review splitting now uses consistent shared behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->