### PR TITLE
feat(skills): add qcut-cityfilm reference-driven city film workflow

### DIFF
--- a/qcut/.agents/skills/qcut-toolkit/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/SKILL.md
@@ -37,6 +37,20 @@ Handles:
 - Separate background and subtitle verification frames
 - Safe resume based on artifact dependency timestamps
 
+### 2b. qcut-cityfilm — Reference-Driven City / Promo Films
+**When:** Reproducing the structure and feel of a reference city, travel, or promo film with your own or licensed footage, including multi-language narration
+**Invoke:** `/qcut-cityfilm`
+**Skill path:** `.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md`
+
+Handles:
+- Reference breakdown: contact sheets, transcript, and scene-cut pacing profile
+- Shot-language inventory turned into licensed-footage search queries with attribution manifest
+- Segment picking against per-act target shot lengths
+- Per-act emotional narration through Seed Audio, one pass per language
+- QCut project assembly (import, timeline, subtitles, export) via the editor CLI
+- Final audio bed mixed outside the editor: ambience, segmented music, ducked narration
+- Level and frame verification of the exported file, not just the timeline
+
 ### 3. ffmpeg-skill — Media Processing
 **When:** Converting, compressing, trimming, resizing, extracting audio, adding subtitles, creating GIFs, applying effects
 **Invoke:** `/ffmpeg-skill`
@@ -128,6 +142,7 @@ When the user's request involves multiple sub-skills, chain them in this order:
 |-----------|----------|
 | "organize", "set up project", "clean up files" | native-cli |
 | "vlog", "talking head", "剪口播", "去口头词", "去停顿", "人像滤镜", "美颜", "口播字幕", "抠像换背景" | qcut-vlog |
+| "复刻宣传片", "城市宣传片", "参考片拆解", "city film", "travel promo", "reference-driven edit", "多语言配音成片" | qcut-cityfilm |
 | "convert", "compress", "trim", "resize", "extract audio", "gif", "subtitle" | ffmpeg-skill |
 | "generate image", "generate video", "avatar", "lipsync", "transcribe", "analyze video", "AI pipeline" | ai-content-pipeline |
 | "add to timeline", "update project settings", "list media", "export preset", "configure for TikTok" | native-cli |

--- a/qcut/.agents/skills/qcut-toolkit/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: [task description]
 
 # QCut Toolkit
 
-Unified entry point for QCut's eight sub-skills. Route tasks to the appropriate sub-skill based on what the user needs.
+Unified entry point for QCut's sub-skills. Route tasks to the appropriate sub-skill based on what the user needs.
 
 ## Sub-Skills
 
@@ -37,7 +37,7 @@ Handles:
 - Separate background and subtitle verification frames
 - Safe resume based on artifact dependency timestamps
 
-### 2b. qcut-cityfilm — Reference-Driven City / Promo Films
+### 3. qcut-cityfilm — Reference-Driven City / Promo Films
 **When:** Reproducing the structure and feel of a reference city, travel, or promo film with your own or licensed footage, including multi-language narration
 **Invoke:** `/qcut-cityfilm`
 **Skill path:** `.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md`
@@ -51,7 +51,7 @@ Handles:
 - Final audio bed mixed outside the editor: ambience, segmented music, ducked narration
 - Level and frame verification of the exported file, not just the timeline
 
-### 3. ffmpeg-skill — Media Processing
+### 4. ffmpeg-skill — Media Processing
 **When:** Converting, compressing, trimming, resizing, extracting audio, adding subtitles, creating GIFs, applying effects
 **Invoke:** `/ffmpeg-skill`
 **Skill path:** `.claude/skills/qcut-toolkit/ffmpeg-skill/SKILL.md`
@@ -63,7 +63,7 @@ Handles:
 - GIF creation, speed changes, merging/concatenation
 - Streaming (HLS, DASH, RTMP) and complex filtergraphs
 
-### 4. ai-content-pipeline — AI Content Generation & Analysis
+### 5. ai-content-pipeline — AI Content Generation & Analysis
 **When:** Generating images/videos/avatars, transcribing audio, analyzing video, running AI pipelines
 **Invoke:** `/ai-content-pipeline`
 **Skill path:** `.claude/skills/qcut-toolkit/ai-content-pipeline/SKILL.md`
@@ -77,7 +77,7 @@ Handles:
 - YAML pipeline orchestration with parallel execution
 - Motion transfer between images and videos
 
-### 5. seedance — Video Prompt Engineering
+### 6. seedance — Video Prompt Engineering
 **When:** Writing video prompts, Seedance/即梦 workflows, AI video prompt generation, video descriptions (Chinese or English)
 **Invoke:** `/seedance`
 **Skill path:** `.claude/skills/qcut-toolkit/seedance/SKILL.md`
@@ -88,7 +88,7 @@ Handles:
 - Short drama (短剧), advertising video, and cinematic prompt templates
 - Prompt engineering best practices for ByteDance video models
 
-### 6. qcut-mcp-preview-test — MCP Preview Testing
+### 7. qcut-mcp-preview-test — MCP Preview Testing
 **When:** Testing MCP app preview, toggling "MCP Media App" mode, debugging iframe rendering, troubleshooting `mcp:app-html` events or `/api/claude/mcp/app`
 **Invoke:** `/qcut-mcp-preview-test`
 **Skill path:** `.claude/skills/qcut-toolkit/qcut-mcp-preview-test/SKILL.md`
@@ -99,7 +99,7 @@ Handles:
 - Debugging IPC (`mcp:app-html`) and HTTP (`/api/claude/mcp/app`) delivery
 - Crafting prompts that modify MCP media app UI safely
 
-### 7. ipad-cli — Real iPad & Simulator Automation
+### 8. ipad-cli — Real iPad & Simulator Automation
 **When:** Installing on iPad, testing on iPad, taking iPad screenshots, running E2E device tests, sending CLI commands to the iPad app
 **Invoke:** `/ipad-cli`
 **Skill path:** `.claude/skills/qcut-toolkit/ipad-cli/SKILL.md`
@@ -111,7 +111,7 @@ Handles:
 - E2E testing: navigate to editor, trigger exports, check state, FPS benchmarks
 - Managing pymobiledevice3 tunnels for advanced device access
 
-### 8. pr-comments — PR Review Processing
+### 9. pr-comments — PR Review Processing
 **When:** Exporting PR comments, evaluating code reviews, fixing review feedback from CodeRabbit/Gemini bots
 **Invoke:** `/pr-comments`
 **Skill path:** `.claude/skills/pr-comments/SKILL.md`

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -40,7 +40,7 @@ bun "$CITYFILM_ROOT/scripts/main.ts" analyze /path/to/reference.mp4 \
 # Stage 6 — narrate a plan (one language at a time)
 bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan /path/to/work/plan-zh.json
 
-# Stage 8 — mix the exported picture with music and narration
+# Stage 7 — mix the exported picture with music and narration
 bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan /path/to/work/plan-zh.json \
   --video /path/to/work/export.mp4 \
   --output /path/to/work/final-zh.mp4

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -186,8 +186,38 @@ qcut gen tts -m seed_audio -o <dir> \
   not translations of the Chinese ones.
 - Check each cue's VO against its slot (`checkCueFit`) and shorten the line
   rather than speeding up the read.
-- Seed Audio also accepts reference audio for voice cloning and `speed`/`pitch`
-  when a specific voice is required.
+
+### Keeping one voice across the cut
+
+Seed Audio picks a **fresh speaker on every request** — a cut narrated cue by
+cue sounds like several different people. There is no seed parameter and no
+documented preset voice list, so the voice is pinned with a reference clip:
+
+1. Render one cue on its own; keep the hosted `audioUrl` it returns.
+2. Pass that URL as `audio_urls[0]` (`--audio-url`) for every other cue **and**
+   name it in the prompt as `@Audio1`. The reference is ignored unless the
+   prompt references it — this is the part that is easy to miss.
+
+`runVoBatch` does this automatically (`lockVoice`, on by default) and returns
+the anchor as `voiceAnchorUrl`; persist it into the plan so later re-renders
+and other languages reuse the same speaker.
+
+```bash
+qcut gen tts -m seed_audio --audio-url "<anchor-url>" -o <dir> \
+  -t "@Audio1 (用温柔怀旧的语气)有些街道,一别就是三年。"
+```
+
+Measured on three renders of one line (long-term average spectrum similarity,
+1.0 = identical timbre):
+
+| Method | Take-to-take similarity |
+|---|---|
+| Plain prompt | 0.84 |
+| `--audio-url` only, no tag | 0.91 |
+| `--audio-url` + `@Audio1` | **0.95** |
+
+Reference clips are capped at 30s / 10MB, and up to three can be supplied
+(`@Audio1`…`@Audio3`) when a film needs more than one narrator.
 
 ## Stage 7 — Mix The Audio Bed
 

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: qcut-cityfilm
+description: Reproduce the look and structure of a reference city/travel promo film with your own or licensed footage — analyze the reference, gather clips, pick segments, write per-act copy, narrate it with emotional TTS, assemble the timeline in QCut, and mix the final audio bed. Use for 复刻宣传片, 城市宣传片, 旅行 vlog 剪辑, city film, travel promo, reference-driven edit, 参考片拆解, 素材复刻, 多语言配音成片, or turning a reference video into a repeatable edit plan.
+---
+
+# QCut City Film
+
+Turn a reference film into a plan, then build your own cut from that plan. The
+workflow is reference → plan → assets → assembly → mix → proof. Every stage
+writes an artifact, so a later stage can be rerun without redoing the earlier
+ones.
+
+## Required Order
+
+```text
+reference film
+  -> contact sheets + transcript + scene-cut pacing   (understand it)
+  -> BREAKDOWN.md: acts, pacing, shot language, style  (write it down)
+  -> shot-type queries -> licensed footage + MANIFEST  (gather)
+  -> per-clip segment picks with in/out points         (choose)
+  -> SHOTPLAN.md: act timing, copy, music placement    (plan the cut)
+  -> emotional VO per cue, per language                (narrate)
+  -> QCut project: import, timeline, subtitles, export (assemble)
+  -> ffmpeg audio bed: ambience + music + VO + duck    (mix)
+  -> measured levels + extracted frames                (prove)
+```
+
+Never skip the proof stage. A timeline that looks correct in the editor can
+still export silent — see [Verification](#verification).
+
+## Run
+
+```bash
+export CITYFILM_ROOT=".agents/skills/qcut-toolkit/qcut-cityfilm"
+
+# Stage 1 — understand a reference film
+bun "$CITYFILM_ROOT/scripts/main.ts" analyze /path/to/reference.mp4 \
+  --output-dir /path/to/work/analysis
+
+# Stage 6 — narrate a plan (one language at a time)
+bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan /path/to/work/plan-zh.json
+
+# Stage 8 — mix the exported picture with music and narration
+bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan /path/to/work/plan-zh.json \
+  --video /path/to/work/export.mp4 \
+  --output /path/to/work/final-zh.mp4
+```
+
+Use `npx -y bun@1.3.10` when Bun is not installed globally. The runner resolves
+this repository's `bun run pipeline` first, then `qcut` from `PATH`, and
+prefers QCut's staged FFmpeg binaries.
+
+## Stage 1 — Understand The Reference
+
+Watch the whole film cheaply, then measure it.
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" analyze reference.mp4 -o analysis
+qcut analyze transcribe -i analysis/audio.mp3 -m scribe_v2 --srt -o analysis
+```
+
+`analyze` writes 5×5 contact sheets, `scene-cuts.txt`, `analysis.json`, and the
+extracted `audio.mp3`. **Read every sheet image** — that is how the structure is
+recovered. Tile `k` of sheet `n` maps to `((n-1)*25 + k) * duration/frames`
+seconds.
+
+Rules that matter here:
+
+- FAL's speech-to-text rejects video containers; always transcribe the
+  extracted MP3, never the source video.
+- QCut's staged FFmpeg has no `drawtext` filter — do not try to burn timestamps
+  into the sheets; compute them.
+- Scene detection at `gt(scene,0.30)` is a good default for cut-heavy promos.
+
+Write `BREAKDOWN.md` with: an act table (time range, content, purpose), the
+per-minute cut counts, the shot-language inventory (which *types* of shots the
+film uses — establishing aerials, walking POV, detail macros, portraits,
+transport, night neon…), the grade and subtitle style, and the copy's
+emotional arc. That inventory becomes the shopping list for stage 2.
+
+## Stage 2 — Gather Licensed Footage
+
+One search query per shot type from the inventory. On YouTube, append
+`&sp=EgIwAQ%253D%253D` to filter to Creative Commons, then **verify each
+candidate** — the filter is not trustworthy on its own:
+
+```bash
+yt-dlp "https://www.youtube.com/results?search_query=<q>&sp=EgIwAQ%253D%253D" \
+  --flat-playlist -I 1:6 --print "%(id)s | %(duration)s | %(title)s"
+
+yt-dlp --print "%(id)s | %(license)s | %(uploader)s" -- <video-id>
+```
+
+Keep only `Creative Commons Attribution license (reuse allowed)`. Download
+capped at 1080p, and take only the useful stretch of long walking tours:
+
+```bash
+yt-dlp -f "bv*[height<=1080]+ba/b[height<=1080]/b" -S "res:1080,vcodec:h264" \
+  --merge-output-format mp4 --download-sections "*00:00:00-00:03:00" \
+  -o "<dir>/%(id)s - %(title).50s.%(ext)s" -- <video-id>
+```
+
+Write `MANIFEST.md` with folder, id, **uploader, and URL** for every clip plus
+every music track. CC-BY requires attribution in the finished piece; the
+manifest is what you paste into the credits. Also record which shots the stock
+footage *cannot* cover (pieces to camera, product macros, candid portraits of
+identifiable people) so the gap is explicit.
+
+## Stage 3 — Pick Segments
+
+Build a contact sheet per clip and choose in/out points against the act's
+target shot length. Selection rules, learned from a real pass:
+
+- Never include channel intros, title cards, watermark-heavy moments, or a
+  presenter talking to camera.
+- Prefer steady motion, good light, clean composition.
+- Avoid close-ups of identifiable children.
+- Round to 0.5s; keep every pick inside the clip's real duration.
+
+Store picks as `SegmentPick[]` (see `scripts/types.ts`). With many categories,
+fan this out — one agent per category folder, each returning its picks as JSON.
+
+## Stage 4 — Plan The Cut
+
+`SHOTPLAN.md` plus a machine-readable `plan-<lang>.json` (`CityFilmPlan`).
+
+Pacing is the thing being copied. Derive it from the reference's per-minute cut
+counts, e.g. a montage act at 1.2–1.5s per shot, dialogue/observation acts at
+2–2.5s, the emotional act at 3–4s, and the closing card held long.
+
+Copy rules:
+
+- Write **original** lines. Copy the narrative arc (return → immersion →
+  fatigue → healing → resolve), never the reference's sentences.
+- One idea per cue; keep cues inside their act.
+- Give every act an `emotion` directive in the copy's own language — it is fed
+  verbatim to the TTS model.
+
+## Stage 5 — Assemble In QCut
+
+```bash
+qcut editor:project:create --new-name "<name>" --json
+qcut editor:project:update-settings --project-id <p> --data '{"fps":25,"width":1920,"height":1080}'
+qcut editor:media:batch-import --project-id <p> --items @imports.json --json
+qcut editor:timeline:import --project-id <p> --data @timeline.json --replace --json
+qcut editor:export:start --project-id <p> --data '{"width":1920,"height":1080,"fps":25,"format":"mp4"}' \
+  --output-dir <dir> --poll --timeout 900 --json
+```
+
+Build `timeline.json` from the plan: media elements laid end to end with
+`trimStart`/`trimEnd` derived from each pick, one text element per cue, and a
+black tail clip so the closing card has picture under it.
+
+Editor facts that cost time when unknown:
+
+| Fact | Consequence |
+|---|---|
+| Text `x`/`y` are canvas **pixels offset from center**, not fractions | `y: 0.87` puts the subtitle at the middle; use `y: 380` on a 1080p canvas |
+| CJK and Latin need different sizing | Latin copy wants ~0.8× the font size and ~0.4× the letter spacing of the CJK cut |
+| `timeline:import` drops `transitions` | Plan hard cuts; add fades as elements or in the mix |
+| Export ends at the last **picture** element | A text-only tail is truncated — hold a black clip under the closing card |
+| `batch-import` does not notify the renderer per item | Re-check the store before assuming media resolved; import stragglers individually |
+| Elements resolve by `sourceName` | Import first, then import the timeline, or elements land on the wrong track |
+
+Verify the timeline before exporting:
+
+```bash
+qcut editor:timeline:export --project-id <p> --json   # element count, track types
+qcut editor:state:snapshot --project-id <p> --json     # what the renderer actually holds
+```
+
+## Stage 6 — Narrate With Emotion
+
+ByteDance Seed Audio takes a parenthesised directive in front of the line. The
+difference between a flat read and a directed one is large — always direct it.
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan plan-zh.json
+# equivalent single call:
+qcut gen tts -m seed_audio -o <dir> \
+  -t "(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。"
+```
+
+- One directive per act, written in the copy's language.
+- Generate each language separately; English lines need their own directives,
+  not translations of the Chinese ones.
+- Check each cue's VO against its slot (`checkCueFit`) and shorten the line
+  rather than speeding up the read.
+- Seed Audio also accepts reference audio for voice cloning and `speed`/`pitch`
+  when a specific voice is required.
+
+## Stage 7 — Mix The Audio Bed
+
+QCut's export currently drops CLI-imported audio from its mix, so the exported
+picture supplies ambience only and the bed is assembled afterwards:
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan plan-zh.json \
+  --video export.mp4 --output final-zh.mp4
+```
+
+The graph: ambience held low, music segmented per act with fades, each VO cue
+delayed to its cue time, then the music+ambience bus ducked under a copy of the
+VO bus via `sidechaincompress`, limited, and muxed with `-c:v copy`.
+
+Two failure modes to respect: every declared filter label must be consumed or
+FFmpeg aborts, and music cues that do not cover the timeline shorten the bed
+unless the gaps are padded. `buildMixGraph` enforces both.
+
+## Verification
+
+Report a cut only after all four checks:
+
+1. `ffprobe` duration matches the plan within 0.25s.
+2. `volumedetect` over several windows — opening, a montage act, the emotional
+   act, and the closing card — all show speech/music level, not −91 dB.
+3. Extract frames at the title card, one mid-film subtitle, and the closing
+   card, and **look at them**: correct language, no clipping, readable size.
+4. The manifest's attribution list is present wherever the film will be
+   published.
+
+Check the exported file, never the timeline alone. A project whose timeline
+contains music can still export silence.
+
+## Output Contract
+
+```text
+<work-dir>/
+├── analysis/
+│   ├── sheet_01..NN.jpg
+│   ├── scene-cuts.txt
+│   ├── analysis.json
+│   ├── audio.mp3
+│   └── transcription.srt
+├── BREAKDOWN.md
+├── assets/
+│   ├── <shot-type folders>/*.mp4
+│   ├── music/*.mp3
+│   ├── vo/vo-<lang>-<cueId>.mp3
+│   └── MANIFEST.md
+├── SHOTPLAN.md
+├── plan-<lang>.json
+├── timeline-<lang>.json
+└── out/
+    ├── export-<lang>.mp4        # picture from QCut, ambience only
+    ├── final-<lang>.mp4         # after the mix — the deliverable
+    └── frames/*.jpg
+```
+
+## Notes
+
+- Keep the reference film out of the deliverable. This skill copies structure,
+  pacing, and treatment — not footage, not copy.
+- Attribution is not optional for CC-BY material.
+- When the same cut ships in several languages, share the picture export and
+  vary only subtitles and VO — but re-verify levels per language, since VO
+  lengths differ.

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	tileTimestamp,
+} from "./analyze-graph";
+
+describe("qcut-cityfilm contact sheets", () => {
+	test("samples the whole film into evenly tiled sheets", () => {
+		expect(
+			buildContactSheetArgs({
+				input: "/films/melbourne.mp4",
+				durationSeconds: 154.2,
+				frames: 40,
+				columns: 5,
+				rows: 4,
+				outputPattern: "/out/sheet_%02d.jpg",
+			})
+		).toEqual([
+			"-y",
+			"-i",
+			"/films/melbourne.mp4",
+			"-vf",
+			"fps=40/154.2,scale=384:-2,tile=5x4",
+			"-q:v",
+			"2",
+			"/out/sheet_%02d.jpg",
+		]);
+	});
+
+	test("never burns in timestamps, because the staged build lacks drawtext", () => {
+		const args = buildContactSheetArgs({
+			input: "in.mp4",
+			durationSeconds: 60,
+			frames: 4,
+			columns: 2,
+			rows: 2,
+			outputPattern: "sheet_%02d.jpg",
+		});
+		expect(args.join(" ")).not.toContain("drawtext");
+	});
+
+	test("rejects layouts that would pad the trailing sheet", () => {
+		expect(() =>
+			buildContactSheetArgs({
+				input: "in.mp4",
+				durationSeconds: 60,
+				frames: 30,
+				columns: 5,
+				rows: 4,
+				outputPattern: "sheet_%02d.jpg",
+			})
+		).toThrow("must be a multiple of columns x rows");
+		expect(() =>
+			buildContactSheetArgs({
+				input: "in.mp4",
+				durationSeconds: 0,
+				frames: 4,
+				columns: 2,
+				rows: 2,
+				outputPattern: "sheet_%02d.jpg",
+			})
+		).toThrow("durationSeconds must be a positive number");
+	});
+});
+
+describe("qcut-cityfilm tile timestamps", () => {
+	test("maps tile index onto the fps sampling grid", () => {
+		expect(tileTimestamp({ index: 0, frames: 40, durationSeconds: 200 })).toBe(
+			0
+		);
+		expect(tileTimestamp({ index: 1, frames: 40, durationSeconds: 200 })).toBe(
+			5
+		);
+		expect(tileTimestamp({ index: 39, frames: 40, durationSeconds: 200 })).toBe(
+			195
+		);
+	});
+
+	test("lists every tile in reading order", () => {
+		expect(buildTileTimestamps({ frames: 4, durationSeconds: 120 })).toEqual([
+			0, 30, 60, 90,
+		]);
+	});
+
+	test("rejects indexes outside the sheet", () => {
+		expect(() =>
+			tileTimestamp({ index: -1, frames: 4, durationSeconds: 120 })
+		).toThrow("non-negative integer");
+		expect(() =>
+			tileTimestamp({ index: 4, frames: 4, durationSeconds: 120 })
+		).toThrow("must be below frames");
+	});
+});
+
+describe("qcut-cityfilm scene detection", () => {
+	test("quotes the select expression and the metadata path", () => {
+		expect(
+			buildSceneDetectArgs({
+				input: "/films/melbourne.mp4",
+				threshold: 0.4,
+				metadataFile: "/out/scenes.txt",
+			})
+		).toEqual([
+			"-i",
+			"/films/melbourne.mp4",
+			"-vf",
+			"scale=480:-2,select='gt(scene,0.4)',metadata=print:file='/out/scenes.txt'",
+			"-an",
+			"-f",
+			"null",
+			"-",
+		]);
+	});
+
+	test("escapes drive letters and backslashes in the metadata path", () => {
+		const args = buildSceneDetectArgs({
+			input: "in.mp4",
+			threshold: 0.3,
+			metadataFile: "C:\\out\\scenes.txt",
+		});
+		expect(args[3]).toContain("file='C:\\\\out\\\\scenes.txt'");
+	});
+
+	test("rejects thresholds outside the scene-score range", () => {
+		expect(() =>
+			buildSceneDetectArgs({
+				input: "in.mp4",
+				threshold: 0,
+				metadataFile: "scenes.txt",
+			})
+		).toThrow("threshold must be between 0 and 1");
+		expect(() =>
+			buildSceneDetectArgs({
+				input: "in.mp4",
+				threshold: 1,
+				metadataFile: "scenes.txt",
+			})
+		).toThrow("threshold must be between 0 and 1");
+	});
+});
+
+describe("qcut-cityfilm pacing", () => {
+	const metadataText = [
+		"frame:0    pts:0       pts_time:5",
+		"lavfi.scene_score=0.512000",
+		"frame:1    pts:720000  pts_time:30.5",
+		"lavfi.scene_score=0.641000",
+		"frame:2    pts:1560000 pts_time:65.25",
+		"lavfi.scene_score=0.470100",
+		"frame:3    pts:3000000 pts_time:125",
+		"lavfi.scene_score=0.882000",
+	].join("\n");
+
+	test("buckets cuts per minute and averages shot length", () => {
+		expect(parsePacing({ metadataText, durationSeconds: 130 })).toEqual({
+			durationSeconds: 130,
+			cutCount: 4,
+			cutsPerMinute: [2, 1, 1],
+			averageShotSeconds: 32.5,
+		});
+	});
+
+	test("treats an empty or garbage metadata file as zero cuts", () => {
+		expect(parsePacing({ metadataText: "", durationSeconds: 90 })).toEqual({
+			durationSeconds: 90,
+			cutCount: 0,
+			cutsPerMinute: [0, 0],
+			averageShotSeconds: 90,
+		});
+		expect(
+			parsePacing({
+				metadataText: "\u0000\u0001 not metadata\nlavfi.scene_score=0.9\n",
+				durationSeconds: 45,
+			})
+		).toEqual({
+			durationSeconds: 45,
+			cutCount: 0,
+			cutsPerMinute: [0],
+			averageShotSeconds: 45,
+		});
+	});
+
+	test("widens the histogram when cuts land past the reported duration", () => {
+		const profile = parsePacing({
+			metadataText: "pts_time:130.5",
+			durationSeconds: 60,
+		});
+		expect(profile.cutsPerMinute).toEqual([0, 0, 1]);
+		expect(profile.cutCount).toBe(1);
+	});
+});
+
+describe("qcut-cityfilm audio extraction", () => {
+	test("strips video because speech-to-text rejects video containers", () => {
+		expect(
+			extractAudioArgs({
+				input: "/films/melbourne.mp4",
+				output: "/out/melbourne-audio.mp3",
+			})
+		).toEqual([
+			"-y",
+			"-i",
+			"/films/melbourne.mp4",
+			"-vn",
+			"-acodec",
+			"libmp3lame",
+			"-q:a",
+			"4",
+			"/out/melbourne-audio.mp3",
+		]);
+	});
+});
+
+describe("qcut-cityfilm probe arguments", () => {
+	test("asks ffprobe only for the fields the profile needs", () => {
+		expect(buildProbeArgs({ input: "/films/melbourne.mp4" })).toEqual([
+			"-v",
+			"error",
+			"-of",
+			"json",
+			"-show_entries",
+			"format=duration:stream=codec_type,width,height,avg_frame_rate,r_frame_rate",
+			"/films/melbourne.mp4",
+		]);
+	});
+});
+
+describe("qcut-cityfilm probe parsing", () => {
+	test("reads shape, rate and audio presence from ffprobe JSON", () => {
+		const stdout = JSON.stringify({
+			streams: [
+				{
+					codec_type: "video",
+					width: 3840,
+					height: 2160,
+					avg_frame_rate: "30000/1001",
+					r_frame_rate: "30000/1001",
+				},
+				{ codec_type: "audio" },
+			],
+			format: { duration: "154.234000" },
+		});
+		const probe = parseProbeJson({ stdout });
+		expect(probe.width).toBe(3840);
+		expect(probe.height).toBe(2160);
+		expect(probe.hasAudio).toBe(true);
+		expect(probe.durationSeconds).toBeCloseTo(154.234, 3);
+		expect(probe.fps).toBeCloseTo(29.97, 2);
+	});
+
+	test("falls back to r_frame_rate and reports silent sources", () => {
+		const probe = parseProbeJson({
+			stdout: JSON.stringify({
+				streams: [
+					{
+						codec_type: "video",
+						width: 1920,
+						height: 1080,
+						avg_frame_rate: "0/0",
+						r_frame_rate: "25/1",
+					},
+				],
+				format: { duration: "10" },
+			}),
+		});
+		expect(probe.fps).toBe(25);
+		expect(probe.hasAudio).toBe(false);
+	});
+
+	test("fails loudly on unusable ffprobe output", () => {
+		expect(() => parseProbeJson({ stdout: "not json" })).toThrow(
+			"did not return JSON"
+		);
+		expect(() =>
+			parseProbeJson({ stdout: JSON.stringify({ streams: [] }) })
+		).toThrow("No video stream found");
+		expect(() =>
+			parseProbeJson({
+				stdout: JSON.stringify({
+					streams: [{ codec_type: "video" }],
+					format: { duration: "N/A" },
+				}),
+			})
+		).toThrow("Could not determine duration");
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.ts
@@ -1,0 +1,311 @@
+/**
+ * Pure FFmpeg/FFprobe argument builders and output parsers for reference-film
+ * analysis. Nothing here touches the filesystem or spawns a process, so the
+ * graphs can be asserted in unit tests; `analyze.ts` owns the execution.
+ */
+
+import type { PacingProfile } from "./types";
+
+/** Shape of the reference film, as reported by ffprobe. */
+export interface VideoProbe {
+	durationSeconds: number;
+	width: number;
+	height: number;
+	fps: number;
+	hasAudio: boolean;
+}
+
+function requirePositive({
+	value,
+	name,
+}: {
+	value: number;
+	name: string;
+}): number {
+	if (!Number.isFinite(value) || value <= 0) {
+		throw new Error(`${name} must be a positive number`);
+	}
+	return value;
+}
+
+function requirePositiveInteger({
+	value,
+	name,
+}: {
+	value: number;
+	name: string;
+}): number {
+	requirePositive({ value, name });
+	if (!Number.isInteger(value)) {
+		throw new Error(`${name} must be an integer`);
+	}
+	return value;
+}
+
+/** Render a number for a filter string without exponent notation. */
+function formatNumber({ value }: { value: number }): string {
+	return String(Number(value.toFixed(6)));
+}
+
+/**
+ * Quote a value for an FFmpeg filter option so `:` and `,` inside paths are
+ * not read as option or filter separators.
+ */
+function quoteFilterValue({ value }: { value: string }): string {
+	return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Build the contact-sheet command.
+ *
+ * `fps=<frames>/<duration>` samples exactly `frames` stills across the film and
+ * `tile` packs them `columns x rows` per sheet, so `frames` must divide evenly
+ * into a whole number of sheets — otherwise the trailing sheet is padded and
+ * tile indexes stop lining up with {@link tileTimestamp}.
+ *
+ * Timestamps are deliberately NOT burned in: the staged FFmpeg build in this
+ * repo ships without the `drawtext` filter. Use {@link buildTileTimestamps} to
+ * label the tiles instead.
+ */
+export function buildContactSheetArgs({
+	input,
+	durationSeconds,
+	frames,
+	columns,
+	rows,
+	outputPattern,
+}: {
+	input: string;
+	durationSeconds: number;
+	frames: number;
+	columns: number;
+	rows: number;
+	outputPattern: string;
+}): string[] {
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	requirePositiveInteger({ value: frames, name: "frames" });
+	requirePositiveInteger({ value: columns, name: "columns" });
+	requirePositiveInteger({ value: rows, name: "rows" });
+	const perSheet = columns * rows;
+	if (frames % perSheet !== 0) {
+		throw new Error(
+			`frames (${frames}) must be a multiple of columns x rows (${perSheet})`
+		);
+	}
+	const rate = `${frames}/${formatNumber({ value: durationSeconds })}`;
+	return [
+		"-y",
+		"-i",
+		input,
+		"-vf",
+		`fps=${rate},scale=384:-2,tile=${columns}x${rows}`,
+		"-q:v",
+		"2",
+		outputPattern,
+	];
+}
+
+/**
+ * Timestamp of one contact-sheet tile, in seconds.
+ *
+ * `fps=frames/duration` emits its Nth frame at `N / rate`, so tile `index`
+ * (0-based, counted across every sheet in reading order) shows the film at
+ * `index * durationSeconds / frames`. Tile 0 is the opening frame; the last
+ * tile sits one sampling interval short of the end.
+ *
+ * For a tile inside sheet `s` (1-based) at slot `k` (0-based):
+ * `index = (s - 1) * columns * rows + k`.
+ */
+export function tileTimestamp({
+	index,
+	frames,
+	durationSeconds,
+}: {
+	index: number;
+	frames: number;
+	durationSeconds: number;
+}): number {
+	requirePositiveInteger({ value: frames, name: "frames" });
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	if (!Number.isInteger(index) || index < 0) {
+		throw new Error("index must be a non-negative integer");
+	}
+	if (index >= frames) {
+		throw new Error(`index must be below frames (${frames})`);
+	}
+	return (index * durationSeconds) / frames;
+}
+
+/** Every tile timestamp in reading order. */
+export function buildTileTimestamps({
+	frames,
+	durationSeconds,
+}: {
+	frames: number;
+	durationSeconds: number;
+}): number[] {
+	requirePositiveInteger({ value: frames, name: "frames" });
+	const timestamps: number[] = [];
+	for (let index = 0; index < frames; index += 1) {
+		timestamps.push(tileTimestamp({ index, frames, durationSeconds }));
+	}
+	return timestamps;
+}
+
+/**
+ * Build the scene-detection command.
+ *
+ * The graph downscales first (scene scoring is unchanged at 480px and far
+ * cheaper), keeps frames whose scene score exceeds `threshold`, and dumps one
+ * metadata block per kept frame to `metadataFile`. The single quotes around
+ * `gt(scene,N)` are part of the filter string, not shell quoting: without them
+ * FFmpeg reads the comma as a filter separator.
+ */
+export function buildSceneDetectArgs({
+	input,
+	threshold,
+	metadataFile,
+}: {
+	input: string;
+	threshold: number;
+	metadataFile: string;
+}): string[] {
+	if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
+		throw new Error("threshold must be between 0 and 1");
+	}
+	const scene = formatNumber({ value: threshold });
+	const target = quoteFilterValue({ value: metadataFile });
+	return [
+		"-i",
+		input,
+		"-vf",
+		`scale=480:-2,select='gt(scene,${scene})',metadata=print:file=${target}`,
+		"-an",
+		"-f",
+		"null",
+		"-",
+	];
+}
+
+/**
+ * Extract narration audio as MP3.
+ *
+ * FAL's speech-to-text endpoint rejects video containers, so the audio has to
+ * be pulled out before transcription rather than uploading the film itself.
+ */
+export function extractAudioArgs({
+	input,
+	output,
+}: {
+	input: string;
+	output: string;
+}): string[] {
+	return [
+		"-y",
+		"-i",
+		input,
+		"-vn",
+		"-acodec",
+		"libmp3lame",
+		"-q:a",
+		"4",
+		output,
+	];
+}
+
+/**
+ * Turn `metadata=print` output into a pacing profile.
+ *
+ * Each detected cut prints a `pts_time:<seconds>` line; anything else in the
+ * file is ignored, so an empty or truncated log yields a zero-cut profile
+ * instead of throwing.
+ */
+export function parsePacing({
+	metadataText,
+	durationSeconds,
+}: {
+	metadataText: string;
+	durationSeconds: number;
+}): PacingProfile {
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	const times: number[] = [];
+	for (const match of metadataText.matchAll(/pts_time:\s*(\d+(?:\.\d+)?)/g)) {
+		const seconds = Number(match[1]);
+		if (Number.isFinite(seconds)) times.push(seconds);
+	}
+
+	let minutes = Math.max(1, Math.ceil(durationSeconds / 60));
+	for (const seconds of times) {
+		minutes = Math.max(minutes, Math.floor(seconds / 60) + 1);
+	}
+	const cutsPerMinute = new Array<number>(minutes).fill(0);
+	for (const seconds of times) {
+		cutsPerMinute[Math.floor(seconds / 60)] += 1;
+	}
+
+	return {
+		durationSeconds,
+		cutCount: times.length,
+		cutsPerMinute,
+		averageShotSeconds: durationSeconds / Math.max(1, times.length),
+	};
+}
+
+function parseFrameRate({ value }: { value?: string }): number {
+	if (!value) return 0;
+	const [numerator, denominator] = value.split("/");
+	const top = Number(numerator);
+	const bottom = denominator === undefined ? 1 : Number(denominator);
+	if (!Number.isFinite(top) || !Number.isFinite(bottom) || bottom === 0) {
+		return 0;
+	}
+	const fps = top / bottom;
+	return Number.isFinite(fps) && fps > 0 ? fps : 0;
+}
+
+interface ProbeStream {
+	codec_type?: string;
+	width?: number;
+	height?: number;
+	avg_frame_rate?: string;
+	r_frame_rate?: string;
+}
+
+/** Pure half of `probeVideo`: read ffprobe's JSON into a {@link VideoProbe}. */
+export function parseProbeJson({ stdout }: { stdout: string }): VideoProbe {
+	let parsed: { streams?: ProbeStream[]; format?: { duration?: string } };
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		throw new Error("ffprobe did not return JSON");
+	}
+	const streams = parsed.streams ?? [];
+	const video = streams.find((stream) => stream.codec_type === "video");
+	if (!video) throw new Error("No video stream found");
+	const durationSeconds = Number(parsed.format?.duration);
+	if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+		throw new Error("Could not determine duration");
+	}
+	return {
+		durationSeconds,
+		width: Number(video.width ?? 0),
+		height: Number(video.height ?? 0),
+		fps:
+			parseFrameRate({ value: video.avg_frame_rate }) ||
+			parseFrameRate({ value: video.r_frame_rate }),
+		hasAudio: streams.some((stream) => stream.codec_type === "audio"),
+	};
+}
+
+/** FFprobe argv for {@link parseProbeJson}. */
+export function buildProbeArgs({ input }: { input: string }): string[] {
+	return [
+		"-v",
+		"error",
+		"-of",
+		"json",
+		"-show_entries",
+		"format=duration:stream=codec_type,width,height,avg_frame_rate,r_frame_rate",
+		input,
+	];
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
@@ -1,7 +1,14 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import * as analyze from "./analyze";
 import * as graph from "./analyze-graph";
 import { type CommandRunner, runAnalyze } from "./analyze";
@@ -147,5 +154,54 @@ describe("qcut-cityfilm analyze run", () => {
 				runner: failing,
 			})
 		).rejects.toThrow("Invalid data found");
+	});
+});
+
+describe("stale artifact handling", () => {
+	it("removes sheets and scene metadata from a previous run", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cityfilm-stale-"));
+		const input = join(dir, "ref.mp4");
+		writeFileSync(input, "");
+		const outputDir = join(dir, "analysis");
+		mkdirSync(outputDir, { recursive: true });
+		// Leftovers from a longer previous pass.
+		writeFileSync(join(outputDir, "sheet_01.jpg"), "old");
+		writeFileSync(join(outputDir, "sheet_09.jpg"), "old");
+		writeFileSync(join(outputDir, "scenes.txt"), "pts_time:1.0\n");
+
+		const runner = async ({ args }: { executable: string; args: string[] }) => {
+			if (args.some((arg) => arg.startsWith("format=duration:stream="))) {
+				return {
+					exitCode: 0,
+					stdout: JSON.stringify({
+						format: { duration: "20" },
+						streams: [
+							{
+								codec_type: "video",
+								width: 1920,
+								height: 1080,
+								avg_frame_rate: "25/1",
+							},
+						],
+					}),
+					stderr: "",
+				};
+			}
+			// This pass finds no cuts, so ffmpeg never writes scenes.txt.
+			return { exitCode: 0, stdout: "", stderr: "" };
+		};
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			frames: 20,
+			columns: 5,
+			rows: 4,
+			runner,
+		});
+
+		expect(existsSync(join(outputDir, "sheet_09.jpg"))).toBe(false);
+		expect(result.pacing.cutCount).toBe(0);
+		rmSync(dir, { recursive: true, force: true });
 	});
 });

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import * as analyze from "./analyze";
+import * as graph from "./analyze-graph";
+import { type CommandRunner, runAnalyze } from "./analyze";
+
+describe("qcut-cityfilm analyze surface", () => {
+	test("re-exports every pure helper so callers need one import", () => {
+		for (const name of [
+			"buildContactSheetArgs",
+			"buildProbeArgs",
+			"buildSceneDetectArgs",
+			"buildTileTimestamps",
+			"extractAudioArgs",
+			"parsePacing",
+			"parseProbeJson",
+			"tileTimestamp",
+		] as const) {
+			expect(analyze[name]).toBe(graph[name]);
+		}
+	});
+});
+
+function createFakeRunner({
+	outputDir,
+	hasAudio,
+}: {
+	outputDir: string;
+	hasAudio: boolean;
+}): { calls: string[][]; runner: CommandRunner } {
+	const calls: string[][] = [];
+	const runner: CommandRunner = ({ executable, args }) => {
+		calls.push([executable, ...args]);
+		if (executable.includes("ffprobe")) {
+			return Promise.resolve({
+				exitCode: 0,
+				stderr: "",
+				stdout: JSON.stringify({
+					streams: hasAudio
+						? [
+								{ codec_type: "video", width: 1920, height: 1080 },
+								{ codec_type: "audio" },
+							]
+						: [{ codec_type: "video", width: 1920, height: 1080 }],
+					format: { duration: "120" },
+				}),
+			});
+		}
+		const graph = args[args.indexOf("-vf") + 1] ?? "";
+		if (graph.includes("tile=")) {
+			writeFileSync(join(outputDir, "sheet_01.jpg"), "first");
+			writeFileSync(join(outputDir, "sheet_02.jpg"), "second");
+		} else if (graph.includes("select=")) {
+			writeFileSync(
+				join(outputDir, "scenes.txt"),
+				"pts_time:3.5\nlavfi.scene_score=0.9\npts_time:70\n"
+			);
+		} else {
+			writeFileSync(args[args.length - 1], "audio");
+		}
+		return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+	};
+	return { calls, runner };
+}
+
+describe("qcut-cityfilm analyze run", () => {
+	test("probes, sheets, detects, then extracts audio", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-analyze-"));
+		const input = join(directory, "melbourne.mp4");
+		const outputDir = join(directory, "analysis");
+		writeFileSync(input, "film");
+		const { calls, runner } = createFakeRunner({ outputDir, hasAudio: true });
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			ffmpegPath: "/bin/fake-ffmpeg",
+			ffprobePath: "/bin/fake-ffprobe",
+			runner,
+		});
+
+		expect(calls).toHaveLength(4);
+		expect(calls[0][0]).toBe("/bin/fake-ffprobe");
+		expect(calls.slice(1).every((call) => call[0] === "/bin/fake-ffmpeg")).toBe(
+			true
+		);
+		expect(result.probe.durationSeconds).toBe(120);
+		expect(result.pacing).toEqual({
+			durationSeconds: 120,
+			cutCount: 2,
+			cutsPerMinute: [1, 1],
+			averageShotSeconds: 60,
+		});
+		expect(result.contactSheet.sheets).toEqual([
+			join(outputDir, "sheet_01.jpg"),
+			join(outputDir, "sheet_02.jpg"),
+		]);
+		expect(result.contactSheet.tileTimestamps).toHaveLength(40);
+		expect(result.contactSheet.tileTimestamps[1]).toBe(3);
+		expect(result.audioPath).toBe(join(outputDir, "melbourne-audio.mp3"));
+
+		const written = JSON.parse(readFileSync(result.analysisPath, "utf8"));
+		expect(written.pacing.cutCount).toBe(2);
+		expect(written.audioPath).toBe(result.audioPath);
+		expect(typeof written.generatedAt).toBe("string");
+	});
+
+	test("skips audio extraction for silent sources", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-silent-"));
+		const input = join(directory, "silent.mov");
+		const outputDir = join(directory, "analysis");
+		writeFileSync(input, "film");
+		const { calls, runner } = createFakeRunner({ outputDir, hasAudio: false });
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			frames: 8,
+			columns: 4,
+			rows: 2,
+			ffmpegPath: "/bin/fake-ffmpeg",
+			ffprobePath: "/bin/fake-ffprobe",
+			runner,
+		});
+
+		expect(calls).toHaveLength(3);
+		expect(result.audioPath).toBeUndefined();
+		expect(result.contactSheet.frames).toBe(8);
+	});
+
+	test("surfaces the tail of stderr when a tool fails", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-fail-"));
+		const failing: CommandRunner = () =>
+			Promise.resolve({
+				exitCode: 1,
+				stdout: "",
+				stderr: "line one\nInvalid data found when processing input\n",
+			});
+
+		await expect(
+			runAnalyze({
+				input: join(directory, "broken.mp4"),
+				outputDir: join(directory, "analysis"),
+				ffprobePath: "/bin/fake-ffprobe",
+				runner: failing,
+			})
+		).rejects.toThrow("Invalid data found");
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
@@ -9,7 +9,13 @@
  * re-exported here; this file only orchestrates the child processes.
  */
 
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import {
 	buildContactSheetArgs,
@@ -151,10 +157,30 @@ function listSheets({ outputDir }: { outputDir: string }): string[] {
 function readSceneMetadata({ filePath }: { filePath: string }): string {
 	try {
 		return readFileSync(filePath, "utf8");
-	} catch {
-		// No cut crossed the threshold, so FFmpeg never created the file.
-		return "";
+	} catch (error) {
+		// A missing file means no cut crossed the threshold — FFmpeg only
+		// creates it on a match. Anything else (permissions, I/O) is a real
+		// failure and must not masquerade as "this film has no cuts".
+		if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "";
+		throw error;
 	}
+}
+
+/**
+ * Drop artifacts a previous run left behind so they cannot leak into this
+ * one's results.
+ */
+function clearStaleArtifacts({
+	outputDir,
+	sceneMetadataPath,
+}: {
+	outputDir: string;
+	sceneMetadataPath: string;
+}): void {
+	for (const sheet of listSheets({ outputDir })) {
+		rmSync(sheet, { force: true });
+	}
+	rmSync(sceneMetadataPath, { force: true });
 }
 
 /**
@@ -185,6 +211,13 @@ export async function runAnalyze(
 	const sceneMetadataPath = join(outputDir, "scenes.txt");
 	const analysisPath = join(outputDir, "analysis.json");
 	const audioPath = join(outputDir, `${stem}-audio.mp3`);
+
+	// Re-analysing the same film with different frames/threshold is the normal
+	// tuning loop, and both artifacts survive a rerun that should have replaced
+	// them: extra sheet_NN.jpg from a longer previous pass stay on disk, and a
+	// pass that finds no cuts never rewrites scenes.txt (metadata=print only
+	// fires on a match). Clearing them keeps analysis.json describing this run.
+	clearStaleArtifacts({ outputDir, sceneMetadataPath });
 
 	const probe = await probeVideo({
 		input,

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
@@ -1,0 +1,256 @@
+/**
+ * Reference-film analysis for the qcut-cityfilm skill.
+ *
+ * Before copying a film's structure you need three things from it: how long it
+ * is and at what shape, what its shots actually look like, and how fast it
+ * cuts. This module produces all three plus a narration-ready audio file.
+ *
+ * Argument building and output parsing live in `analyze-graph.ts` and are
+ * re-exported here; this file only orchestrates the child processes.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	type VideoProbe,
+} from "./analyze-graph";
+import type { PacingProfile } from "./types";
+
+export {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	tileTimestamp,
+} from "./analyze-graph";
+export type { VideoProbe } from "./analyze-graph";
+
+/** Frames sampled across the whole film, spread evenly. */
+const DEFAULT_FRAMES = 40;
+const DEFAULT_COLUMNS = 5;
+const DEFAULT_ROWS = 4;
+/** `select='gt(scene,N)'` threshold that matched hand-counted cuts. */
+const DEFAULT_SCENE_THRESHOLD = 0.4;
+
+export interface CommandOutcome {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Injectable process runner; the default shells out through `Bun.spawn`. */
+export type CommandRunner = (input: {
+	executable: string;
+	args: string[];
+}) => Promise<CommandOutcome>;
+
+export interface AnalyzeOptions {
+	/** Reference film to study. */
+	input: string;
+	/** Where sheets, scene metadata, audio and analysis.json land. */
+	outputDir?: string;
+	frames?: number;
+	columns?: number;
+	rows?: number;
+	sceneThreshold?: number;
+	ffmpegPath?: string;
+	ffprobePath?: string;
+	runner?: CommandRunner;
+}
+
+export interface ContactSheetSummary {
+	frames: number;
+	columns: number;
+	rows: number;
+	/** The `%02d` pattern handed to FFmpeg. */
+	pattern: string;
+	/** Sheets that actually got written, in order. */
+	sheets: string[];
+	/** Timestamp of every tile, left-to-right then sheet-by-sheet. */
+	tileTimestamps: number[];
+}
+
+export interface AnalyzeResult {
+	input: string;
+	outputDir: string;
+	probe: VideoProbe;
+	pacing: PacingProfile;
+	contactSheet: ContactSheetSummary;
+	sceneMetadataPath: string;
+	analysisPath: string;
+	/** Extracted narration audio; absent when the source has no audio stream. */
+	audioPath?: string;
+}
+
+const spawnCapture: CommandRunner = async ({ executable, args }) => {
+	const child = Bun.spawn([executable, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { exitCode: await child.exited, stdout, stderr };
+};
+
+async function runTool({
+	executable,
+	args,
+	runner,
+}: {
+	executable: string;
+	args: string[];
+	runner: CommandRunner;
+}): Promise<CommandOutcome> {
+	const outcome = await runner({ executable, args });
+	if (outcome.exitCode !== 0) {
+		const detail = outcome.stderr.trim().split("\n").slice(-3).join(" | ");
+		throw new Error(
+			`${executable} failed (${outcome.exitCode})${detail ? `: ${detail}` : ""}`
+		);
+	}
+	return outcome;
+}
+
+/** Read the reference film's duration, frame size, rate and audio presence. */
+export async function probeVideo({
+	input,
+	ffprobePath = "ffprobe",
+	runner = spawnCapture,
+}: {
+	input: string;
+	ffprobePath?: string;
+	runner?: CommandRunner;
+}): Promise<VideoProbe> {
+	const outcome = await runTool({
+		executable: ffprobePath,
+		args: buildProbeArgs({ input }),
+		runner,
+	});
+	return parseProbeJson({ stdout: outcome.stdout });
+}
+
+function listSheets({ outputDir }: { outputDir: string }): string[] {
+	return readdirSync(outputDir)
+		.filter((name) => /^sheet_\d+\.jpg$/.test(name))
+		.sort()
+		.map((name) => join(outputDir, name));
+}
+
+function readSceneMetadata({ filePath }: { filePath: string }): string {
+	try {
+		return readFileSync(filePath, "utf8");
+	} catch {
+		// No cut crossed the threshold, so FFmpeg never created the file.
+		return "";
+	}
+}
+
+/**
+ * Probe, sheet, scene-detect, measure pacing and extract audio in one pass,
+ * then write `analysis.json` beside the sheets.
+ *
+ * Transcription is deliberately out of scope: run the CLI the SKILL.md
+ * documents (`qcut analyze transcribe -m scribe_v2 --srt`) against the returned
+ * `audioPath`.
+ */
+export async function runAnalyze(
+	options: AnalyzeOptions
+): Promise<AnalyzeResult> {
+	const input = resolve(options.input);
+	const stem = basename(input, extname(input));
+	const outputDir = options.outputDir
+		? resolve(options.outputDir)
+		: join(dirname(input), `${stem}-analysis`);
+	const frames = options.frames ?? DEFAULT_FRAMES;
+	const columns = options.columns ?? DEFAULT_COLUMNS;
+	const rows = options.rows ?? DEFAULT_ROWS;
+	const threshold = options.sceneThreshold ?? DEFAULT_SCENE_THRESHOLD;
+	const ffmpegPath = options.ffmpegPath ?? "ffmpeg";
+	const runner = options.runner ?? spawnCapture;
+
+	mkdirSync(outputDir, { recursive: true });
+	const pattern = join(outputDir, "sheet_%02d.jpg");
+	const sceneMetadataPath = join(outputDir, "scenes.txt");
+	const analysisPath = join(outputDir, "analysis.json");
+	const audioPath = join(outputDir, `${stem}-audio.mp3`);
+
+	const probe = await probeVideo({
+		input,
+		ffprobePath: options.ffprobePath,
+		runner,
+	});
+
+	await runTool({
+		executable: ffmpegPath,
+		args: buildContactSheetArgs({
+			input,
+			durationSeconds: probe.durationSeconds,
+			frames,
+			columns,
+			rows,
+			outputPattern: pattern,
+		}),
+		runner,
+	});
+
+	await runTool({
+		executable: ffmpegPath,
+		args: buildSceneDetectArgs({
+			input,
+			threshold,
+			metadataFile: sceneMetadataPath,
+		}),
+		runner,
+	});
+
+	const pacing = parsePacing({
+		metadataText: readSceneMetadata({ filePath: sceneMetadataPath }),
+		durationSeconds: probe.durationSeconds,
+	});
+
+	if (probe.hasAudio) {
+		await runTool({
+			executable: ffmpegPath,
+			args: extractAudioArgs({ input, output: audioPath }),
+			runner,
+		});
+	}
+
+	const result: AnalyzeResult = {
+		input,
+		outputDir,
+		probe,
+		pacing,
+		contactSheet: {
+			frames,
+			columns,
+			rows,
+			pattern,
+			sheets: listSheets({ outputDir }),
+			tileTimestamps: buildTileTimestamps({
+				frames,
+				durationSeconds: probe.durationSeconds,
+			}),
+		},
+		sceneMetadataPath,
+		analysisPath,
+		audioPath: probe.hasAudio ? audioPath : undefined,
+	};
+	writeFileSync(
+		analysisPath,
+		`${JSON.stringify({ ...result, generatedAt: new Date().toISOString() }, null, 2)}\n`
+	);
+	return result;
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseArgs, parseWindows } from "./main";
+import { parseArgs, parseWindows, renderHuman } from "./main";
 
 describe("parseArgs", () => {
 	it("splits a command, positionals, and flags", () => {
@@ -56,5 +56,20 @@ describe("parseWindows", () => {
 	it("rejects malformed windows", () => {
 		expect(() => parseWindows({ value: "0:abc" })).toThrow();
 		expect(() => parseWindows({ value: "5:0" })).toThrow();
+	});
+});
+
+describe("renderHuman", () => {
+	it("renders one key per line instead of JSON", () => {
+		const text = renderHuman({
+			payload: { outputPath: "/out/final.mp4", durationSeconds: 101.8 },
+		});
+		expect(text).toBe("outputPath: /out/final.mp4\ndurationSeconds: 101.8");
+	});
+
+	it("summarises arrays by length", () => {
+		expect(renderHuman({ payload: { failed: [1, 2, 3] } })).toBe(
+			"failed: 3 item(s)"
+		);
 	});
 });

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs, parseWindows } from "./main";
+
+describe("parseArgs", () => {
+	it("splits a command, positionals, and flags", () => {
+		const parsed = parseArgs({
+			argv: ["analyze", "ref.mp4", "-o", "out", "--frames", "40"],
+		});
+		expect(parsed.command).toBe("analyze");
+		expect(parsed.positional).toEqual(["ref.mp4"]);
+		expect(parsed.flags.get("output-dir")).toBe("out");
+		expect(parsed.flags.get("frames")).toBe("40");
+	});
+
+	it("treats a flag with no value as boolean", () => {
+		const parsed = parseArgs({
+			argv: ["vo", "--plan", "p.json", "--force", "--json"],
+		});
+		expect(parsed.flags.get("force")).toBe(true);
+		expect(parsed.flags.get("json")).toBe(true);
+		expect(parsed.flags.get("plan")).toBe("p.json");
+	});
+
+	it("accepts --flag=value", () => {
+		const parsed = parseArgs({ argv: ["mix", "--video=a.mp4"] });
+		expect(parsed.flags.get("video")).toBe("a.mp4");
+	});
+
+	it("does not swallow the next flag as a value", () => {
+		const parsed = parseArgs({ argv: ["vo", "--force", "--plan", "p.json"] });
+		expect(parsed.flags.get("force")).toBe(true);
+		expect(parsed.flags.get("plan")).toBe("p.json");
+	});
+
+	it("reports no command when argv starts with a flag", () => {
+		const parsed = parseArgs({ argv: ["--help"] });
+		expect(parsed.command).toBe("");
+		expect(parsed.flags.get("help")).toBe(true);
+	});
+});
+
+describe("parseWindows", () => {
+	it("defaults to an opening and a mid-film window", () => {
+		const windows = parseWindows({});
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({ startSeconds: 0, endSeconds: 5 });
+	});
+
+	it("converts start:length pairs into start/end windows", () => {
+		expect(parseWindows({ value: "0:5,48.4:12" })).toEqual([
+			{ label: "w1", startSeconds: 0, endSeconds: 5 },
+			{ label: "w2", startSeconds: 48.4, endSeconds: 60.4 },
+		]);
+	});
+
+	it("rejects malformed windows", () => {
+		expect(() => parseWindows({ value: "0:abc" })).toThrow();
+		expect(() => parseWindows({ value: "5:0" })).toThrow();
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
@@ -137,12 +137,25 @@ export function parseWindows({ value }: { value?: string }): LevelWindow[] {
 	});
 }
 
+/** `key: value` lines, one per top-level field, for terminal reading. */
+export function renderHuman({ payload }: { payload: unknown }): string {
+	if (payload === null || typeof payload !== "object") return String(payload);
+	return Object.entries(payload as Record<string, unknown>)
+		.map(([key, value]) => {
+			if (Array.isArray(value)) return `${key}: ${value.length} item(s)`;
+			if (value !== null && typeof value === "object") {
+				return `${key}: ${JSON.stringify(value)}`;
+			}
+			return `${key}: ${String(value)}`;
+		})
+		.join("\n");
+}
+
 function emit({ json, payload }: { json: boolean; payload: unknown }): void {
-	if (json) {
-		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-		return;
-	}
-	process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+	const text = json
+		? JSON.stringify(payload, null, 2)
+		: renderHuman({ payload });
+	process.stdout.write(`${text}\n`);
 }
 
 async function main(): Promise<void> {

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
@@ -1,0 +1,223 @@
+/**
+ * qcut-cityfilm CLI dispatcher.
+ *
+ * Subcommands mirror the stages in SKILL.md that are mechanical enough to
+ * automate: understanding a reference film, narrating a plan, mixing the
+ * final audio bed, and proving the result.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { runAnalyze } from "./analyze";
+import { type LevelWindow, measureLevels, runMix } from "./mix";
+import type { CityFilmPlan } from "./types";
+import { runVoBatch } from "./vo";
+
+const USAGE = `qcut-cityfilm — reference-driven city film workflow
+
+Usage:
+  main.ts analyze <reference-video> [-o <dir>] [--frames N] [--scene-threshold N]
+  main.ts vo --plan <plan.json> [--concurrency N] [--force] [--model <key>]
+  main.ts mix --plan <plan.json> --video <export.mp4> --output <final.mp4>
+  main.ts verify --video <final.mp4> [--windows "0:5,30:5,60:5"]
+
+Options:
+  -o, --output-dir <dir>   Where artifacts are written
+      --frames <n>         Contact-sheet frames (must fill whole sheets)
+      --scene-threshold <n> Scene-cut sensitivity (default 0.4)
+      --plan <file>        CityFilmPlan JSON
+      --video <file>       Picture exported from QCut
+      --output <file>      Mixed deliverable
+      --concurrency <n>    Parallel TTS jobs (default 4)
+      --force              Re-render VO that already exists
+      --json               Machine-readable result
+  -h, --help               Show this help
+`;
+
+interface ParsedArgs {
+	command: string;
+	positional: string[];
+	flags: Map<string, string | boolean>;
+}
+
+/** Splits argv into a command, positionals, and `--flag[=value]` pairs. */
+export function parseArgs({ argv }: { argv: string[] }): ParsedArgs {
+	// A leading flag (`--help`, `--json`) means no subcommand was given.
+	const hasCommand = argv.length > 0 && !argv[0].startsWith("-");
+	const command = hasCommand ? argv[0] : "";
+	const rest = hasCommand ? argv.slice(1) : argv;
+	const positional: string[] = [];
+	const flags = new Map<string, string | boolean>();
+	const aliases: Record<string, string> = {
+		"-o": "output-dir",
+		"-h": "help",
+	};
+
+	for (let index = 0; index < rest.length; index++) {
+		const token = rest[index];
+		if (!token.startsWith("-")) {
+			positional.push(token);
+			continue;
+		}
+		const normalized = aliases[token] ?? token.replace(/^--?/, "");
+		const [name, inlineValue] = normalized.split("=");
+		if (inlineValue !== undefined) {
+			flags.set(name, inlineValue);
+			continue;
+		}
+		const next = rest[index + 1];
+		if (next === undefined || next.startsWith("-")) {
+			flags.set(name, true);
+			continue;
+		}
+		flags.set(name, next);
+		index++;
+	}
+
+	return { command, positional, flags };
+}
+
+function requireFlag({
+	flags,
+	name,
+}: {
+	flags: Map<string, string | boolean>;
+	name: string;
+}): string {
+	const value = flags.get(name);
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Missing --${name}`);
+	}
+	return value;
+}
+
+function optionalNumber({
+	flags,
+	name,
+}: {
+	flags: Map<string, string | boolean>;
+	name: string;
+}): number | undefined {
+	const value = flags.get(name);
+	if (typeof value !== "string") return;
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		throw new Error(`--${name} must be a number, received ${value}`);
+	}
+	return parsed;
+}
+
+function loadPlan({ file }: { file: string }): CityFilmPlan {
+	const path = resolve(file);
+	const plan = JSON.parse(readFileSync(path, "utf8")) as CityFilmPlan;
+	if (!Array.isArray(plan.cues) || !Array.isArray(plan.shots)) {
+		throw new Error(`${path} is not a CityFilmPlan (missing cues/shots)`);
+	}
+	return plan;
+}
+
+/** Parses `"start:length,start:length"` into labelled measurement windows. */
+export function parseWindows({ value }: { value?: string }): LevelWindow[] {
+	if (!value) {
+		return [
+			{ label: "open", startSeconds: 0, endSeconds: 5 },
+			{ label: "mid", startSeconds: 30, endSeconds: 35 },
+		];
+	}
+	return value.split(",").map((entry, index) => {
+		const [start, length] = entry.split(":").map(Number);
+		if (!Number.isFinite(start) || !Number.isFinite(length) || length <= 0) {
+			throw new Error(`Invalid window "${entry}", expected start:length`);
+		}
+		return {
+			label: `w${index + 1}`,
+			startSeconds: start,
+			endSeconds: start + length,
+		};
+	});
+}
+
+function emit({ json, payload }: { json: boolean; payload: unknown }): void {
+	if (json) {
+		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+		return;
+	}
+	process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+	const { command, positional, flags } = parseArgs({
+		argv: process.argv.slice(2),
+	});
+	const json = flags.get("json") === true || flags.get("json") === "true";
+
+	if (!command || flags.get("help") === true || command === "help") {
+		process.stdout.write(USAGE);
+		return;
+	}
+
+	if (command === "analyze") {
+		const input = positional[0];
+		if (!input) throw new Error("analyze needs a reference video path");
+		const result = await runAnalyze({
+			input: resolve(input),
+			outputDir: (flags.get("output-dir") as string) || undefined,
+			frames: optionalNumber({ flags, name: "frames" }),
+			sceneThreshold: optionalNumber({ flags, name: "scene-threshold" }),
+		});
+		emit({ json, payload: result });
+		return;
+	}
+
+	if (command === "vo") {
+		const plan = loadPlan({ file: requireFlag({ flags, name: "plan" }) });
+		const result = await runVoBatch({
+			plan,
+			concurrency: optionalNumber({ flags, name: "concurrency" }),
+			force: flags.get("force") === true,
+			model: (flags.get("model") as string) || undefined,
+		});
+		emit({
+			json,
+			payload: {
+				generated: result.generated.length,
+				skipped: result.skipped.length,
+				failed: result.failed,
+			},
+		});
+		if (result.failed.length > 0) process.exitCode = 1;
+		return;
+	}
+
+	if (command === "mix") {
+		const plan = loadPlan({ file: requireFlag({ flags, name: "plan" }) });
+		const result = await runMix({
+			plan,
+			videoPath: resolve(requireFlag({ flags, name: "video" })),
+			outputPath: resolve(requireFlag({ flags, name: "output" })),
+		});
+		emit({ json, payload: result });
+		return;
+	}
+
+	if (command === "verify") {
+		const file = resolve(requireFlag({ flags, name: "video" }));
+		const levels = await measureLevels({
+			file,
+			windows: parseWindows({ value: flags.get("windows") as string }),
+		});
+		emit({ json, payload: { file, levels } });
+		return;
+	}
+
+	throw new Error(`Unknown command "${command}"\n\n${USAGE}`);
+}
+
+if (import.meta.main) {
+	main().catch((error: unknown) => {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : String(error)}\n`
+		);
+		process.exitCode = 1;
+	});
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test } from "vitest";
+import {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	computeTimelineDuration,
+	resolveVoFile,
+} from "./mix-graph";
+import type { CityFilmPlan } from "./types";
+
+function createPlan(overrides: Partial<CityFilmPlan> = {}): CityFilmPlan {
+	return {
+		name: "melbourne",
+		language: "zh",
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		assetsDir: "/assets/melbourne",
+		acts: [
+			{
+				id: "a1-dawn",
+				title: "第1幕·破晓",
+				startSeconds: 0,
+				endSeconds: 30,
+				shotSeconds: 3,
+				emotion: "平静",
+			},
+		],
+		shots: [
+			{ file: "dawn.mp4", startSeconds: 0, endSeconds: 30 },
+			{ file: "market.mp4", startSeconds: 10, endSeconds: 40 },
+		],
+		cues: [
+			{
+				id: "t01",
+				actId: "a1-dawn",
+				startSeconds: 0,
+				durationSeconds: 4,
+				text: "清晨",
+			},
+			{
+				id: "t02",
+				actId: "a1-dawn",
+				startSeconds: 12.5,
+				durationSeconds: 4,
+				text: "市场",
+			},
+			{
+				id: "t03",
+				actId: "a1-dawn",
+				startSeconds: 40,
+				durationSeconds: 4,
+				text: "黄昏",
+			},
+		],
+		music: [
+			{
+				file: "music/dawn-bed.mp3",
+				startSeconds: 0,
+				endSeconds: 30,
+				sourceOffsetSeconds: 12,
+				fadeInSeconds: 2,
+			},
+			{
+				file: "music/night-bed.mp3",
+				startSeconds: 30,
+				endSeconds: 55,
+				sourceOffsetSeconds: 0,
+				fadeOutSeconds: 3,
+			},
+		],
+		blackTailSeconds: 2,
+		subtitle: {
+			fontSize: 48,
+			letterSpacing: 2,
+			offsetY: 320,
+			titleFontSize: 72,
+			titleLetterSpacing: 8,
+		},
+		...overrides,
+	};
+}
+
+describe("qcut-cityfilm mix graph", () => {
+	test("wires music, narration, and ducking for a two-cue plan", () => {
+		const plan = createPlan();
+		const graph = buildMixGraph({ plan });
+
+		expect(graph.inputs).toEqual([
+			"/assets/melbourne/music/dawn-bed.mp3",
+			"/assets/melbourne/music/night-bed.mp3",
+			"/assets/melbourne/vo/vo-zh-t01.mp3",
+			"/assets/melbourne/vo/vo-zh-t02.mp3",
+			"/assets/melbourne/vo/vo-zh-t03.mp3",
+		]);
+		expect(graph.maps).toEqual(["0:v", "[aout]"]);
+
+		const chains = graph.filterComplex.split(";");
+		expect(chains[0]).toBe("[0:a]volume=0.22[amb]");
+		// Music cues take inputs 1..2, narration cues 3..5.
+		expect(chains[1]).toContain("[1:a]atrim=12:42,asetpts=PTS-STARTPTS");
+		expect(chains[1]).toContain("afade=t=in:st=0:d=2");
+		expect(chains[2]).toContain("[2:a]atrim=0:25,asetpts=PTS-STARTPTS");
+		expect(chains[2]).toContain("afade=t=out:st=22:d=3");
+
+		// 60s of shots + a 2s black tail needs a 7s pad after music ends at 55s.
+		expect(computeTimelineDuration({ plan })).toBe(62);
+		expect(graph.filterComplex).toContain("anullsrc");
+		expect(graph.filterComplex).toContain("atrim=duration=7");
+		expect(chains.find((chain) => chain.includes("concat="))).toBe(
+			"[m0][m1][mp0]concat=n=3:v=0:a=1,volume=0.5[music]"
+		);
+
+		expect(graph.filterComplex).toContain("[3:a]adelay=0|0,volume=1.6[vo0]");
+		expect(graph.filterComplex).toContain(
+			"[4:a]adelay=12500|12500,volume=1.6[vo1]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[5:a]adelay=40000|40000,volume=1.6[vo2]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[vo0][vo1][vo2]amix=inputs=3:normalize=0:dropout_transition=0,apad,atrim=0:62,asetpts=PTS-STARTPTS[vo]"
+		);
+		expect(graph.filterComplex).toContain("[vo]asplit=2[vokey][vomix]");
+		expect(graph.filterComplex).toContain(
+			"[amb][music]amix=inputs=2:normalize=0[bed]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[bed][vokey]sidechaincompress=threshold=0.05:ratio=7:attack=15:release=350:makeup=1[bedduck]"
+		);
+		expect(graph.filterComplex).toMatch(
+			/\[bedduck]\[vomix]amix=inputs=2:normalize=0,alimiter=limit=0\.95,aresample=48000\[aout]$/
+		);
+	});
+
+	test("pads a mid-timeline gap so concat cannot shorten the bed", () => {
+		const plan = createPlan({
+			shots: [{ file: "dawn.mp4", startSeconds: 0, endSeconds: 20 }],
+			blackTailSeconds: 0,
+			music: [
+				{
+					file: "music/a.mp3",
+					startSeconds: 0,
+					endSeconds: 5,
+					sourceOffsetSeconds: 0,
+				},
+				{
+					file: "music/b.mp3",
+					startSeconds: 12,
+					endSeconds: 20,
+					sourceOffsetSeconds: 4,
+				},
+			],
+			cues: [],
+		});
+		const graph = buildMixGraph({ plan });
+
+		expect(graph.filterComplex).toContain("atrim=duration=7");
+		expect(graph.filterComplex).toContain("[m0][mp0][m1]concat=n=3:v=0:a=1");
+		// No narration means no duck stage; the bed goes straight to [aout].
+		expect(graph.filterComplex).not.toContain("sidechaincompress");
+		expect(graph.filterComplex).toContain(
+			"[amb][music]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	});
+
+	test("pads the voice bus so ducking cannot truncate the film", () => {
+		// Regression: sidechaincompress ends with its key input, so a voice bus
+		// that stopped at the last cue cut the exported audio short (a 62s film
+		// came back as 44s, and -shortest then clipped the picture too).
+		const plan = createPlan({
+			cues: [
+				{
+					id: "t01",
+					actId: "a1-dawn",
+					startSeconds: 2,
+					durationSeconds: 4,
+					text: "清晨",
+				},
+			],
+		});
+		const graph = buildMixGraph({ plan });
+		expect(graph.filterComplex).toContain(
+			"[vo0]amix=inputs=1:normalize=0:dropout_transition=0,apad,atrim=0:62,asetpts=PTS-STARTPTS[vo]"
+		);
+	});
+
+	test("honours custom levels and a non-zero video input index", () => {
+		const graph = buildMixGraph({
+			plan: createPlan(),
+			levels: { ambience: 0.1, music: 0.4, voice: 2, duckRatio: 12 },
+			videoInputIndex: 2,
+		});
+		expect(graph.filterComplex).toContain("[2:a]volume=0.1[amb]");
+		expect(graph.filterComplex).toContain("[3:a]atrim=12:42");
+		expect(graph.filterComplex).toContain("[5:a]adelay=0|0,volume=2[vo0]");
+		expect(graph.filterComplex).toContain("ratio=12:attack=15");
+		expect(graph.maps).toEqual(["2:v", "[aout]"]);
+	});
+
+	test("rejects overlapping or empty music cues", () => {
+		expect(() =>
+			buildMixGraph({
+				plan: createPlan({
+					music: [
+						{
+							file: "a.mp3",
+							startSeconds: 0,
+							endSeconds: 30,
+							sourceOffsetSeconds: 0,
+						},
+						{
+							file: "b.mp3",
+							startSeconds: 20,
+							endSeconds: 40,
+							sourceOffsetSeconds: 0,
+						},
+					],
+				}),
+			})
+		).toThrow("overlaps the previous cue");
+		expect(() =>
+			buildMixGraph({
+				plan: createPlan({
+					music: [
+						{
+							file: "a.mp3",
+							startSeconds: 5,
+							endSeconds: 5,
+							sourceOffsetSeconds: 0,
+						},
+					],
+				}),
+			})
+		).toThrow("non-positive length");
+	});
+
+	test("resolves VO filenames with the vo.ts naming rule", () => {
+		expect(
+			resolveVoFile({ assetsDir: "/a", language: "en", cueId: "t04" })
+		).toBe("/a/vo/vo-en-t04.mp3");
+	});
+});
+
+describe("qcut-cityfilm label guard", () => {
+	test("accepts a graph whose every label is consumed", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: graph.filterComplex,
+				outputLabels: ["aout"],
+			})
+		).not.toThrow();
+	});
+
+	test("rejects an orphan label that ffmpeg would abort on", () => {
+		const orphaned = [
+			"[0:a]volume=0.2[amb]",
+			"[1:a]volume=0.5[music]",
+			"[2:a]volume=1.6[strays]",
+			"[amb][music]amix=inputs=2:normalize=0[aout]",
+		].join(";");
+		expect(() =>
+			assertLabelsConsumed({ filterComplex: orphaned, outputLabels: ["aout"] })
+		).toThrow("[strays]");
+		expect(() =>
+			assertLabelsConsumed({ filterComplex: orphaned, outputLabels: ["aout"] })
+		).toThrow("nothing consumes");
+	});
+
+	test("rejects dangling references and duplicate labels", () => {
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: "[0:a]volume=0.2[amb];[amb][music]amix=inputs=2[aout]",
+			})
+		).toThrow("never produced");
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex:
+					"[0:a]volume=0.2[amb];[1:a]volume=0.5[amb];[amb]anull[aout]",
+			})
+		).toThrow("more than once");
+	});
+
+	test("treats the last chain's outputs as terminal by default", () => {
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: "[0:a]volume=0.2[amb];[amb]anull[aout]",
+			})
+		).not.toThrow();
+	});
+});
+
+describe("qcut-cityfilm mix arguments", () => {
+	test("copies the picture and encodes only the new bed", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		const args = buildMixArgs({
+			videoPath: "/out/picture.mp4",
+			outputPath: "/out/final.mp4",
+			graph,
+		});
+
+		expect(args.slice(0, 3)).toEqual(["-y", "-i", "/out/picture.mp4"]);
+		expect(args.filter((value) => value === "-i")).toHaveLength(
+			1 + graph.inputs.length
+		);
+		const filterIndex = args.indexOf("-filter_complex");
+		expect(args[filterIndex + 1]).toBe(graph.filterComplex);
+		expect(args.slice(filterIndex + 2)).toEqual([
+			"-map",
+			"0:v",
+			"-map",
+			"[aout]",
+			"-c:v",
+			"copy",
+			"-c:a",
+			"aac",
+			"-b:a",
+			"192k",
+			"-shortest",
+			"/out/final.mp4",
+		]);
+	});
+
+	test("refuses to overwrite the exported picture", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		expect(() =>
+			buildMixArgs({
+				videoPath: "/out/picture.mp4",
+				outputPath: "/out/picture.mp4",
+				graph,
+			})
+		).toThrow("cannot replace the exported picture");
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.ts
@@ -1,0 +1,398 @@
+/**
+ * Pure filter-graph construction for the qcut-cityfilm final mix.
+ *
+ * QCut's exporter currently drops CLI-imported audio from the render, so the
+ * picture is exported from QCut (it still carries the source clips' ambience)
+ * and the music + narration are mixed on top in a single ffmpeg pass that
+ * copies the video stream untouched. Nothing here spawns a process.
+ */
+import { isAbsolute, join, resolve } from "node:path";
+import { type CityFilmPlan, DEFAULT_MIX_LEVELS, type MixLevels } from "./types";
+import { voFileName } from "./vo";
+
+/** Seconds below which two timeline positions count as the same instant. */
+const EPSILON = 1e-3;
+
+/** Every concat segment must agree on format or ffmpeg rejects the join. */
+const AUDIO_FORMAT =
+	"aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo";
+
+/** Input pads (`0:a`, `1:v`) are supplied by ffmpeg, not by a filter chain. */
+const INPUT_PAD_PATTERN = /^\d+:[a-zA-Z]+$/;
+
+/** A fully wired filter graph, ready to be turned into ffmpeg arguments. */
+export interface MixGraph {
+	/** Audio files appended after the video input, in ffmpeg input order. */
+	inputs: string[];
+	filterComplex: string;
+	/** Raw `-map` values, e.g. `["0:v", "[aout]"]`. */
+	maps: string[];
+}
+
+export function formatNumber({ value }: { value: number }): string {
+	if (!Number.isFinite(value)) {
+		throw new Error(`Expected a finite number, received ${value}`);
+	}
+	return String(Math.round(value * 1000) / 1000);
+}
+
+/**
+ * Where vo.ts wrote a cue's narration: `<assetsDir>/vo/vo-<lang>-<id>.mp3`.
+ * The filename itself comes from vo.ts so the rule has one owner.
+ */
+export function resolveVoFile({
+	assetsDir,
+	language,
+	cueId,
+}: {
+	assetsDir: string;
+	language: string;
+	cueId: string;
+}): string {
+	return join(assetsDir, "vo", voFileName({ language, cueId }));
+}
+
+/**
+ * Picture length the music bed has to cover: every shot laid end to end plus
+ * the black tail held for the closing card.
+ */
+export function computeTimelineDuration({
+	plan,
+}: {
+	plan: CityFilmPlan;
+}): number {
+	const shots = plan.shots.reduce((total, shot) => {
+		const length = shot.endSeconds - shot.startSeconds;
+		if (length <= 0) {
+			throw new Error(
+				`Shot ${shot.file} has a non-positive length (${shot.startSeconds}..${shot.endSeconds})`
+			);
+		}
+		return total + length;
+	}, 0);
+	return shots + Math.max(0, plan.blackTailSeconds);
+}
+
+function splitChainLabels({ chain }: { chain: string }): {
+	inputs: string[];
+	outputs: string[];
+} {
+	const trimmed = chain.trim();
+	const leading = trimmed.match(/^(?:\[[^[\]]+\])+/);
+	const trailing = trimmed.match(/(?:\[[^[\]]+\])+$/);
+	const leadingEnd = leading ? leading[0].length : 0;
+	const names = (value: string | undefined): string[] =>
+		value ? [...value.matchAll(/\[([^[\]]+)\]/g)].map((match) => match[1]) : [];
+	const trailingIsSeparate =
+		trailing !== null &&
+		trailing.index !== undefined &&
+		trailing.index >= leadingEnd;
+	return {
+		inputs: names(leading?.[0]),
+		outputs: trailingIsSeparate ? names(trailing[0]) : [],
+	};
+}
+
+/**
+ * Guards the mistake that broke the first hand-run: ffmpeg aborts the whole
+ * render when a filter graph declares a label nothing reads. Also catches the
+ * two neighbouring failures — referencing a label that is never produced, and
+ * producing the same label twice.
+ *
+ * @param outputLabels Terminal labels meant to leave the graph via `-map`.
+ * Defaults to the outputs of the last filter chain.
+ */
+export function assertLabelsConsumed({
+	filterComplex,
+	outputLabels,
+}: {
+	filterComplex: string;
+	outputLabels?: string[];
+}): void {
+	const chains = filterComplex
+		.split(";")
+		.map((chain) => chain.trim())
+		.filter((chain) => chain.length > 0);
+	if (chains.length === 0) throw new Error("Filter graph is empty");
+
+	const produced: string[] = [];
+	const consumed = new Set<string>();
+	let lastOutputs: string[] = [];
+	for (const chain of chains) {
+		const { inputs, outputs } = splitChainLabels({ chain });
+		for (const label of inputs) {
+			if (!INPUT_PAD_PATTERN.test(label)) consumed.add(label);
+		}
+		for (const label of outputs) {
+			if (produced.includes(label)) {
+				throw new Error(
+					`Filter graph declares label [${label}] more than once; ffmpeg needs unique labels`
+				);
+			}
+			produced.push(label);
+		}
+		lastOutputs = outputs;
+	}
+
+	const terminal = new Set(outputLabels ?? lastOutputs);
+	const list = (labels: string[]): string =>
+		labels.map((label) => `[${label}]`).join(", ");
+	const undefinedLabels = [...consumed].filter(
+		(label) => !produced.includes(label)
+	);
+	if (undefinedLabels.length > 0) {
+		throw new Error(
+			`Filter graph reads labels that are never produced: ${list(undefinedLabels)}`
+		);
+	}
+	const orphans = produced.filter(
+		(label) => !consumed.has(label) && !terminal.has(label)
+	);
+	if (orphans.length > 0) {
+		throw new Error(
+			`Filter graph produces labels nothing consumes: ${list(orphans)}. ffmpeg fails on unused filter outputs; consume them or drop the chain.`
+		);
+	}
+}
+
+function buildMusicChains({
+	plan,
+	levels,
+	firstAudioIndex,
+	timelineDuration,
+}: {
+	plan: CityFilmPlan;
+	levels: MixLevels;
+	firstAudioIndex: number;
+	timelineDuration: number;
+}): { chains: string[]; inputs: string[]; concatChain: string } {
+	const ordered = [...plan.music].sort(
+		(left, right) => left.startSeconds - right.startSeconds
+	);
+	const chains: string[] = [];
+	const inputs: string[] = [];
+	const segments: string[] = [];
+	let cursor = 0;
+	let padIndex = 0;
+
+	const pad = ({ length }: { length: number }): void => {
+		const label = `mp${padIndex}`;
+		padIndex += 1;
+		chains.push(
+			`anullsrc=channel_layout=stereo:sample_rate=48000,atrim=duration=${formatNumber({ value: length })},asetpts=PTS-STARTPTS,${AUDIO_FORMAT}[${label}]`
+		);
+		segments.push(label);
+	};
+
+	for (const cue of ordered) {
+		const length = cue.endSeconds - cue.startSeconds;
+		if (length <= 0) {
+			throw new Error(
+				`Music cue ${cue.file} has a non-positive length (${cue.startSeconds}..${cue.endSeconds})`
+			);
+		}
+		if (cue.sourceOffsetSeconds < 0) {
+			throw new Error(`Music cue ${cue.file} has a negative source offset`);
+		}
+		if (cue.startSeconds < cursor - EPSILON) {
+			throw new Error(
+				`Music cue ${cue.file} at ${cue.startSeconds}s overlaps the previous cue ending at ${cursor}s`
+			);
+		}
+		if (cue.startSeconds > cursor + EPSILON) {
+			pad({ length: cue.startSeconds - cursor });
+		}
+
+		const label = `m${inputs.length}`;
+		const inputIndex = firstAudioIndex + inputs.length;
+		inputs.push(
+			isAbsolute(cue.file) ? cue.file : join(plan.assetsDir, cue.file)
+		);
+		const steps = [
+			`atrim=${formatNumber({ value: cue.sourceOffsetSeconds })}:${formatNumber({ value: cue.sourceOffsetSeconds + length })}`,
+			"asetpts=PTS-STARTPTS",
+			AUDIO_FORMAT,
+		];
+		if (cue.fadeInSeconds && cue.fadeInSeconds > 0) {
+			steps.push(
+				`afade=t=in:st=0:d=${formatNumber({ value: cue.fadeInSeconds })}`
+			);
+		}
+		if (cue.fadeOutSeconds && cue.fadeOutSeconds > 0) {
+			const start = Math.max(0, length - cue.fadeOutSeconds);
+			steps.push(
+				`afade=t=out:st=${formatNumber({ value: start })}:d=${formatNumber({ value: cue.fadeOutSeconds })}`
+			);
+		}
+		chains.push(`[${inputIndex}:a]${steps.join(",")}[${label}]`);
+		segments.push(label);
+		cursor = cue.endSeconds;
+	}
+
+	if (cursor < timelineDuration - EPSILON) {
+		pad({ length: timelineDuration - cursor });
+	}
+	if (segments.length === 0) {
+		throw new Error("Music bed has no segments; the timeline duration is zero");
+	}
+
+	return {
+		chains,
+		inputs,
+		concatChain: `${segments.map((label) => `[${label}]`).join("")}concat=n=${segments.length}:v=0:a=1,volume=${formatNumber({ value: levels.music })}[music]`,
+	};
+}
+
+function buildVoiceChains({
+	plan,
+	levels,
+	firstAudioIndex,
+}: {
+	plan: CityFilmPlan;
+	levels: MixLevels;
+	firstAudioIndex: number;
+}): { chains: string[]; inputs: string[]; labels: string[] } {
+	const chains: string[] = [];
+	const inputs: string[] = [];
+	const labels: string[] = [];
+	const ordered = [...plan.cues].sort(
+		(left, right) => left.startSeconds - right.startSeconds
+	);
+	for (const cue of ordered) {
+		if (cue.startSeconds < 0) {
+			throw new Error(`Cue ${cue.id} starts before the timeline`);
+		}
+		const label = `vo${labels.length}`;
+		const inputIndex = firstAudioIndex + inputs.length;
+		inputs.push(
+			resolveVoFile({
+				assetsDir: plan.assetsDir,
+				language: plan.language,
+				cueId: cue.id,
+			})
+		);
+		const delayMs = Math.round(cue.startSeconds * 1000);
+		chains.push(
+			`[${inputIndex}:a]adelay=${delayMs}|${delayMs},volume=${formatNumber({ value: levels.voice })}[${label}]`
+		);
+		labels.push(label);
+	}
+	return { chains, inputs, labels };
+}
+
+/**
+ * Builds the whole mix graph. Music segments are concatenated in timeline
+ * order — any stretch the cues do not cover is padded with `anullsrc` so
+ * concat cannot shorten the bed — then ducked under the narration by a
+ * sidechain compressor keyed off a split copy of the voice bus.
+ *
+ * Input order is: the picture at `videoInputIndex`, then one input per music
+ * cue in timeline order, then one input per narration cue in timeline order.
+ * A cue gets its own input even when two cues share a file, because an ffmpeg
+ * input pad can only be read once.
+ */
+export function buildMixGraph({
+	plan,
+	levels = DEFAULT_MIX_LEVELS,
+	videoInputIndex = 0,
+}: {
+	plan: CityFilmPlan;
+	levels?: MixLevels;
+	videoInputIndex?: number;
+}): MixGraph {
+	if (!Number.isInteger(videoInputIndex) || videoInputIndex < 0) {
+		throw new Error("videoInputIndex must be a non-negative integer");
+	}
+
+	const musicEnd = plan.music.reduce(
+		(latest, cue) => Math.max(latest, cue.endSeconds),
+		0
+	);
+	const timelineDuration = Math.max(
+		computeTimelineDuration({ plan }),
+		musicEnd
+	);
+
+	const music = buildMusicChains({
+		plan,
+		levels,
+		firstAudioIndex: videoInputIndex + 1,
+		timelineDuration,
+	});
+	const voice = buildVoiceChains({
+		plan,
+		levels,
+		firstAudioIndex: videoInputIndex + 1 + music.inputs.length,
+	});
+
+	const chains = [
+		`[${videoInputIndex}:a]volume=${formatNumber({ value: levels.ambience })}[amb]`,
+		...music.chains,
+		music.concatChain,
+		...voice.chains,
+	];
+
+	// `sidechaincompress` stops as soon as its key input ends, so a voice bus
+	// that runs out before the last shot would truncate the whole film. Pad the
+	// bus to the timeline before it is split into key and mix copies.
+	const voiceBus = `amix=inputs=${voice.labels.length}:normalize=0:dropout_transition=0,apad,atrim=0:${formatNumber({ value: timelineDuration })},asetpts=PTS-STARTPTS`;
+
+	if (voice.labels.length === 0) {
+		chains.push(
+			"[amb][music]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	} else {
+		chains.push(
+			`${voice.labels.map((label) => `[${label}]`).join("")}${voiceBus}[vo]`,
+			"[vo]asplit=2[vokey][vomix]",
+			"[amb][music]amix=inputs=2:normalize=0[bed]",
+			`[bed][vokey]sidechaincompress=threshold=0.05:ratio=${formatNumber({ value: levels.duckRatio })}:attack=15:release=350:makeup=1[bedduck]`,
+			"[bedduck][vomix]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	}
+
+	const filterComplex = chains.join(";");
+	assertLabelsConsumed({ filterComplex, outputLabels: ["aout"] });
+	return {
+		inputs: [...music.inputs, ...voice.inputs],
+		filterComplex,
+		maps: [`${videoInputIndex}:v`, "[aout]"],
+	};
+}
+
+/**
+ * Full ffmpeg argv. The video stream is copied, so this pass only re-encodes
+ * audio. Assumes the picture occupies input 0, which is what `buildMixGraph`
+ * produces with its default `videoInputIndex`.
+ */
+export function buildMixArgs({
+	videoPath,
+	outputPath,
+	graph,
+}: {
+	videoPath: string;
+	outputPath: string;
+	graph: MixGraph;
+}): string[] {
+	if (resolve(videoPath) === resolve(outputPath)) {
+		throw new Error("Mix output cannot replace the exported picture");
+	}
+	if (graph.maps.length === 0) throw new Error("Mix graph has no output maps");
+	assertLabelsConsumed({ filterComplex: graph.filterComplex });
+
+	const args = ["-y", "-i", videoPath];
+	for (const input of graph.inputs) args.push("-i", input);
+	args.push("-filter_complex", graph.filterComplex);
+	for (const map of graph.maps) args.push("-map", map);
+	args.push(
+		"-c:v",
+		"copy",
+		"-c:a",
+		"aac",
+		"-b:a",
+		"192k",
+		"-shortest",
+		outputPath
+	);
+	return args;
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	buildVolumeDetectArgs,
+	computeTimelineDuration,
+	parseVolumeDetect,
+	resolveVoFile,
+} from "./mix";
+
+describe("qcut-cityfilm level verification", () => {
+	test("measures a single window with volumedetect", () => {
+		expect(
+			buildVolumeDetectArgs({
+				file: "/out/final.mp4",
+				window: { label: "act2", startSeconds: 12.5, endSeconds: 20 },
+			})
+		).toEqual([
+			"-hide_banner",
+			"-nostats",
+			"-ss",
+			"12.5",
+			"-t",
+			"7.5",
+			"-i",
+			"/out/final.mp4",
+			"-vn",
+			"-af",
+			"volumedetect",
+			"-f",
+			"null",
+			"-",
+		]);
+	});
+
+	test("rejects a window that cannot be measured", () => {
+		expect(() =>
+			buildVolumeDetectArgs({
+				file: "/out/final.mp4",
+				window: { label: "tail", startSeconds: 20, endSeconds: 20 },
+			})
+		).toThrow("non-positive length");
+	});
+
+	test("parses mean and max levels, including digital silence", () => {
+		expect(
+			parseVolumeDetect({
+				stderr: [
+					"[Parsed_volumedetect_0 @ 0x1] n_samples: 705600",
+					"[Parsed_volumedetect_0 @ 0x1] mean_volume: -23.4 dB",
+					"[Parsed_volumedetect_0 @ 0x1] max_volume: -3.0 dB",
+				].join("\n"),
+			})
+		).toEqual({ meanDb: -23.4, maxDb: -3 });
+
+		expect(
+			parseVolumeDetect({
+				stderr: "mean_volume: -inf dB\nmax_volume: -inf dB",
+			})
+		).toEqual({
+			meanDb: Number.NEGATIVE_INFINITY,
+			maxDb: Number.NEGATIVE_INFINITY,
+		});
+
+		expect(() => parseVolumeDetect({ stderr: "no levels here" })).toThrow(
+			"volumedetect printed no"
+		);
+	});
+});
+
+describe("qcut-cityfilm mix entry surface", () => {
+	test("re-exports the pure graph builders so callers need one import", () => {
+		expect(typeof buildMixGraph).toBe("function");
+		expect(typeof buildMixArgs).toBe("function");
+		expect(typeof assertLabelsConsumed).toBe("function");
+		expect(typeof computeTimelineDuration).toBe("function");
+		expect(
+			resolveVoFile({ assetsDir: "/a", language: "zh", cueId: "t09" })
+		).toBe("/a/vo/vo-zh-t09.mp3");
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.ts
@@ -1,0 +1,288 @@
+/**
+ * Renders the qcut-cityfilm audio bed and proves it landed.
+ *
+ * The picture comes out of QCut (it carries the source clips' ambience) and
+ * this module lays music + narration over it with one ffmpeg pass, then
+ * measures the result. Graph construction lives in mix-graph.ts; everything
+ * here is process execution and output parsing.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { buildMixArgs, buildMixGraph } from "./mix-graph";
+import type { CityFilmPlan, MixLevels } from "./types";
+
+export {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	computeTimelineDuration,
+	resolveVoFile,
+} from "./mix-graph";
+export type { MixGraph } from "./mix-graph";
+
+/** One stretch of the finished file to measure. */
+export interface LevelWindow {
+	/** Reporting label, e.g. `"act2"` or `"vo-t04"`. */
+	label: string;
+	startSeconds: number;
+	endSeconds: number;
+}
+
+/** What `volumedetect` reported for one window. */
+export interface LevelReading {
+	label: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** RMS mean in dBFS; `-Infinity` for digital silence. */
+	meanDb: number;
+	maxDb: number;
+	silent: boolean;
+}
+
+export interface MixOptions {
+	plan: CityFilmPlan;
+	/** Picture exported from QCut; must carry an audio track for ambience. */
+	videoPath: string;
+	outputPath: string;
+	levels?: MixLevels;
+	videoInputIndex?: number;
+	ffmpegPath?: string;
+	ffprobePath?: string;
+	/** Optional file to receive the command line and ffmpeg's stderr. */
+	logPath?: string;
+}
+
+export interface MixResult {
+	outputPath: string;
+	durationSeconds: number;
+}
+
+function formatSeconds({ value }: { value: number }): string {
+	if (!Number.isFinite(value)) {
+		throw new Error(`Expected a finite number, received ${value}`);
+	}
+	return String(Math.round(value * 1000) / 1000);
+}
+
+/** ffmpeg argv that measures one window with `volumedetect`. */
+export function buildVolumeDetectArgs({
+	file,
+	window,
+}: {
+	file: string;
+	window: LevelWindow;
+}): string[] {
+	const length = window.endSeconds - window.startSeconds;
+	if (length <= 0) {
+		throw new Error(
+			`Level window ${window.label} has a non-positive length (${window.startSeconds}..${window.endSeconds})`
+		);
+	}
+	return [
+		"-hide_banner",
+		"-nostats",
+		"-ss",
+		formatSeconds({ value: window.startSeconds }),
+		"-t",
+		formatSeconds({ value: length }),
+		"-i",
+		file,
+		"-vn",
+		"-af",
+		"volumedetect",
+		"-f",
+		"null",
+		"-",
+	];
+}
+
+function parseDecibels({ value }: { value: string }): number {
+	if (value === "-inf") return Number.NEGATIVE_INFINITY;
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		throw new Error(`Could not parse a dB value from "${value}"`);
+	}
+	return parsed;
+}
+
+/** Reads `mean_volume` / `max_volume` out of an ffmpeg `volumedetect` run. */
+export function parseVolumeDetect({ stderr }: { stderr: string }): {
+	meanDb: number;
+	maxDb: number;
+} {
+	const mean = stderr.match(/mean_volume:\s*(-?[\d.]+|-inf)\s*dB/);
+	const max = stderr.match(/max_volume:\s*(-?[\d.]+|-inf)\s*dB/);
+	if (!mean || !max) {
+		throw new Error(
+			"volumedetect printed no mean_volume/max_volume line; the window is probably past the end of the file"
+		);
+	}
+	return {
+		meanDb: parseDecibels({ value: mean[1] }),
+		maxDb: parseDecibels({ value: max[1] }),
+	};
+}
+
+function resolveBinary({
+	value,
+	name,
+}: {
+	value?: string;
+	name: string;
+}): string {
+	if (value) return value;
+	return Bun.which(name) ?? name;
+}
+
+async function runProcess({
+	executable,
+	args,
+}: {
+	executable: string;
+	args: string[];
+}): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const child = Bun.spawn([executable, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { stdout, stderr, exitCode: await child.exited };
+}
+
+async function probeDuration({
+	ffprobePath,
+	filePath,
+}: {
+	ffprobePath: string;
+	filePath: string;
+}): Promise<number> {
+	const result = await runProcess({
+		executable: ffprobePath,
+		args: [
+			"-v",
+			"error",
+			"-show_entries",
+			"format=duration",
+			"-of",
+			"json",
+			filePath,
+		],
+	});
+	if (result.exitCode !== 0) {
+		throw new Error(`ffprobe failed for ${filePath}: ${result.stderr.trim()}`);
+	}
+	const parsed = JSON.parse(result.stdout) as {
+		format?: { duration?: string };
+	};
+	const duration = Number(parsed.format?.duration);
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error(`Could not determine duration: ${filePath}`);
+	}
+	return duration;
+}
+
+/** Builds the graph, renders it, and reports the finished file's duration. */
+export async function runMix(options: MixOptions): Promise<MixResult> {
+	const graph = buildMixGraph({
+		plan: options.plan,
+		levels: options.levels,
+		videoInputIndex: options.videoInputIndex,
+	});
+	const missing = [options.videoPath, ...graph.inputs].filter(
+		(file) => !existsSync(file)
+	);
+	if (missing.length > 0) {
+		throw new Error(`Mix inputs are missing:\n  ${missing.join("\n  ")}`);
+	}
+
+	const args = buildMixArgs({
+		videoPath: options.videoPath,
+		outputPath: options.outputPath,
+		graph,
+	});
+	const ffmpegPath = resolveBinary({
+		value: options.ffmpegPath,
+		name: "ffmpeg",
+	});
+	mkdirSync(dirname(resolve(options.outputPath)), { recursive: true });
+	const result = await runProcess({ executable: ffmpegPath, args });
+	if (options.logPath) {
+		mkdirSync(dirname(resolve(options.logPath)), { recursive: true });
+		writeFileSync(
+			options.logPath,
+			`$ ${[ffmpegPath, ...args].join(" ")}\n${result.stderr}`,
+			"utf8"
+		);
+	}
+	if (result.exitCode !== 0) {
+		const detail = result.stderr.trim().split("\n").slice(-3).join(" | ");
+		throw new Error(`ffmpeg mix failed (${result.exitCode}): ${detail}`);
+	}
+
+	return {
+		outputPath: options.outputPath,
+		durationSeconds: await probeDuration({
+			ffprobePath: resolveBinary({
+				value: options.ffprobePath,
+				name: "ffprobe",
+			}),
+			filePath: options.outputPath,
+		}),
+	};
+}
+
+/**
+ * Measures mean/max level per window on a rendered file. The hand-run once
+ * shipped a silent cut because only the timeline was inspected — always prove
+ * the audio landed in the exported file itself.
+ */
+export async function measureLevels({
+	file,
+	windows,
+	ffmpegPath,
+	silenceFloorDb = -60,
+}: {
+	file: string;
+	windows: LevelWindow[];
+	ffmpegPath?: string;
+	silenceFloorDb?: number;
+}): Promise<LevelReading[]> {
+	if (!existsSync(file)) {
+		throw new Error(`Cannot measure a missing file: ${file}`);
+	}
+	const executable = resolveBinary({ value: ffmpegPath, name: "ffmpeg" });
+	const readings: LevelReading[] = [];
+	for (const window of windows) {
+		const result = await runProcess({
+			executable,
+			args: buildVolumeDetectArgs({ file, window }),
+		});
+		if (result.exitCode !== 0) {
+			const detail = result.stderr.trim().split("\n").slice(-2).join(" | ");
+			throw new Error(
+				`volumedetect failed for window ${window.label}: ${detail}`
+			);
+		}
+		let meanDb: number;
+		let maxDb: number;
+		try {
+			({ meanDb, maxDb } = parseVolumeDetect({ stderr: result.stderr }));
+		} catch (error) {
+			throw new Error(
+				`Could not measure window ${window.label} (${window.startSeconds}..${window.endSeconds}s) of ${file}: ${error instanceof Error ? error.message : String(error)}`
+			);
+		}
+		readings.push({
+			label: window.label,
+			startSeconds: window.startSeconds,
+			endSeconds: window.endSeconds,
+			meanDb,
+			maxDb,
+			silent: !(meanDb > silenceFloorDb),
+		});
+	}
+	return readings;
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
@@ -74,6 +74,13 @@ export interface CityFilmPlan {
 	music: MusicCue[];
 	/** Seconds of black held after the last shot for the closing card. */
 	blackTailSeconds: number;
+	/**
+	 * Hosted clip (≤30s) that anchors the narrator's timbre. Seed Audio picks a
+	 * fresh speaker per request otherwise, so cuts end up sounding like several
+	 * different people. The runner fills this from the first rendered cue when
+	 * voice locking is on.
+	 */
+	voiceAnchorUrl?: string;
 	/** Subtitle styling, in canvas pixels. */
 	subtitle: SubtitleStyle;
 }

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared contracts for the qcut-cityfilm skill.
+ *
+ * The workflow this encodes: analyze a reference film, gather licensed
+ * footage, pick segments, narrate with emotion, assemble in QCut, and mix the
+ * final audio bed outside the editor.
+ */
+
+/** One act of the film. Acts drive pacing, copy, VO emotion, and music. */
+export interface ActPlan {
+	/** Stable key used in filenames and cue ids, e.g. "a2-market". */
+	id: string;
+	/** Human label, e.g. "第2幕·市场". */
+	title: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** Target shot length inside this act, in seconds. */
+	shotSeconds: number;
+	/** Emotion directive passed to the TTS model, in the copy's language. */
+	emotion: string;
+}
+
+/** A chosen in/out range of a source clip. */
+export interface SegmentPick {
+	/** Basename of the source file, as imported into the project. */
+	file: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** Why this segment was chosen — kept for review, not used by the build. */
+	note?: string;
+}
+
+/** One narration/subtitle cue. */
+export interface Cue {
+	/** Cue id, e.g. "t04". Also names the VO file: vo-<lang>-<id>.mp3. */
+	id: string;
+	/** Act this cue belongs to; supplies the TTS emotion directive. */
+	actId: string;
+	startSeconds: number;
+	durationSeconds: number;
+	/** Subtitle text; also the TTS prompt body. */
+	text: string;
+	/** Centered title card instead of a bottom subtitle. */
+	title?: boolean;
+}
+
+/** Music bed segment: one stretch of one track. */
+export interface MusicCue {
+	/** Basename of the audio file. */
+	file: string;
+	/** Where the segment lands on the timeline. */
+	startSeconds: number;
+	endSeconds: number;
+	/** Offset inside the source track. */
+	sourceOffsetSeconds: number;
+	fadeInSeconds?: number;
+	fadeOutSeconds?: number;
+}
+
+/** The full recipe for one language cut. */
+export interface CityFilmPlan {
+	name: string;
+	/** BCP-47-ish short code used in VO filenames: "zh", "en", ... */
+	language: string;
+	width: number;
+	height: number;
+	fps: number;
+	/** Directory holding footage, music, and generated VO. */
+	assetsDir: string;
+	acts: ActPlan[];
+	/** Ordered shot list; the build lays these out end to end. */
+	shots: SegmentPick[];
+	cues: Cue[];
+	music: MusicCue[];
+	/** Seconds of black held after the last shot for the closing card. */
+	blackTailSeconds: number;
+	/** Subtitle styling, in canvas pixels. */
+	subtitle: SubtitleStyle;
+}
+
+export interface SubtitleStyle {
+	fontSize: number;
+	letterSpacing: number;
+	/** Vertical offset from canvas center, positive is down. */
+	offsetY: number;
+	titleFontSize: number;
+	titleLetterSpacing: number;
+}
+
+/** Per-language mixing levels. */
+export interface MixLevels {
+	/** Source-clip ambience kept under the bed. */
+	ambience: number;
+	music: number;
+	voice: number;
+	/** Ducking depth applied to the bed while narration plays. */
+	duckRatio: number;
+}
+
+export const DEFAULT_MIX_LEVELS: MixLevels = {
+	ambience: 0.22,
+	music: 0.5,
+	voice: 1.6,
+	duckRatio: 7,
+};
+
+/** Scene-cut statistics extracted from a reference film. */
+export interface PacingProfile {
+	durationSeconds: number;
+	cutCount: number;
+	/** Cuts per minute, index 0 = first minute. */
+	cutsPerMinute: number[];
+	averageShotSeconds: number;
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
@@ -1,0 +1,85 @@
+/**
+ * Process-level helpers for the narration batch.
+ *
+ * Everything that spawns a child process or moves a file lives here, so the
+ * planning and prompt logic in vo.ts stays unit-testable without a TTS call.
+ */
+
+import { spawn } from "node:child_process";
+import { copyFileSync, renameSync, rmSync } from "node:fs";
+
+export interface SpawnOutcome {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Never rejects: a spawn error is reported as a non-zero exit instead. */
+export function spawnCollect({
+	executable,
+	args,
+	cwd,
+	env,
+}: {
+	executable: string;
+	args: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+}): Promise<SpawnOutcome> {
+	return new Promise<SpawnOutcome>((resolveOutcome) => {
+		const out: Buffer[] = [];
+		const err: Buffer[] = [];
+		const child = spawn(executable, args, {
+			cwd,
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+		child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+		const finish = (exitCode: number, extra = "") =>
+			resolveOutcome({
+				exitCode,
+				stdout: Buffer.concat(out).toString("utf8"),
+				stderr: `${Buffer.concat(err).toString("utf8")}${extra}`,
+			});
+		child.once("error", (error: Error) => finish(1, error.message));
+		child.once("close", (code) => finish(code ?? 1));
+	});
+}
+
+/** Explicit override wins, then PATH lookup, then a bare-name fallback. */
+export function resolveExecutable({
+	override,
+	name,
+	fallback,
+}: {
+	override?: string;
+	name: string;
+	fallback: string;
+}): string {
+	if (override) return override;
+	const found = typeof Bun === "undefined" ? undefined : Bun.which(name);
+	return found ?? fallback;
+}
+
+/** Last few lines of child output, collapsed into one error-sized string. */
+export function tailMessage({
+	text,
+	lines = 3,
+}: {
+	text: string;
+	lines?: number;
+}): string {
+	return text.trim().split("\n").slice(-lines).join(" | ");
+}
+
+/** Rename, falling back to copy+unlink when temp and assets differ by device. */
+export function moveFile({ from, to }: { from: string; to: string }): void {
+	try {
+		renameSync(from, to);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EXDEV") throw error;
+		copyFileSync(from, to);
+		rmSync(from, { force: true });
+	}
+}

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
@@ -14,17 +14,26 @@ export interface SpawnOutcome {
 	stderr: string;
 }
 
-/** Never rejects: a spawn error is reported as a non-zero exit instead. */
+/**
+ * A hosted TTS call that never answers would otherwise pin one concurrency
+ * lane for the whole batch, so children are given a deadline.
+ */
+export const DEFAULT_SPAWN_TIMEOUT_MS = 300_000;
+
+/** Never rejects: a spawn error or timeout is reported as a non-zero exit. */
 export function spawnCollect({
 	executable,
 	args,
 	cwd,
 	env,
+	timeoutMs = DEFAULT_SPAWN_TIMEOUT_MS,
 }: {
 	executable: string;
 	args: string[];
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
+	/** Kill the child after this long; 0 or negative disables the deadline. */
+	timeoutMs?: number;
 }): Promise<SpawnOutcome> {
 	return new Promise<SpawnOutcome>((resolveOutcome) => {
 		const out: Buffer[] = [];
@@ -34,14 +43,27 @@ export function spawnCollect({
 			env,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
 		child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
-		const finish = (exitCode: number, extra = "") =>
+		const finish = (exitCode: number, extra = "") => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
 			resolveOutcome({
 				exitCode,
 				stdout: Buffer.concat(out).toString("utf8"),
 				stderr: `${Buffer.concat(err).toString("utf8")}${extra}`,
 			});
+		};
+		if (timeoutMs > 0) {
+			timer = setTimeout(() => {
+				child.kill("SIGKILL");
+				finish(124, `\ntimed out after ${timeoutMs}ms`);
+			}, timeoutMs);
+			timer.unref?.();
+		}
 		child.once("error", (error: Error) => finish(1, error.message));
 		child.once("close", (code) => finish(code ?? 1));
 	});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -12,6 +12,7 @@ import {
 	VOICE_REFERENCE_TAG,
 	voFileName,
 } from "./vo";
+import { spawnCollect } from "./vo-exec";
 import { resolveExecutable, tailMessage } from "./vo-exec";
 
 const act: ActPlan = {
@@ -316,5 +317,27 @@ describe("voice locking", () => {
 		expect(() =>
 			parseTtsAudioUrl({ stdout: JSON.stringify({ status: "ok", data: {} }) })
 		).toThrow();
+	});
+});
+
+describe("spawnCollect timeout", () => {
+	it("kills a stalled child and reports a non-zero exit", async () => {
+		const outcome = await spawnCollect({
+			executable: "sleep",
+			args: ["30"],
+			timeoutMs: 150,
+		});
+		expect(outcome.exitCode).toBe(124);
+		expect(outcome.stderr).toContain("timed out");
+	});
+
+	it("leaves a fast child untouched", async () => {
+		const outcome = await spawnCollect({
+			executable: "echo",
+			args: ["ok"],
+			timeoutMs: 5000,
+		});
+		expect(outcome.exitCode).toBe(0);
+		expect(outcome.stdout.trim()).toBe("ok");
 	});
 });

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "vitest";
+import type { ActPlan, CityFilmPlan, Cue } from "./types";
+import {
+	buildTtsArgs,
+	buildTtsPrompt,
+	checkCueFit,
+	parseDurationSeconds,
+	pickGeneratedAudioName,
+	planVoJobs,
+	runWithConcurrency,
+	voFileName,
+} from "./vo";
+import { resolveExecutable, tailMessage } from "./vo-exec";
+
+const act: ActPlan = {
+	id: "a1-return",
+	title: "第1幕·归来",
+	startSeconds: 0,
+	endSeconds: 30,
+	shotSeconds: 3,
+	emotion: "(用温柔、怀旧、带一点感慨的语气)",
+};
+
+const cue: Cue = {
+	id: "t04",
+	actId: "a1-return",
+	startSeconds: 12,
+	durationSeconds: 4,
+	text: "好久不见,墨尔本。",
+};
+
+function makePlan({ overrides }: { overrides?: Partial<CityFilmPlan> } = {}) {
+	const plan: CityFilmPlan = {
+		name: "melbourne",
+		language: "zh",
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		assetsDir: "/films/melbourne/assets",
+		acts: [
+			act,
+			{
+				id: "a2-market",
+				title: "第2幕·市场",
+				startSeconds: 30,
+				endSeconds: 60,
+				shotSeconds: 2,
+				emotion: "(用明快、好奇的语气)",
+			},
+		],
+		shots: [],
+		cues: [
+			cue,
+			{
+				id: "t05",
+				actId: "a2-market",
+				startSeconds: 31,
+				durationSeconds: 3,
+				text: "市场醒了。",
+			},
+			{
+				id: "t06",
+				actId: "a9-missing",
+				startSeconds: 40,
+				durationSeconds: 3,
+				text: "没有情绪指令。",
+			},
+		],
+		music: [],
+		blackTailSeconds: 2,
+		subtitle: {
+			fontSize: 48,
+			letterSpacing: 2,
+			offsetY: 380,
+			titleFontSize: 72,
+			titleLetterSpacing: 8,
+		},
+	};
+	return { ...plan, ...overrides };
+}
+
+describe("qcut-cityfilm vo prompts", () => {
+	test("prefixes the act emotion directive with no extra separator", () => {
+		expect(buildTtsPrompt({ cue, act })).toBe(
+			"(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。"
+		);
+	});
+
+	test("falls back to the plain copy when no directive is available", () => {
+		expect(buildTtsPrompt({ cue })).toBe("好久不见,墨尔本。");
+		expect(buildTtsPrompt({ cue, act: { ...act, emotion: "   " } })).toBe(
+			"好久不见,墨尔本。"
+		);
+	});
+
+	test("names VO files by language and cue id", () => {
+		expect(voFileName({ language: "zh", cueId: "t04" })).toBe("vo-zh-t04.mp3");
+		expect(voFileName({ language: "en", cueId: "t12" })).toBe("vo-en-t12.mp3");
+	});
+
+	test("builds the pipeline TTS argv", () => {
+		expect(
+			buildTtsArgs({
+				model: "seed_audio",
+				prompt: "(用温柔的语气)好久不见。",
+				outputDir: "/tmp/vo-t04",
+			})
+		).toEqual([
+			"run",
+			"pipeline",
+			"gen",
+			"tts",
+			"-m",
+			"seed_audio",
+			"-t",
+			"(用温柔的语气)好久不见。",
+			"-o",
+			"/tmp/vo-t04",
+			"--json",
+		]);
+	});
+});
+
+describe("qcut-cityfilm vo job planning", () => {
+	test("emits one job per cue resolved under assetsDir/vo", () => {
+		const jobs = planVoJobs({ plan: makePlan() });
+
+		expect(jobs).toHaveLength(3);
+		expect(jobs[0]).toEqual({
+			cueId: "t04",
+			prompt: "(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。",
+			outputFile: "/films/melbourne/assets/vo/vo-zh-t04.mp3",
+		});
+		expect(jobs[1]?.prompt).toBe("(用明快、好奇的语气)市场醒了。");
+		expect(jobs[1]?.outputFile).toBe(
+			"/films/melbourne/assets/vo/vo-zh-t05.mp3"
+		);
+		// An unknown act id must not drop the cue — it renders undirected.
+		expect(jobs[2]?.prompt).toBe("没有情绪指令。");
+	});
+
+	test("follows the plan language into every filename", () => {
+		const jobs = planVoJobs({
+			plan: makePlan({ overrides: { language: "en" } }),
+		});
+		expect(jobs.map((job) => job.outputFile)).toEqual([
+			"/films/melbourne/assets/vo/vo-en-t04.mp3",
+			"/films/melbourne/assets/vo/vo-en-t05.mp3",
+			"/films/melbourne/assets/vo/vo-en-t06.mp3",
+		]);
+	});
+});
+
+describe("qcut-cityfilm cue fit", () => {
+	test("accepts narration up to the tolerance and rejects beyond it", () => {
+		expect(checkCueFit({ cue, voDurationSeconds: 3.2 })).toEqual({
+			fits: true,
+			overflowSeconds: 0,
+		});
+		expect(checkCueFit({ cue, voDurationSeconds: 4 })).toEqual({
+			fits: true,
+			overflowSeconds: 0,
+		});
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 4.25, toleranceSeconds: 0.25 })
+		).toEqual({ fits: true, overflowSeconds: 0.25 });
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 4.26, toleranceSeconds: 0.25 })
+		).toEqual({ fits: false, overflowSeconds: 0.26 });
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 6.5, toleranceSeconds: 0 })
+		).toEqual({ fits: false, overflowSeconds: 2.5 });
+	});
+});
+
+describe("qcut-cityfilm vo runner helpers", () => {
+	test("prefers speech.mp3 and falls back to any mp3", () => {
+		expect(
+			pickGeneratedAudioName({ entries: ["meta.json", "speech.mp3"] })
+		).toBe("speech.mp3");
+		expect(
+			pickGeneratedAudioName({ entries: ["meta.json", "seed-out.MP3"] })
+		).toBe("seed-out.MP3");
+		expect(pickGeneratedAudioName({ entries: ["meta.json"] })).toBeUndefined();
+	});
+
+	test("reads the ffprobe duration payload", () => {
+		expect(
+			parseDurationSeconds({ stdout: '{"format":{"duration":"3.744000"}}' })
+		).toBeCloseTo(3.744, 3);
+		expect(() => parseDurationSeconds({ stdout: "not json" })).toThrow(
+			"did not return JSON"
+		);
+		expect(() => parseDurationSeconds({ stdout: "{}" })).toThrow(
+			"no usable duration"
+		);
+	});
+
+	test("bounds concurrency while preserving input order", async () => {
+		let active = 0;
+		let peak = 0;
+		const results = await runWithConcurrency<number, string>({
+			items: [1, 2, 3, 4, 5, 6, 7],
+			limit: 3,
+			worker: async (item) => {
+				active += 1;
+				peak = Math.max(peak, active);
+				await new Promise((done) => setTimeout(done, 5));
+				active -= 1;
+				return `job-${item}`;
+			},
+		});
+
+		expect(peak).toBeLessThanOrEqual(3);
+		expect(results).toEqual([
+			"job-1",
+			"job-2",
+			"job-3",
+			"job-4",
+			"job-5",
+			"job-6",
+			"job-7",
+		]);
+		expect(
+			await runWithConcurrency<number, number>({
+				items: [],
+				limit: 4,
+				worker: async (item) => item,
+			})
+		).toEqual([]);
+	});
+
+	test("condenses child output into one error line", () => {
+		expect(tailMessage({ text: "a\nb\nc\nd\ne\n" })).toBe("c | d | e");
+		expect(tailMessage({ text: "only\n", lines: 3 })).toBe("only");
+	});
+
+	test("prefers an explicit executable override over PATH lookup", () => {
+		expect(
+			resolveExecutable({
+				override: "/opt/bun/bin/bun",
+				name: "bun",
+				fallback: "/usr/bin/node",
+			})
+		).toBe("/opt/bun/bin/bun");
+		expect(
+			resolveExecutable({
+				name: "definitely-not-a-real-binary-9f2c",
+				fallback: "fallback-bin",
+			})
+		).toBe("fallback-bin");
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import type { ActPlan, CityFilmPlan, Cue } from "./types";
 import {
 	buildTtsArgs,
@@ -6,8 +6,10 @@ import {
 	checkCueFit,
 	parseDurationSeconds,
 	pickGeneratedAudioName,
+	parseTtsAudioUrl,
 	planVoJobs,
 	runWithConcurrency,
+	VOICE_REFERENCE_TAG,
 	voFileName,
 } from "./vo";
 import { resolveExecutable, tailMessage } from "./vo-exec";
@@ -249,5 +251,70 @@ describe("qcut-cityfilm vo runner helpers", () => {
 				fallback: "fallback-bin",
 			})
 		).toBe("fallback-bin");
+	});
+});
+
+describe("voice locking", () => {
+	const anchoredPlan = makePlan({
+		overrides: { voiceAnchorUrl: "https://fal.media/anchor.mp3" },
+	});
+
+	it("tags the prompt only when a reference is supplied", () => {
+		const plan = makePlan();
+		const [firstCue] = plan.cues;
+		const [firstAct] = plan.acts;
+		expect(
+			buildTtsPrompt({ cue: firstCue, act: firstAct })
+		).not.toContain(VOICE_REFERENCE_TAG);
+		expect(
+			buildTtsPrompt({
+				cue: firstCue,
+				act: firstAct,
+				referenceAudioUrl: "https://x/a.mp3",
+			})
+		).toMatch(new RegExp(`^${VOICE_REFERENCE_TAG} `));
+	});
+
+	it("passes the anchor through planVoJobs", () => {
+		const jobs = planVoJobs({ plan: anchoredPlan });
+		expect(jobs.every((job) => job.referenceAudioUrl === anchoredPlan.voiceAnchorUrl)).toBe(true);
+		expect(jobs.every((job) => job.prompt.startsWith(VOICE_REFERENCE_TAG))).toBe(
+			true
+		);
+	});
+
+	it("adds --audio-url to the CLI args when anchored", () => {
+		const args = buildTtsArgs({
+			model: "seed_audio",
+			prompt: "@Audio1 hi",
+			outputDir: "/tmp/out",
+			referenceAudioUrl: "https://fal.media/anchor.mp3",
+		});
+		expect(args).toContain("--audio-url");
+		expect(args[args.indexOf("--audio-url") + 1]).toBe(
+			"https://fal.media/anchor.mp3"
+		);
+		expect(args.at(-1)).toBe("--json");
+	});
+
+	it("omits --audio-url when no anchor is set", () => {
+		const args = buildTtsArgs({
+			model: "seed_audio",
+			prompt: "hi",
+			outputDir: "/tmp/out",
+		});
+		expect(args).not.toContain("--audio-url");
+	});
+
+	it("reads the hosted url out of a gen tts envelope", () => {
+		const stdout = `$ bun run pipeline\n${JSON.stringify({
+			status: "ok",
+			data: { data: { audioUrl: "https://fal.media/x.mp3" } },
+		})}`;
+		expect(parseTtsAudioUrl({ stdout })).toBe("https://fal.media/x.mp3");
+		expect(() => parseTtsAudioUrl({ stdout: "no json here" })).toThrow();
+		expect(() =>
+			parseTtsAudioUrl({ stdout: JSON.stringify({ status: "ok", data: {} }) })
+		).toThrow();
 	});
 });

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
@@ -41,6 +41,8 @@ export interface VoJob {
 	prompt: string;
 	/** Absolute destination, `<assetsDir>/vo/vo-<language>-<cueId>.mp3`. */
 	outputFile: string;
+	/** Voice anchor passed as `audio_urls[0]`, when the voice is locked. */
+	referenceAudioUrl?: string;
 }
 
 export type VoJobStatus = "generated" | "skipped" | "failed";
@@ -50,6 +52,8 @@ export interface VoJobOutcome {
 	status: VoJobStatus;
 	/** Present only when status is "failed". */
 	error?: string;
+	/** Hosted URL of the rendered take, reusable as a voice anchor. */
+	audioUrl?: string;
 }
 
 export interface VoJobFailure {
@@ -59,6 +63,8 @@ export interface VoJobFailure {
 }
 
 export interface VoBatchResult {
+	/** Anchor used (or discovered) for this batch; persist it into the plan. */
+	voiceAnchorUrl?: string;
 	generated: VoJob[];
 	skipped: VoJob[];
 	failed: VoJobFailure[];
@@ -80,6 +86,12 @@ export interface VoBatchOptions {
 	tempRoot?: string;
 	env?: NodeJS.ProcessEnv;
 	onProgress?: (outcome: VoJobOutcome) => void;
+	/**
+	 * Render the first cue alone, then anchor every remaining cue to it so the
+	 * whole cut keeps one voice. Defaults on; turn off only when the plan
+	 * already carries a `voiceAnchorUrl` or a single voice does not matter.
+	 */
+	lockVoice?: boolean;
 }
 
 export interface CueFit {
@@ -93,19 +105,25 @@ function roundMilliseconds({ value }: { value: number }): number {
 }
 
 /**
- * Prefix the copy with the act's emotion directive. The directive already ends
- * in its own closing paren, so nothing is inserted between the two halves.
+ * Token that binds a rendering to the first reference clip. Seed Audio only
+ * applies `audio_urls` when the prompt names the clip, so passing a reference
+ * without this tag leaves the speaker free to drift between cues.
  */
+export const VOICE_REFERENCE_TAG = "@Audio1";
+
 export function buildTtsPrompt({
 	cue,
 	act,
+	referenceAudioUrl,
 }: {
 	cue: Cue;
 	act?: ActPlan;
+	/** Anchor clip that fixes the speaker across every cue. */
+	referenceAudioUrl?: string;
 }): string {
 	const directive = act?.emotion?.trim();
-	if (!directive) return cue.text;
-	return `${directive}${cue.text}`;
+	const body = directive ? `${directive}${cue.text}` : cue.text;
+	return referenceAudioUrl ? `${VOICE_REFERENCE_TAG} ${body}` : body;
 }
 
 export function voFileName({
@@ -122,12 +140,15 @@ export function buildTtsArgs({
 	model,
 	prompt,
 	outputDir,
+	referenceAudioUrl,
 }: {
 	model: string;
 	prompt: string;
 	outputDir: string;
+	/** Sent as `audio_urls[0]`; the prompt must also carry the tag. */
+	referenceAudioUrl?: string;
 }): string[] {
-	return [
+	const args = [
 		"run",
 		"pipeline",
 		"gen",
@@ -138,24 +159,63 @@ export function buildTtsArgs({
 		prompt,
 		"-o",
 		outputDir,
-		"--json",
 	];
+	if (referenceAudioUrl) args.push("--audio-url", referenceAudioUrl);
+	args.push("--json");
+	return args;
+}
+
+/**
+ * Reads the hosted audio URL out of a `gen tts --json` envelope. The URL is
+ * what later cues reuse as their voice anchor, so it is kept rather than the
+ * downloaded file (the model needs a URL, not a local path).
+ */
+export function parseTtsAudioUrl({ stdout }: { stdout: string }): string {
+	const start = stdout.indexOf("{");
+	if (start < 0) throw new Error("gen tts did not return JSON");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout.slice(start)) as unknown;
+	} catch {
+		throw new Error("gen tts returned malformed JSON");
+	}
+	const envelope = parsed as {
+		data?: { data?: { audioUrl?: string }; audioUrl?: string };
+	};
+	const url = envelope.data?.data?.audioUrl ?? envelope.data?.audioUrl;
+	if (typeof url !== "string" || url.length === 0) {
+		throw new Error("gen tts response carried no audioUrl");
+	}
+	return url;
 }
 
 /**
  * One job per cue, in plan order. Nothing is filtered here — the runner decides
  * what already exists so callers can inspect the full intended set.
  */
-export function planVoJobs({ plan }: { plan: CityFilmPlan }): VoJob[] {
+export function planVoJobs({
+	plan,
+	referenceAudioUrl,
+}: {
+	plan: CityFilmPlan;
+	/** Anchor clip URL; when set every prompt is tagged and reference-bound. */
+	referenceAudioUrl?: string;
+}): VoJob[] {
 	const actsById = new Map(plan.acts.map((act) => [act.id, act]));
 	const voDir = join(plan.assetsDir, "vo");
+	const anchor = referenceAudioUrl ?? plan.voiceAnchorUrl;
 	return plan.cues.map((cue) => ({
 		cueId: cue.id,
-		prompt: buildTtsPrompt({ cue, act: actsById.get(cue.actId) }),
+		prompt: buildTtsPrompt({
+			cue,
+			act: actsById.get(cue.actId),
+			referenceAudioUrl: anchor,
+		}),
 		outputFile: join(
 			voDir,
 			voFileName({ language: plan.language, cueId: cue.id })
 		),
+		referenceAudioUrl: anchor,
 	}));
 }
 
@@ -293,6 +353,7 @@ async function runVoJob({
 				model: runtime.model,
 				prompt: job.prompt,
 				outputDir: workDir,
+				referenceAudioUrl: job.referenceAudioUrl,
 			}),
 			cwd: runtime.cwd,
 			env: runtime.env,
@@ -304,7 +365,13 @@ async function runVoJob({
 		const produced = pickGeneratedAudioName({ entries: readdirSync(workDir) });
 		if (!produced) throw new Error("tts produced no mp3");
 		moveFile({ from: join(workDir, produced), to: job.outputFile });
-		return { job, status: "generated" };
+		let audioUrl: string | undefined;
+		try {
+			audioUrl = parseTtsAudioUrl({ stdout: outcome.stdout });
+		} catch {
+			// The mp3 is on disk either way; only voice anchoring needs the URL.
+		}
+		return { job, status: "generated", audioUrl };
 	} catch (error) {
 		return {
 			job,
@@ -331,6 +398,7 @@ export async function runVoBatch({
 	tempRoot = tmpdir(),
 	env = process.env,
 	onProgress,
+	lockVoice = true,
 }: VoBatchOptions): Promise<VoBatchResult> {
 	const runtime: VoJobRuntime = {
 		model,
@@ -344,17 +412,47 @@ export async function runVoBatch({
 		force,
 		env,
 	};
-	const outcomes = await runWithConcurrency<VoJob, VoJobOutcome>({
-		items: jobs ?? planVoJobs({ plan }),
-		limit: concurrency,
-		worker: async (job) => {
-			const outcome = await runVoJob({ job, runtime });
-			onProgress?.(outcome);
-			return outcome;
-		},
-	});
+	const runOne = async (job: VoJob): Promise<VoJobOutcome> => {
+		const outcome = await runVoJob({ job, runtime });
+		onProgress?.(outcome);
+		return outcome;
+	};
 
-	const result: VoBatchResult = { generated: [], skipped: [], failed: [] };
+	// Seed Audio picks a new speaker per request, so the cues are rendered
+	// against a single anchor clip: either one supplied by the plan, or the
+	// first cue rendered on its own and then reused for the rest.
+	let anchorUrl = plan.voiceAnchorUrl;
+	const outcomes: VoJobOutcome[] = [];
+	let pending = jobs ?? planVoJobs({ plan, referenceAudioUrl: anchorUrl });
+
+	if (lockVoice && !anchorUrl && pending.length > 1) {
+		const [first, ...rest] = pending;
+		const firstOutcome = await runOne(first);
+		outcomes.push(firstOutcome);
+		anchorUrl = firstOutcome.audioUrl;
+		pending = anchorUrl
+			? rest.map((job) => ({
+					...job,
+					prompt: `${VOICE_REFERENCE_TAG} ${job.prompt}`,
+					referenceAudioUrl: anchorUrl,
+				}))
+			: rest;
+	}
+
+	outcomes.push(
+		...(await runWithConcurrency<VoJob, VoJobOutcome>({
+			items: pending,
+			limit: concurrency,
+			worker: runOne,
+		}))
+	);
+
+	const result: VoBatchResult = {
+		generated: [],
+		skipped: [],
+		failed: [],
+		voiceAnchorUrl: anchorUrl,
+	};
 	for (const outcome of outcomes) {
 		if (outcome.status === "generated") result.generated.push(outcome.job);
 		else if (outcome.status === "skipped") result.skipped.push(outcome.job);

--- a/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
+++ b/qcut/.agents/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
@@ -1,0 +1,370 @@
+/**
+ * Batch emotional narration for the city-film workflow.
+ *
+ * Each cue is spoken by ByteDance Seed Audio through the QCut pipeline CLI
+ * (`bun run pipeline gen tts -m seed_audio -t "<text>" -o <dir>`), which always
+ * writes `<dir>/speech.mp3`. Emotion is steered by prefixing the copy with the
+ * act's parenthesised directive in the copy's own language — the plain prompt
+ * reads flat, the directed one carries the cut.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ActPlan, CityFilmPlan, Cue } from "./types";
+import {
+	moveFile,
+	resolveExecutable,
+	spawnCollect,
+	tailMessage,
+} from "./vo-exec";
+
+/** Seed Audio is the only model that renders the emotion directives well. */
+export const DEFAULT_VO_MODEL = "seed_audio";
+/** Seed Audio tolerates a handful of parallel requests; four is safe. */
+export const DEFAULT_VO_CONCURRENCY = 4;
+/** A cue may run this far past its slot before the shot has to be relengthened. */
+export const DEFAULT_FIT_TOLERANCE_SECONDS = 0.25;
+/** The pipeline CLI always writes this basename into the output directory. */
+export const TTS_OUTPUT_BASENAME = "speech.mp3";
+
+/** One narration render: a prompt in, one mp3 out. */
+export interface VoJob {
+	cueId: string;
+	/** Emotion directive + copy, exactly as handed to the TTS model. */
+	prompt: string;
+	/** Absolute destination, `<assetsDir>/vo/vo-<language>-<cueId>.mp3`. */
+	outputFile: string;
+}
+
+export type VoJobStatus = "generated" | "skipped" | "failed";
+
+export interface VoJobOutcome {
+	job: VoJob;
+	status: VoJobStatus;
+	/** Present only when status is "failed". */
+	error?: string;
+}
+
+export interface VoJobFailure {
+	cueId: string;
+	outputFile: string;
+	error: string;
+}
+
+export interface VoBatchResult {
+	generated: VoJob[];
+	skipped: VoJob[];
+	failed: VoJobFailure[];
+}
+
+export interface VoBatchOptions {
+	plan: CityFilmPlan;
+	/** Defaults to `planVoJobs({ plan })`; pass a subset to re-render cues. */
+	jobs?: VoJob[];
+	model?: string;
+	concurrency?: number;
+	/** Re-render cues whose mp3 already exists. */
+	force?: boolean;
+	/** Executable that fronts `run pipeline ...`; defaults to Bun. */
+	executable?: string;
+	/** Must be the QCut repository root so `bun run pipeline` resolves. */
+	cwd?: string;
+	/** Parent directory for the per-job scratch dirs. */
+	tempRoot?: string;
+	env?: NodeJS.ProcessEnv;
+	onProgress?: (outcome: VoJobOutcome) => void;
+}
+
+export interface CueFit {
+	fits: boolean;
+	/** Seconds the narration runs past the cue slot; 0 when it fits. */
+	overflowSeconds: number;
+}
+
+function roundMilliseconds({ value }: { value: number }): number {
+	return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Prefix the copy with the act's emotion directive. The directive already ends
+ * in its own closing paren, so nothing is inserted between the two halves.
+ */
+export function buildTtsPrompt({
+	cue,
+	act,
+}: {
+	cue: Cue;
+	act?: ActPlan;
+}): string {
+	const directive = act?.emotion?.trim();
+	if (!directive) return cue.text;
+	return `${directive}${cue.text}`;
+}
+
+export function voFileName({
+	language,
+	cueId,
+}: {
+	language: string;
+	cueId: string;
+}): string {
+	return `vo-${language}-${cueId}.mp3`;
+}
+
+export function buildTtsArgs({
+	model,
+	prompt,
+	outputDir,
+}: {
+	model: string;
+	prompt: string;
+	outputDir: string;
+}): string[] {
+	return [
+		"run",
+		"pipeline",
+		"gen",
+		"tts",
+		"-m",
+		model,
+		"-t",
+		prompt,
+		"-o",
+		outputDir,
+		"--json",
+	];
+}
+
+/**
+ * One job per cue, in plan order. Nothing is filtered here — the runner decides
+ * what already exists so callers can inspect the full intended set.
+ */
+export function planVoJobs({ plan }: { plan: CityFilmPlan }): VoJob[] {
+	const actsById = new Map(plan.acts.map((act) => [act.id, act]));
+	const voDir = join(plan.assetsDir, "vo");
+	return plan.cues.map((cue) => ({
+		cueId: cue.id,
+		prompt: buildTtsPrompt({ cue, act: actsById.get(cue.actId) }),
+		outputFile: join(
+			voDir,
+			voFileName({ language: plan.language, cueId: cue.id })
+		),
+	}));
+}
+
+/**
+ * A long line overruns its shot, so every rendered cue is measured against the
+ * slot it was written for.
+ */
+export function checkCueFit({
+	cue,
+	voDurationSeconds,
+	toleranceSeconds = DEFAULT_FIT_TOLERANCE_SECONDS,
+}: {
+	cue: Cue;
+	voDurationSeconds: number;
+	toleranceSeconds?: number;
+}): CueFit {
+	const overflow = Math.max(0, voDurationSeconds - cue.durationSeconds);
+	return {
+		fits: overflow <= toleranceSeconds,
+		overflowSeconds: roundMilliseconds({ value: overflow }),
+	};
+}
+
+/** Prefer the documented `speech.mp3`, but accept a single renamed sibling. */
+export function pickGeneratedAudioName({
+	entries,
+}: {
+	entries: string[];
+}): string | undefined {
+	if (entries.includes(TTS_OUTPUT_BASENAME)) return TTS_OUTPUT_BASENAME;
+	return entries.find((entry) => entry.toLowerCase().endsWith(".mp3"));
+}
+
+export function parseDurationSeconds({ stdout }: { stdout: string }): number {
+	let parsed: { format?: { duration?: string } };
+	try {
+		parsed = JSON.parse(stdout) as { format?: { duration?: string } };
+	} catch {
+		throw new Error("ffprobe did not return JSON");
+	}
+	const duration = Number(parsed.format?.duration);
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error("ffprobe reported no usable duration");
+	}
+	return duration;
+}
+
+/** Bounded-concurrency map that preserves input order in the results. */
+export async function runWithConcurrency<TItem, TResult>({
+	items,
+	limit,
+	worker,
+}: {
+	items: TItem[];
+	limit: number;
+	worker: (item: TItem, index: number) => Promise<TResult>;
+}): Promise<TResult[]> {
+	const results = new Array<TResult>(items.length);
+	const lanes = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+	let cursor = 0;
+	const runners = Array.from({ length: lanes }, async () => {
+		while (cursor < items.length) {
+			const index = cursor;
+			cursor += 1;
+			results[index] = await worker(items[index] as TItem, index);
+		}
+	});
+	await Promise.all(runners);
+	return results;
+}
+
+/** Measure a rendered narration so callers can verify it fits its cue slot. */
+export async function probeDurationSeconds({
+	file,
+	ffprobe,
+	env = process.env,
+}: {
+	file: string;
+	ffprobe?: string;
+	env?: NodeJS.ProcessEnv;
+}): Promise<number> {
+	const outcome = await spawnCollect({
+		executable: resolveExecutable({
+			override: ffprobe ?? env.QCUT_CITYFILM_FFPROBE_BIN,
+			name: "ffprobe",
+			fallback: "ffprobe",
+		}),
+		args: [
+			"-v",
+			"error",
+			"-show_entries",
+			"format=duration",
+			"-of",
+			"json",
+			file,
+		],
+		env,
+	});
+	if (outcome.exitCode !== 0) {
+		throw new Error(
+			`ffprobe failed (${outcome.exitCode}) for ${file}: ${tailMessage({ text: outcome.stderr })}`
+		);
+	}
+	return parseDurationSeconds({ stdout: outcome.stdout });
+}
+
+interface VoJobRuntime {
+	model: string;
+	executable: string;
+	cwd?: string;
+	tempRoot: string;
+	force: boolean;
+	env?: NodeJS.ProcessEnv;
+}
+
+/** Renders one cue into its own scratch dir. Never throws. */
+async function runVoJob({
+	job,
+	runtime,
+}: {
+	job: VoJob;
+	runtime: VoJobRuntime;
+}): Promise<VoJobOutcome> {
+	if (!runtime.force && existsSync(job.outputFile)) {
+		return { job, status: "skipped" };
+	}
+	let workDir: string | undefined;
+	try {
+		mkdirSync(dirname(job.outputFile), { recursive: true });
+		mkdirSync(runtime.tempRoot, { recursive: true });
+		workDir = mkdtempSync(join(runtime.tempRoot, `cityfilm-vo-${job.cueId}-`));
+		const outcome = await spawnCollect({
+			executable: runtime.executable,
+			args: buildTtsArgs({
+				model: runtime.model,
+				prompt: job.prompt,
+				outputDir: workDir,
+			}),
+			cwd: runtime.cwd,
+			env: runtime.env,
+		});
+		if (outcome.exitCode !== 0) {
+			const detail = tailMessage({ text: outcome.stderr || outcome.stdout });
+			throw new Error(`tts exited ${outcome.exitCode}: ${detail}`);
+		}
+		const produced = pickGeneratedAudioName({ entries: readdirSync(workDir) });
+		if (!produced) throw new Error("tts produced no mp3");
+		moveFile({ from: join(workDir, produced), to: job.outputFile });
+		return { job, status: "generated" };
+	} catch (error) {
+		return {
+			job,
+			status: "failed",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		if (workDir) rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Render every cue's narration, skipping mp3s that already exist unless forced.
+ * A single failing cue never aborts the batch; it lands in `failed` instead.
+ */
+export async function runVoBatch({
+	plan,
+	jobs,
+	model = DEFAULT_VO_MODEL,
+	concurrency = DEFAULT_VO_CONCURRENCY,
+	force = false,
+	executable,
+	cwd = process.cwd(),
+	tempRoot = tmpdir(),
+	env = process.env,
+	onProgress,
+}: VoBatchOptions): Promise<VoBatchResult> {
+	const runtime: VoJobRuntime = {
+		model,
+		executable: resolveExecutable({
+			override: executable,
+			name: "bun",
+			fallback: process.execPath,
+		}),
+		cwd,
+		tempRoot,
+		force,
+		env,
+	};
+	const outcomes = await runWithConcurrency<VoJob, VoJobOutcome>({
+		items: jobs ?? planVoJobs({ plan }),
+		limit: concurrency,
+		worker: async (job) => {
+			const outcome = await runVoJob({ job, runtime });
+			onProgress?.(outcome);
+			return outcome;
+		},
+	});
+
+	const result: VoBatchResult = { generated: [], skipped: [], failed: [] };
+	for (const outcome of outcomes) {
+		if (outcome.status === "generated") result.generated.push(outcome.job);
+		else if (outcome.status === "skipped") result.skipped.push(outcome.job);
+		else {
+			result.failed.push({
+				cueId: outcome.job.cueId,
+				outputFile: outcome.job.outputFile,
+				error: outcome.error ?? "unknown error",
+			});
+		}
+	}
+	return result;
+}

--- a/qcut/.claude/skills/qcut-toolkit/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/SKILL.md
@@ -37,6 +37,20 @@ Handles:
 - Separate background and subtitle verification frames
 - Safe resume based on artifact dependency timestamps
 
+### 2b. qcut-cityfilm — Reference-Driven City / Promo Films
+**When:** Reproducing the structure and feel of a reference city, travel, or promo film with your own or licensed footage, including multi-language narration
+**Invoke:** `/qcut-cityfilm`
+**Skill path:** `.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md`
+
+Handles:
+- Reference breakdown: contact sheets, transcript, and scene-cut pacing profile
+- Shot-language inventory turned into licensed-footage search queries with attribution manifest
+- Segment picking against per-act target shot lengths
+- Per-act emotional narration through Seed Audio, one pass per language
+- QCut project assembly (import, timeline, subtitles, export) via the editor CLI
+- Final audio bed mixed outside the editor: ambience, segmented music, ducked narration
+- Level and frame verification of the exported file, not just the timeline
+
 ### 3. ffmpeg-skill — Media Processing
 **When:** Converting, compressing, trimming, resizing, extracting audio, adding subtitles, creating GIFs, applying effects
 **Invoke:** `/ffmpeg-skill`
@@ -128,6 +142,7 @@ When the user's request involves multiple sub-skills, chain them in this order:
 |-----------|----------|
 | "organize", "set up project", "clean up files" | native-cli |
 | "vlog", "talking head", "剪口播", "去口头词", "去停顿", "人像滤镜", "美颜", "口播字幕", "抠像换背景" | qcut-vlog |
+| "复刻宣传片", "城市宣传片", "参考片拆解", "city film", "travel promo", "reference-driven edit", "多语言配音成片" | qcut-cityfilm |
 | "convert", "compress", "trim", "resize", "extract audio", "gif", "subtitle" | ffmpeg-skill |
 | "generate image", "generate video", "avatar", "lipsync", "transcribe", "analyze video", "AI pipeline" | ai-content-pipeline |
 | "add to timeline", "update project settings", "list media", "export preset", "configure for TikTok" | native-cli |

--- a/qcut/.claude/skills/qcut-toolkit/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: [task description]
 
 # QCut Toolkit
 
-Unified entry point for QCut's eight sub-skills. Route tasks to the appropriate sub-skill based on what the user needs.
+Unified entry point for QCut's sub-skills. Route tasks to the appropriate sub-skill based on what the user needs.
 
 ## Sub-Skills
 
@@ -37,7 +37,7 @@ Handles:
 - Separate background and subtitle verification frames
 - Safe resume based on artifact dependency timestamps
 
-### 2b. qcut-cityfilm — Reference-Driven City / Promo Films
+### 3. qcut-cityfilm — Reference-Driven City / Promo Films
 **When:** Reproducing the structure and feel of a reference city, travel, or promo film with your own or licensed footage, including multi-language narration
 **Invoke:** `/qcut-cityfilm`
 **Skill path:** `.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md`
@@ -51,7 +51,7 @@ Handles:
 - Final audio bed mixed outside the editor: ambience, segmented music, ducked narration
 - Level and frame verification of the exported file, not just the timeline
 
-### 3. ffmpeg-skill — Media Processing
+### 4. ffmpeg-skill — Media Processing
 **When:** Converting, compressing, trimming, resizing, extracting audio, adding subtitles, creating GIFs, applying effects
 **Invoke:** `/ffmpeg-skill`
 **Skill path:** `.claude/skills/qcut-toolkit/ffmpeg-skill/SKILL.md`
@@ -63,7 +63,7 @@ Handles:
 - GIF creation, speed changes, merging/concatenation
 - Streaming (HLS, DASH, RTMP) and complex filtergraphs
 
-### 4. ai-content-pipeline — AI Content Generation & Analysis
+### 5. ai-content-pipeline — AI Content Generation & Analysis
 **When:** Generating images/videos/avatars, transcribing audio, analyzing video, running AI pipelines
 **Invoke:** `/ai-content-pipeline`
 **Skill path:** `.claude/skills/qcut-toolkit/ai-content-pipeline/SKILL.md`
@@ -77,7 +77,7 @@ Handles:
 - YAML pipeline orchestration with parallel execution
 - Motion transfer between images and videos
 
-### 5. seedance — Video Prompt Engineering
+### 6. seedance — Video Prompt Engineering
 **When:** Writing video prompts, Seedance/即梦 workflows, AI video prompt generation, video descriptions (Chinese or English)
 **Invoke:** `/seedance`
 **Skill path:** `.claude/skills/qcut-toolkit/seedance/SKILL.md`
@@ -88,7 +88,7 @@ Handles:
 - Short drama (短剧), advertising video, and cinematic prompt templates
 - Prompt engineering best practices for ByteDance video models
 
-### 6. qcut-mcp-preview-test — MCP Preview Testing
+### 7. qcut-mcp-preview-test — MCP Preview Testing
 **When:** Testing MCP app preview, toggling "MCP Media App" mode, debugging iframe rendering, troubleshooting `mcp:app-html` events or `/api/claude/mcp/app`
 **Invoke:** `/qcut-mcp-preview-test`
 **Skill path:** `.claude/skills/qcut-toolkit/qcut-mcp-preview-test/SKILL.md`
@@ -99,7 +99,7 @@ Handles:
 - Debugging IPC (`mcp:app-html`) and HTTP (`/api/claude/mcp/app`) delivery
 - Crafting prompts that modify MCP media app UI safely
 
-### 7. ipad-cli — Real iPad & Simulator Automation
+### 8. ipad-cli — Real iPad & Simulator Automation
 **When:** Installing on iPad, testing on iPad, taking iPad screenshots, running E2E device tests, sending CLI commands to the iPad app
 **Invoke:** `/ipad-cli`
 **Skill path:** `.claude/skills/qcut-toolkit/ipad-cli/SKILL.md`
@@ -111,7 +111,7 @@ Handles:
 - E2E testing: navigate to editor, trigger exports, check state, FPS benchmarks
 - Managing pymobiledevice3 tunnels for advanced device access
 
-### 8. pr-comments — PR Review Processing
+### 9. pr-comments — PR Review Processing
 **When:** Exporting PR comments, evaluating code reviews, fixing review feedback from CodeRabbit/Gemini bots
 **Invoke:** `/pr-comments`
 **Skill path:** `.claude/skills/pr-comments/SKILL.md`

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -40,7 +40,7 @@ bun "$CITYFILM_ROOT/scripts/main.ts" analyze /path/to/reference.mp4 \
 # Stage 6 — narrate a plan (one language at a time)
 bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan /path/to/work/plan-zh.json
 
-# Stage 8 — mix the exported picture with music and narration
+# Stage 7 — mix the exported picture with music and narration
 bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan /path/to/work/plan-zh.json \
   --video /path/to/work/export.mp4 \
   --output /path/to/work/final-zh.mp4

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -186,8 +186,38 @@ qcut gen tts -m seed_audio -o <dir> \
   not translations of the Chinese ones.
 - Check each cue's VO against its slot (`checkCueFit`) and shorten the line
   rather than speeding up the read.
-- Seed Audio also accepts reference audio for voice cloning and `speed`/`pitch`
-  when a specific voice is required.
+
+### Keeping one voice across the cut
+
+Seed Audio picks a **fresh speaker on every request** — a cut narrated cue by
+cue sounds like several different people. There is no seed parameter and no
+documented preset voice list, so the voice is pinned with a reference clip:
+
+1. Render one cue on its own; keep the hosted `audioUrl` it returns.
+2. Pass that URL as `audio_urls[0]` (`--audio-url`) for every other cue **and**
+   name it in the prompt as `@Audio1`. The reference is ignored unless the
+   prompt references it — this is the part that is easy to miss.
+
+`runVoBatch` does this automatically (`lockVoice`, on by default) and returns
+the anchor as `voiceAnchorUrl`; persist it into the plan so later re-renders
+and other languages reuse the same speaker.
+
+```bash
+qcut gen tts -m seed_audio --audio-url "<anchor-url>" -o <dir> \
+  -t "@Audio1 (用温柔怀旧的语气)有些街道,一别就是三年。"
+```
+
+Measured on three renders of one line (long-term average spectrum similarity,
+1.0 = identical timbre):
+
+| Method | Take-to-take similarity |
+|---|---|
+| Plain prompt | 0.84 |
+| `--audio-url` only, no tag | 0.91 |
+| `--audio-url` + `@Audio1` | **0.95** |
+
+Reference clips are capped at 30s / 10MB, and up to three can be supplied
+(`@Audio1`…`@Audio3`) when a film needs more than one narrator.
 
 ## Stage 7 — Mix The Audio Bed
 

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: qcut-cityfilm
+description: Reproduce the look and structure of a reference city/travel promo film with your own or licensed footage — analyze the reference, gather clips, pick segments, write per-act copy, narrate it with emotional TTS, assemble the timeline in QCut, and mix the final audio bed. Use for 复刻宣传片, 城市宣传片, 旅行 vlog 剪辑, city film, travel promo, reference-driven edit, 参考片拆解, 素材复刻, 多语言配音成片, or turning a reference video into a repeatable edit plan.
+---
+
+# QCut City Film
+
+Turn a reference film into a plan, then build your own cut from that plan. The
+workflow is reference → plan → assets → assembly → mix → proof. Every stage
+writes an artifact, so a later stage can be rerun without redoing the earlier
+ones.
+
+## Required Order
+
+```text
+reference film
+  -> contact sheets + transcript + scene-cut pacing   (understand it)
+  -> BREAKDOWN.md: acts, pacing, shot language, style  (write it down)
+  -> shot-type queries -> licensed footage + MANIFEST  (gather)
+  -> per-clip segment picks with in/out points         (choose)
+  -> SHOTPLAN.md: act timing, copy, music placement    (plan the cut)
+  -> emotional VO per cue, per language                (narrate)
+  -> QCut project: import, timeline, subtitles, export (assemble)
+  -> ffmpeg audio bed: ambience + music + VO + duck    (mix)
+  -> measured levels + extracted frames                (prove)
+```
+
+Never skip the proof stage. A timeline that looks correct in the editor can
+still export silent — see [Verification](#verification).
+
+## Run
+
+```bash
+export CITYFILM_ROOT=".agents/skills/qcut-toolkit/qcut-cityfilm"
+
+# Stage 1 — understand a reference film
+bun "$CITYFILM_ROOT/scripts/main.ts" analyze /path/to/reference.mp4 \
+  --output-dir /path/to/work/analysis
+
+# Stage 6 — narrate a plan (one language at a time)
+bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan /path/to/work/plan-zh.json
+
+# Stage 8 — mix the exported picture with music and narration
+bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan /path/to/work/plan-zh.json \
+  --video /path/to/work/export.mp4 \
+  --output /path/to/work/final-zh.mp4
+```
+
+Use `npx -y bun@1.3.10` when Bun is not installed globally. The runner resolves
+this repository's `bun run pipeline` first, then `qcut` from `PATH`, and
+prefers QCut's staged FFmpeg binaries.
+
+## Stage 1 — Understand The Reference
+
+Watch the whole film cheaply, then measure it.
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" analyze reference.mp4 -o analysis
+qcut analyze transcribe -i analysis/audio.mp3 -m scribe_v2 --srt -o analysis
+```
+
+`analyze` writes 5×5 contact sheets, `scene-cuts.txt`, `analysis.json`, and the
+extracted `audio.mp3`. **Read every sheet image** — that is how the structure is
+recovered. Tile `k` of sheet `n` maps to `((n-1)*25 + k) * duration/frames`
+seconds.
+
+Rules that matter here:
+
+- FAL's speech-to-text rejects video containers; always transcribe the
+  extracted MP3, never the source video.
+- QCut's staged FFmpeg has no `drawtext` filter — do not try to burn timestamps
+  into the sheets; compute them.
+- Scene detection at `gt(scene,0.30)` is a good default for cut-heavy promos.
+
+Write `BREAKDOWN.md` with: an act table (time range, content, purpose), the
+per-minute cut counts, the shot-language inventory (which *types* of shots the
+film uses — establishing aerials, walking POV, detail macros, portraits,
+transport, night neon…), the grade and subtitle style, and the copy's
+emotional arc. That inventory becomes the shopping list for stage 2.
+
+## Stage 2 — Gather Licensed Footage
+
+One search query per shot type from the inventory. On YouTube, append
+`&sp=EgIwAQ%253D%253D` to filter to Creative Commons, then **verify each
+candidate** — the filter is not trustworthy on its own:
+
+```bash
+yt-dlp "https://www.youtube.com/results?search_query=<q>&sp=EgIwAQ%253D%253D" \
+  --flat-playlist -I 1:6 --print "%(id)s | %(duration)s | %(title)s"
+
+yt-dlp --print "%(id)s | %(license)s | %(uploader)s" -- <video-id>
+```
+
+Keep only `Creative Commons Attribution license (reuse allowed)`. Download
+capped at 1080p, and take only the useful stretch of long walking tours:
+
+```bash
+yt-dlp -f "bv*[height<=1080]+ba/b[height<=1080]/b" -S "res:1080,vcodec:h264" \
+  --merge-output-format mp4 --download-sections "*00:00:00-00:03:00" \
+  -o "<dir>/%(id)s - %(title).50s.%(ext)s" -- <video-id>
+```
+
+Write `MANIFEST.md` with folder, id, **uploader, and URL** for every clip plus
+every music track. CC-BY requires attribution in the finished piece; the
+manifest is what you paste into the credits. Also record which shots the stock
+footage *cannot* cover (pieces to camera, product macros, candid portraits of
+identifiable people) so the gap is explicit.
+
+## Stage 3 — Pick Segments
+
+Build a contact sheet per clip and choose in/out points against the act's
+target shot length. Selection rules, learned from a real pass:
+
+- Never include channel intros, title cards, watermark-heavy moments, or a
+  presenter talking to camera.
+- Prefer steady motion, good light, clean composition.
+- Avoid close-ups of identifiable children.
+- Round to 0.5s; keep every pick inside the clip's real duration.
+
+Store picks as `SegmentPick[]` (see `scripts/types.ts`). With many categories,
+fan this out — one agent per category folder, each returning its picks as JSON.
+
+## Stage 4 — Plan The Cut
+
+`SHOTPLAN.md` plus a machine-readable `plan-<lang>.json` (`CityFilmPlan`).
+
+Pacing is the thing being copied. Derive it from the reference's per-minute cut
+counts, e.g. a montage act at 1.2–1.5s per shot, dialogue/observation acts at
+2–2.5s, the emotional act at 3–4s, and the closing card held long.
+
+Copy rules:
+
+- Write **original** lines. Copy the narrative arc (return → immersion →
+  fatigue → healing → resolve), never the reference's sentences.
+- One idea per cue; keep cues inside their act.
+- Give every act an `emotion` directive in the copy's own language — it is fed
+  verbatim to the TTS model.
+
+## Stage 5 — Assemble In QCut
+
+```bash
+qcut editor:project:create --new-name "<name>" --json
+qcut editor:project:update-settings --project-id <p> --data '{"fps":25,"width":1920,"height":1080}'
+qcut editor:media:batch-import --project-id <p> --items @imports.json --json
+qcut editor:timeline:import --project-id <p> --data @timeline.json --replace --json
+qcut editor:export:start --project-id <p> --data '{"width":1920,"height":1080,"fps":25,"format":"mp4"}' \
+  --output-dir <dir> --poll --timeout 900 --json
+```
+
+Build `timeline.json` from the plan: media elements laid end to end with
+`trimStart`/`trimEnd` derived from each pick, one text element per cue, and a
+black tail clip so the closing card has picture under it.
+
+Editor facts that cost time when unknown:
+
+| Fact | Consequence |
+|---|---|
+| Text `x`/`y` are canvas **pixels offset from center**, not fractions | `y: 0.87` puts the subtitle at the middle; use `y: 380` on a 1080p canvas |
+| CJK and Latin need different sizing | Latin copy wants ~0.8× the font size and ~0.4× the letter spacing of the CJK cut |
+| `timeline:import` drops `transitions` | Plan hard cuts; add fades as elements or in the mix |
+| Export ends at the last **picture** element | A text-only tail is truncated — hold a black clip under the closing card |
+| `batch-import` does not notify the renderer per item | Re-check the store before assuming media resolved; import stragglers individually |
+| Elements resolve by `sourceName` | Import first, then import the timeline, or elements land on the wrong track |
+
+Verify the timeline before exporting:
+
+```bash
+qcut editor:timeline:export --project-id <p> --json   # element count, track types
+qcut editor:state:snapshot --project-id <p> --json     # what the renderer actually holds
+```
+
+## Stage 6 — Narrate With Emotion
+
+ByteDance Seed Audio takes a parenthesised directive in front of the line. The
+difference between a flat read and a directed one is large — always direct it.
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" vo --plan plan-zh.json
+# equivalent single call:
+qcut gen tts -m seed_audio -o <dir> \
+  -t "(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。"
+```
+
+- One directive per act, written in the copy's language.
+- Generate each language separately; English lines need their own directives,
+  not translations of the Chinese ones.
+- Check each cue's VO against its slot (`checkCueFit`) and shorten the line
+  rather than speeding up the read.
+- Seed Audio also accepts reference audio for voice cloning and `speed`/`pitch`
+  when a specific voice is required.
+
+## Stage 7 — Mix The Audio Bed
+
+QCut's export currently drops CLI-imported audio from its mix, so the exported
+picture supplies ambience only and the bed is assembled afterwards:
+
+```bash
+bun "$CITYFILM_ROOT/scripts/main.ts" mix --plan plan-zh.json \
+  --video export.mp4 --output final-zh.mp4
+```
+
+The graph: ambience held low, music segmented per act with fades, each VO cue
+delayed to its cue time, then the music+ambience bus ducked under a copy of the
+VO bus via `sidechaincompress`, limited, and muxed with `-c:v copy`.
+
+Two failure modes to respect: every declared filter label must be consumed or
+FFmpeg aborts, and music cues that do not cover the timeline shorten the bed
+unless the gaps are padded. `buildMixGraph` enforces both.
+
+## Verification
+
+Report a cut only after all four checks:
+
+1. `ffprobe` duration matches the plan within 0.25s.
+2. `volumedetect` over several windows — opening, a montage act, the emotional
+   act, and the closing card — all show speech/music level, not −91 dB.
+3. Extract frames at the title card, one mid-film subtitle, and the closing
+   card, and **look at them**: correct language, no clipping, readable size.
+4. The manifest's attribution list is present wherever the film will be
+   published.
+
+Check the exported file, never the timeline alone. A project whose timeline
+contains music can still export silence.
+
+## Output Contract
+
+```text
+<work-dir>/
+├── analysis/
+│   ├── sheet_01..NN.jpg
+│   ├── scene-cuts.txt
+│   ├── analysis.json
+│   ├── audio.mp3
+│   └── transcription.srt
+├── BREAKDOWN.md
+├── assets/
+│   ├── <shot-type folders>/*.mp4
+│   ├── music/*.mp3
+│   ├── vo/vo-<lang>-<cueId>.mp3
+│   └── MANIFEST.md
+├── SHOTPLAN.md
+├── plan-<lang>.json
+├── timeline-<lang>.json
+└── out/
+    ├── export-<lang>.mp4        # picture from QCut, ambience only
+    ├── final-<lang>.mp4         # after the mix — the deliverable
+    └── frames/*.jpg
+```
+
+## Notes
+
+- Keep the reference film out of the deliverable. This skill copies structure,
+  pacing, and treatment — not footage, not copy.
+- Attribution is not optional for CC-BY material.
+- When the same cut ships in several languages, share the picture export and
+  vary only subtitles and VO — but re-verify levels per language, since VO
+  lengths differ.

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	tileTimestamp,
+} from "./analyze-graph";
+
+describe("qcut-cityfilm contact sheets", () => {
+	test("samples the whole film into evenly tiled sheets", () => {
+		expect(
+			buildContactSheetArgs({
+				input: "/films/melbourne.mp4",
+				durationSeconds: 154.2,
+				frames: 40,
+				columns: 5,
+				rows: 4,
+				outputPattern: "/out/sheet_%02d.jpg",
+			})
+		).toEqual([
+			"-y",
+			"-i",
+			"/films/melbourne.mp4",
+			"-vf",
+			"fps=40/154.2,scale=384:-2,tile=5x4",
+			"-q:v",
+			"2",
+			"/out/sheet_%02d.jpg",
+		]);
+	});
+
+	test("never burns in timestamps, because the staged build lacks drawtext", () => {
+		const args = buildContactSheetArgs({
+			input: "in.mp4",
+			durationSeconds: 60,
+			frames: 4,
+			columns: 2,
+			rows: 2,
+			outputPattern: "sheet_%02d.jpg",
+		});
+		expect(args.join(" ")).not.toContain("drawtext");
+	});
+
+	test("rejects layouts that would pad the trailing sheet", () => {
+		expect(() =>
+			buildContactSheetArgs({
+				input: "in.mp4",
+				durationSeconds: 60,
+				frames: 30,
+				columns: 5,
+				rows: 4,
+				outputPattern: "sheet_%02d.jpg",
+			})
+		).toThrow("must be a multiple of columns x rows");
+		expect(() =>
+			buildContactSheetArgs({
+				input: "in.mp4",
+				durationSeconds: 0,
+				frames: 4,
+				columns: 2,
+				rows: 2,
+				outputPattern: "sheet_%02d.jpg",
+			})
+		).toThrow("durationSeconds must be a positive number");
+	});
+});
+
+describe("qcut-cityfilm tile timestamps", () => {
+	test("maps tile index onto the fps sampling grid", () => {
+		expect(tileTimestamp({ index: 0, frames: 40, durationSeconds: 200 })).toBe(
+			0
+		);
+		expect(tileTimestamp({ index: 1, frames: 40, durationSeconds: 200 })).toBe(
+			5
+		);
+		expect(tileTimestamp({ index: 39, frames: 40, durationSeconds: 200 })).toBe(
+			195
+		);
+	});
+
+	test("lists every tile in reading order", () => {
+		expect(buildTileTimestamps({ frames: 4, durationSeconds: 120 })).toEqual([
+			0, 30, 60, 90,
+		]);
+	});
+
+	test("rejects indexes outside the sheet", () => {
+		expect(() =>
+			tileTimestamp({ index: -1, frames: 4, durationSeconds: 120 })
+		).toThrow("non-negative integer");
+		expect(() =>
+			tileTimestamp({ index: 4, frames: 4, durationSeconds: 120 })
+		).toThrow("must be below frames");
+	});
+});
+
+describe("qcut-cityfilm scene detection", () => {
+	test("quotes the select expression and the metadata path", () => {
+		expect(
+			buildSceneDetectArgs({
+				input: "/films/melbourne.mp4",
+				threshold: 0.4,
+				metadataFile: "/out/scenes.txt",
+			})
+		).toEqual([
+			"-i",
+			"/films/melbourne.mp4",
+			"-vf",
+			"scale=480:-2,select='gt(scene,0.4)',metadata=print:file='/out/scenes.txt'",
+			"-an",
+			"-f",
+			"null",
+			"-",
+		]);
+	});
+
+	test("escapes drive letters and backslashes in the metadata path", () => {
+		const args = buildSceneDetectArgs({
+			input: "in.mp4",
+			threshold: 0.3,
+			metadataFile: "C:\\out\\scenes.txt",
+		});
+		expect(args[3]).toContain("file='C:\\\\out\\\\scenes.txt'");
+	});
+
+	test("rejects thresholds outside the scene-score range", () => {
+		expect(() =>
+			buildSceneDetectArgs({
+				input: "in.mp4",
+				threshold: 0,
+				metadataFile: "scenes.txt",
+			})
+		).toThrow("threshold must be between 0 and 1");
+		expect(() =>
+			buildSceneDetectArgs({
+				input: "in.mp4",
+				threshold: 1,
+				metadataFile: "scenes.txt",
+			})
+		).toThrow("threshold must be between 0 and 1");
+	});
+});
+
+describe("qcut-cityfilm pacing", () => {
+	const metadataText = [
+		"frame:0    pts:0       pts_time:5",
+		"lavfi.scene_score=0.512000",
+		"frame:1    pts:720000  pts_time:30.5",
+		"lavfi.scene_score=0.641000",
+		"frame:2    pts:1560000 pts_time:65.25",
+		"lavfi.scene_score=0.470100",
+		"frame:3    pts:3000000 pts_time:125",
+		"lavfi.scene_score=0.882000",
+	].join("\n");
+
+	test("buckets cuts per minute and averages shot length", () => {
+		expect(parsePacing({ metadataText, durationSeconds: 130 })).toEqual({
+			durationSeconds: 130,
+			cutCount: 4,
+			cutsPerMinute: [2, 1, 1],
+			averageShotSeconds: 32.5,
+		});
+	});
+
+	test("treats an empty or garbage metadata file as zero cuts", () => {
+		expect(parsePacing({ metadataText: "", durationSeconds: 90 })).toEqual({
+			durationSeconds: 90,
+			cutCount: 0,
+			cutsPerMinute: [0, 0],
+			averageShotSeconds: 90,
+		});
+		expect(
+			parsePacing({
+				metadataText: "\u0000\u0001 not metadata\nlavfi.scene_score=0.9\n",
+				durationSeconds: 45,
+			})
+		).toEqual({
+			durationSeconds: 45,
+			cutCount: 0,
+			cutsPerMinute: [0],
+			averageShotSeconds: 45,
+		});
+	});
+
+	test("widens the histogram when cuts land past the reported duration", () => {
+		const profile = parsePacing({
+			metadataText: "pts_time:130.5",
+			durationSeconds: 60,
+		});
+		expect(profile.cutsPerMinute).toEqual([0, 0, 1]);
+		expect(profile.cutCount).toBe(1);
+	});
+});
+
+describe("qcut-cityfilm audio extraction", () => {
+	test("strips video because speech-to-text rejects video containers", () => {
+		expect(
+			extractAudioArgs({
+				input: "/films/melbourne.mp4",
+				output: "/out/melbourne-audio.mp3",
+			})
+		).toEqual([
+			"-y",
+			"-i",
+			"/films/melbourne.mp4",
+			"-vn",
+			"-acodec",
+			"libmp3lame",
+			"-q:a",
+			"4",
+			"/out/melbourne-audio.mp3",
+		]);
+	});
+});
+
+describe("qcut-cityfilm probe arguments", () => {
+	test("asks ffprobe only for the fields the profile needs", () => {
+		expect(buildProbeArgs({ input: "/films/melbourne.mp4" })).toEqual([
+			"-v",
+			"error",
+			"-of",
+			"json",
+			"-show_entries",
+			"format=duration:stream=codec_type,width,height,avg_frame_rate,r_frame_rate",
+			"/films/melbourne.mp4",
+		]);
+	});
+});
+
+describe("qcut-cityfilm probe parsing", () => {
+	test("reads shape, rate and audio presence from ffprobe JSON", () => {
+		const stdout = JSON.stringify({
+			streams: [
+				{
+					codec_type: "video",
+					width: 3840,
+					height: 2160,
+					avg_frame_rate: "30000/1001",
+					r_frame_rate: "30000/1001",
+				},
+				{ codec_type: "audio" },
+			],
+			format: { duration: "154.234000" },
+		});
+		const probe = parseProbeJson({ stdout });
+		expect(probe.width).toBe(3840);
+		expect(probe.height).toBe(2160);
+		expect(probe.hasAudio).toBe(true);
+		expect(probe.durationSeconds).toBeCloseTo(154.234, 3);
+		expect(probe.fps).toBeCloseTo(29.97, 2);
+	});
+
+	test("falls back to r_frame_rate and reports silent sources", () => {
+		const probe = parseProbeJson({
+			stdout: JSON.stringify({
+				streams: [
+					{
+						codec_type: "video",
+						width: 1920,
+						height: 1080,
+						avg_frame_rate: "0/0",
+						r_frame_rate: "25/1",
+					},
+				],
+				format: { duration: "10" },
+			}),
+		});
+		expect(probe.fps).toBe(25);
+		expect(probe.hasAudio).toBe(false);
+	});
+
+	test("fails loudly on unusable ffprobe output", () => {
+		expect(() => parseProbeJson({ stdout: "not json" })).toThrow(
+			"did not return JSON"
+		);
+		expect(() =>
+			parseProbeJson({ stdout: JSON.stringify({ streams: [] }) })
+		).toThrow("No video stream found");
+		expect(() =>
+			parseProbeJson({
+				stdout: JSON.stringify({
+					streams: [{ codec_type: "video" }],
+					format: { duration: "N/A" },
+				}),
+			})
+		).toThrow("Could not determine duration");
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze-graph.ts
@@ -1,0 +1,311 @@
+/**
+ * Pure FFmpeg/FFprobe argument builders and output parsers for reference-film
+ * analysis. Nothing here touches the filesystem or spawns a process, so the
+ * graphs can be asserted in unit tests; `analyze.ts` owns the execution.
+ */
+
+import type { PacingProfile } from "./types";
+
+/** Shape of the reference film, as reported by ffprobe. */
+export interface VideoProbe {
+	durationSeconds: number;
+	width: number;
+	height: number;
+	fps: number;
+	hasAudio: boolean;
+}
+
+function requirePositive({
+	value,
+	name,
+}: {
+	value: number;
+	name: string;
+}): number {
+	if (!Number.isFinite(value) || value <= 0) {
+		throw new Error(`${name} must be a positive number`);
+	}
+	return value;
+}
+
+function requirePositiveInteger({
+	value,
+	name,
+}: {
+	value: number;
+	name: string;
+}): number {
+	requirePositive({ value, name });
+	if (!Number.isInteger(value)) {
+		throw new Error(`${name} must be an integer`);
+	}
+	return value;
+}
+
+/** Render a number for a filter string without exponent notation. */
+function formatNumber({ value }: { value: number }): string {
+	return String(Number(value.toFixed(6)));
+}
+
+/**
+ * Quote a value for an FFmpeg filter option so `:` and `,` inside paths are
+ * not read as option or filter separators.
+ */
+function quoteFilterValue({ value }: { value: string }): string {
+	return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Build the contact-sheet command.
+ *
+ * `fps=<frames>/<duration>` samples exactly `frames` stills across the film and
+ * `tile` packs them `columns x rows` per sheet, so `frames` must divide evenly
+ * into a whole number of sheets — otherwise the trailing sheet is padded and
+ * tile indexes stop lining up with {@link tileTimestamp}.
+ *
+ * Timestamps are deliberately NOT burned in: the staged FFmpeg build in this
+ * repo ships without the `drawtext` filter. Use {@link buildTileTimestamps} to
+ * label the tiles instead.
+ */
+export function buildContactSheetArgs({
+	input,
+	durationSeconds,
+	frames,
+	columns,
+	rows,
+	outputPattern,
+}: {
+	input: string;
+	durationSeconds: number;
+	frames: number;
+	columns: number;
+	rows: number;
+	outputPattern: string;
+}): string[] {
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	requirePositiveInteger({ value: frames, name: "frames" });
+	requirePositiveInteger({ value: columns, name: "columns" });
+	requirePositiveInteger({ value: rows, name: "rows" });
+	const perSheet = columns * rows;
+	if (frames % perSheet !== 0) {
+		throw new Error(
+			`frames (${frames}) must be a multiple of columns x rows (${perSheet})`
+		);
+	}
+	const rate = `${frames}/${formatNumber({ value: durationSeconds })}`;
+	return [
+		"-y",
+		"-i",
+		input,
+		"-vf",
+		`fps=${rate},scale=384:-2,tile=${columns}x${rows}`,
+		"-q:v",
+		"2",
+		outputPattern,
+	];
+}
+
+/**
+ * Timestamp of one contact-sheet tile, in seconds.
+ *
+ * `fps=frames/duration` emits its Nth frame at `N / rate`, so tile `index`
+ * (0-based, counted across every sheet in reading order) shows the film at
+ * `index * durationSeconds / frames`. Tile 0 is the opening frame; the last
+ * tile sits one sampling interval short of the end.
+ *
+ * For a tile inside sheet `s` (1-based) at slot `k` (0-based):
+ * `index = (s - 1) * columns * rows + k`.
+ */
+export function tileTimestamp({
+	index,
+	frames,
+	durationSeconds,
+}: {
+	index: number;
+	frames: number;
+	durationSeconds: number;
+}): number {
+	requirePositiveInteger({ value: frames, name: "frames" });
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	if (!Number.isInteger(index) || index < 0) {
+		throw new Error("index must be a non-negative integer");
+	}
+	if (index >= frames) {
+		throw new Error(`index must be below frames (${frames})`);
+	}
+	return (index * durationSeconds) / frames;
+}
+
+/** Every tile timestamp in reading order. */
+export function buildTileTimestamps({
+	frames,
+	durationSeconds,
+}: {
+	frames: number;
+	durationSeconds: number;
+}): number[] {
+	requirePositiveInteger({ value: frames, name: "frames" });
+	const timestamps: number[] = [];
+	for (let index = 0; index < frames; index += 1) {
+		timestamps.push(tileTimestamp({ index, frames, durationSeconds }));
+	}
+	return timestamps;
+}
+
+/**
+ * Build the scene-detection command.
+ *
+ * The graph downscales first (scene scoring is unchanged at 480px and far
+ * cheaper), keeps frames whose scene score exceeds `threshold`, and dumps one
+ * metadata block per kept frame to `metadataFile`. The single quotes around
+ * `gt(scene,N)` are part of the filter string, not shell quoting: without them
+ * FFmpeg reads the comma as a filter separator.
+ */
+export function buildSceneDetectArgs({
+	input,
+	threshold,
+	metadataFile,
+}: {
+	input: string;
+	threshold: number;
+	metadataFile: string;
+}): string[] {
+	if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
+		throw new Error("threshold must be between 0 and 1");
+	}
+	const scene = formatNumber({ value: threshold });
+	const target = quoteFilterValue({ value: metadataFile });
+	return [
+		"-i",
+		input,
+		"-vf",
+		`scale=480:-2,select='gt(scene,${scene})',metadata=print:file=${target}`,
+		"-an",
+		"-f",
+		"null",
+		"-",
+	];
+}
+
+/**
+ * Extract narration audio as MP3.
+ *
+ * FAL's speech-to-text endpoint rejects video containers, so the audio has to
+ * be pulled out before transcription rather than uploading the film itself.
+ */
+export function extractAudioArgs({
+	input,
+	output,
+}: {
+	input: string;
+	output: string;
+}): string[] {
+	return [
+		"-y",
+		"-i",
+		input,
+		"-vn",
+		"-acodec",
+		"libmp3lame",
+		"-q:a",
+		"4",
+		output,
+	];
+}
+
+/**
+ * Turn `metadata=print` output into a pacing profile.
+ *
+ * Each detected cut prints a `pts_time:<seconds>` line; anything else in the
+ * file is ignored, so an empty or truncated log yields a zero-cut profile
+ * instead of throwing.
+ */
+export function parsePacing({
+	metadataText,
+	durationSeconds,
+}: {
+	metadataText: string;
+	durationSeconds: number;
+}): PacingProfile {
+	requirePositive({ value: durationSeconds, name: "durationSeconds" });
+	const times: number[] = [];
+	for (const match of metadataText.matchAll(/pts_time:\s*(\d+(?:\.\d+)?)/g)) {
+		const seconds = Number(match[1]);
+		if (Number.isFinite(seconds)) times.push(seconds);
+	}
+
+	let minutes = Math.max(1, Math.ceil(durationSeconds / 60));
+	for (const seconds of times) {
+		minutes = Math.max(minutes, Math.floor(seconds / 60) + 1);
+	}
+	const cutsPerMinute = new Array<number>(minutes).fill(0);
+	for (const seconds of times) {
+		cutsPerMinute[Math.floor(seconds / 60)] += 1;
+	}
+
+	return {
+		durationSeconds,
+		cutCount: times.length,
+		cutsPerMinute,
+		averageShotSeconds: durationSeconds / Math.max(1, times.length),
+	};
+}
+
+function parseFrameRate({ value }: { value?: string }): number {
+	if (!value) return 0;
+	const [numerator, denominator] = value.split("/");
+	const top = Number(numerator);
+	const bottom = denominator === undefined ? 1 : Number(denominator);
+	if (!Number.isFinite(top) || !Number.isFinite(bottom) || bottom === 0) {
+		return 0;
+	}
+	const fps = top / bottom;
+	return Number.isFinite(fps) && fps > 0 ? fps : 0;
+}
+
+interface ProbeStream {
+	codec_type?: string;
+	width?: number;
+	height?: number;
+	avg_frame_rate?: string;
+	r_frame_rate?: string;
+}
+
+/** Pure half of `probeVideo`: read ffprobe's JSON into a {@link VideoProbe}. */
+export function parseProbeJson({ stdout }: { stdout: string }): VideoProbe {
+	let parsed: { streams?: ProbeStream[]; format?: { duration?: string } };
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		throw new Error("ffprobe did not return JSON");
+	}
+	const streams = parsed.streams ?? [];
+	const video = streams.find((stream) => stream.codec_type === "video");
+	if (!video) throw new Error("No video stream found");
+	const durationSeconds = Number(parsed.format?.duration);
+	if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+		throw new Error("Could not determine duration");
+	}
+	return {
+		durationSeconds,
+		width: Number(video.width ?? 0),
+		height: Number(video.height ?? 0),
+		fps:
+			parseFrameRate({ value: video.avg_frame_rate }) ||
+			parseFrameRate({ value: video.r_frame_rate }),
+		hasAudio: streams.some((stream) => stream.codec_type === "audio"),
+	};
+}
+
+/** FFprobe argv for {@link parseProbeJson}. */
+export function buildProbeArgs({ input }: { input: string }): string[] {
+	return [
+		"-v",
+		"error",
+		"-of",
+		"json",
+		"-show_entries",
+		"format=duration:stream=codec_type,width,height,avg_frame_rate,r_frame_rate",
+		input,
+	];
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
@@ -1,7 +1,14 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import * as analyze from "./analyze";
 import * as graph from "./analyze-graph";
 import { type CommandRunner, runAnalyze } from "./analyze";
@@ -147,5 +154,54 @@ describe("qcut-cityfilm analyze run", () => {
 				runner: failing,
 			})
 		).rejects.toThrow("Invalid data found");
+	});
+});
+
+describe("stale artifact handling", () => {
+	it("removes sheets and scene metadata from a previous run", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cityfilm-stale-"));
+		const input = join(dir, "ref.mp4");
+		writeFileSync(input, "");
+		const outputDir = join(dir, "analysis");
+		mkdirSync(outputDir, { recursive: true });
+		// Leftovers from a longer previous pass.
+		writeFileSync(join(outputDir, "sheet_01.jpg"), "old");
+		writeFileSync(join(outputDir, "sheet_09.jpg"), "old");
+		writeFileSync(join(outputDir, "scenes.txt"), "pts_time:1.0\n");
+
+		const runner = async ({ args }: { executable: string; args: string[] }) => {
+			if (args.some((arg) => arg.startsWith("format=duration:stream="))) {
+				return {
+					exitCode: 0,
+					stdout: JSON.stringify({
+						format: { duration: "20" },
+						streams: [
+							{
+								codec_type: "video",
+								width: 1920,
+								height: 1080,
+								avg_frame_rate: "25/1",
+							},
+						],
+					}),
+					stderr: "",
+				};
+			}
+			// This pass finds no cuts, so ffmpeg never writes scenes.txt.
+			return { exitCode: 0, stdout: "", stderr: "" };
+		};
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			frames: 20,
+			columns: 5,
+			rows: 4,
+			runner,
+		});
+
+		expect(existsSync(join(outputDir, "sheet_09.jpg"))).toBe(false);
+		expect(result.pacing.cutCount).toBe(0);
+		rmSync(dir, { recursive: true, force: true });
 	});
 });

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import * as analyze from "./analyze";
+import * as graph from "./analyze-graph";
+import { type CommandRunner, runAnalyze } from "./analyze";
+
+describe("qcut-cityfilm analyze surface", () => {
+	test("re-exports every pure helper so callers need one import", () => {
+		for (const name of [
+			"buildContactSheetArgs",
+			"buildProbeArgs",
+			"buildSceneDetectArgs",
+			"buildTileTimestamps",
+			"extractAudioArgs",
+			"parsePacing",
+			"parseProbeJson",
+			"tileTimestamp",
+		] as const) {
+			expect(analyze[name]).toBe(graph[name]);
+		}
+	});
+});
+
+function createFakeRunner({
+	outputDir,
+	hasAudio,
+}: {
+	outputDir: string;
+	hasAudio: boolean;
+}): { calls: string[][]; runner: CommandRunner } {
+	const calls: string[][] = [];
+	const runner: CommandRunner = ({ executable, args }) => {
+		calls.push([executable, ...args]);
+		if (executable.includes("ffprobe")) {
+			return Promise.resolve({
+				exitCode: 0,
+				stderr: "",
+				stdout: JSON.stringify({
+					streams: hasAudio
+						? [
+								{ codec_type: "video", width: 1920, height: 1080 },
+								{ codec_type: "audio" },
+							]
+						: [{ codec_type: "video", width: 1920, height: 1080 }],
+					format: { duration: "120" },
+				}),
+			});
+		}
+		const graph = args[args.indexOf("-vf") + 1] ?? "";
+		if (graph.includes("tile=")) {
+			writeFileSync(join(outputDir, "sheet_01.jpg"), "first");
+			writeFileSync(join(outputDir, "sheet_02.jpg"), "second");
+		} else if (graph.includes("select=")) {
+			writeFileSync(
+				join(outputDir, "scenes.txt"),
+				"pts_time:3.5\nlavfi.scene_score=0.9\npts_time:70\n"
+			);
+		} else {
+			writeFileSync(args[args.length - 1], "audio");
+		}
+		return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+	};
+	return { calls, runner };
+}
+
+describe("qcut-cityfilm analyze run", () => {
+	test("probes, sheets, detects, then extracts audio", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-analyze-"));
+		const input = join(directory, "melbourne.mp4");
+		const outputDir = join(directory, "analysis");
+		writeFileSync(input, "film");
+		const { calls, runner } = createFakeRunner({ outputDir, hasAudio: true });
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			ffmpegPath: "/bin/fake-ffmpeg",
+			ffprobePath: "/bin/fake-ffprobe",
+			runner,
+		});
+
+		expect(calls).toHaveLength(4);
+		expect(calls[0][0]).toBe("/bin/fake-ffprobe");
+		expect(calls.slice(1).every((call) => call[0] === "/bin/fake-ffmpeg")).toBe(
+			true
+		);
+		expect(result.probe.durationSeconds).toBe(120);
+		expect(result.pacing).toEqual({
+			durationSeconds: 120,
+			cutCount: 2,
+			cutsPerMinute: [1, 1],
+			averageShotSeconds: 60,
+		});
+		expect(result.contactSheet.sheets).toEqual([
+			join(outputDir, "sheet_01.jpg"),
+			join(outputDir, "sheet_02.jpg"),
+		]);
+		expect(result.contactSheet.tileTimestamps).toHaveLength(40);
+		expect(result.contactSheet.tileTimestamps[1]).toBe(3);
+		expect(result.audioPath).toBe(join(outputDir, "melbourne-audio.mp3"));
+
+		const written = JSON.parse(readFileSync(result.analysisPath, "utf8"));
+		expect(written.pacing.cutCount).toBe(2);
+		expect(written.audioPath).toBe(result.audioPath);
+		expect(typeof written.generatedAt).toBe("string");
+	});
+
+	test("skips audio extraction for silent sources", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-silent-"));
+		const input = join(directory, "silent.mov");
+		const outputDir = join(directory, "analysis");
+		writeFileSync(input, "film");
+		const { calls, runner } = createFakeRunner({ outputDir, hasAudio: false });
+
+		const result = await runAnalyze({
+			input,
+			outputDir,
+			frames: 8,
+			columns: 4,
+			rows: 2,
+			ffmpegPath: "/bin/fake-ffmpeg",
+			ffprobePath: "/bin/fake-ffprobe",
+			runner,
+		});
+
+		expect(calls).toHaveLength(3);
+		expect(result.audioPath).toBeUndefined();
+		expect(result.contactSheet.frames).toBe(8);
+	});
+
+	test("surfaces the tail of stderr when a tool fails", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "qcut-cityfilm-fail-"));
+		const failing: CommandRunner = () =>
+			Promise.resolve({
+				exitCode: 1,
+				stdout: "",
+				stderr: "line one\nInvalid data found when processing input\n",
+			});
+
+		await expect(
+			runAnalyze({
+				input: join(directory, "broken.mp4"),
+				outputDir: join(directory, "analysis"),
+				ffprobePath: "/bin/fake-ffprobe",
+				runner: failing,
+			})
+		).rejects.toThrow("Invalid data found");
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
@@ -9,7 +9,13 @@
  * re-exported here; this file only orchestrates the child processes.
  */
 
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import {
 	buildContactSheetArgs,
@@ -151,10 +157,30 @@ function listSheets({ outputDir }: { outputDir: string }): string[] {
 function readSceneMetadata({ filePath }: { filePath: string }): string {
 	try {
 		return readFileSync(filePath, "utf8");
-	} catch {
-		// No cut crossed the threshold, so FFmpeg never created the file.
-		return "";
+	} catch (error) {
+		// A missing file means no cut crossed the threshold — FFmpeg only
+		// creates it on a match. Anything else (permissions, I/O) is a real
+		// failure and must not masquerade as "this film has no cuts".
+		if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "";
+		throw error;
 	}
+}
+
+/**
+ * Drop artifacts a previous run left behind so they cannot leak into this
+ * one's results.
+ */
+function clearStaleArtifacts({
+	outputDir,
+	sceneMetadataPath,
+}: {
+	outputDir: string;
+	sceneMetadataPath: string;
+}): void {
+	for (const sheet of listSheets({ outputDir })) {
+		rmSync(sheet, { force: true });
+	}
+	rmSync(sceneMetadataPath, { force: true });
 }
 
 /**
@@ -185,6 +211,13 @@ export async function runAnalyze(
 	const sceneMetadataPath = join(outputDir, "scenes.txt");
 	const analysisPath = join(outputDir, "analysis.json");
 	const audioPath = join(outputDir, `${stem}-audio.mp3`);
+
+	// Re-analysing the same film with different frames/threshold is the normal
+	// tuning loop, and both artifacts survive a rerun that should have replaced
+	// them: extra sheet_NN.jpg from a longer previous pass stay on disk, and a
+	// pass that finds no cuts never rewrites scenes.txt (metadata=print only
+	// fires on a match). Clearing them keeps analysis.json describing this run.
+	clearStaleArtifacts({ outputDir, sceneMetadataPath });
 
 	const probe = await probeVideo({
 		input,

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/analyze.ts
@@ -1,0 +1,256 @@
+/**
+ * Reference-film analysis for the qcut-cityfilm skill.
+ *
+ * Before copying a film's structure you need three things from it: how long it
+ * is and at what shape, what its shots actually look like, and how fast it
+ * cuts. This module produces all three plus a narration-ready audio file.
+ *
+ * Argument building and output parsing live in `analyze-graph.ts` and are
+ * re-exported here; this file only orchestrates the child processes.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	type VideoProbe,
+} from "./analyze-graph";
+import type { PacingProfile } from "./types";
+
+export {
+	buildContactSheetArgs,
+	buildProbeArgs,
+	buildSceneDetectArgs,
+	buildTileTimestamps,
+	extractAudioArgs,
+	parsePacing,
+	parseProbeJson,
+	tileTimestamp,
+} from "./analyze-graph";
+export type { VideoProbe } from "./analyze-graph";
+
+/** Frames sampled across the whole film, spread evenly. */
+const DEFAULT_FRAMES = 40;
+const DEFAULT_COLUMNS = 5;
+const DEFAULT_ROWS = 4;
+/** `select='gt(scene,N)'` threshold that matched hand-counted cuts. */
+const DEFAULT_SCENE_THRESHOLD = 0.4;
+
+export interface CommandOutcome {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Injectable process runner; the default shells out through `Bun.spawn`. */
+export type CommandRunner = (input: {
+	executable: string;
+	args: string[];
+}) => Promise<CommandOutcome>;
+
+export interface AnalyzeOptions {
+	/** Reference film to study. */
+	input: string;
+	/** Where sheets, scene metadata, audio and analysis.json land. */
+	outputDir?: string;
+	frames?: number;
+	columns?: number;
+	rows?: number;
+	sceneThreshold?: number;
+	ffmpegPath?: string;
+	ffprobePath?: string;
+	runner?: CommandRunner;
+}
+
+export interface ContactSheetSummary {
+	frames: number;
+	columns: number;
+	rows: number;
+	/** The `%02d` pattern handed to FFmpeg. */
+	pattern: string;
+	/** Sheets that actually got written, in order. */
+	sheets: string[];
+	/** Timestamp of every tile, left-to-right then sheet-by-sheet. */
+	tileTimestamps: number[];
+}
+
+export interface AnalyzeResult {
+	input: string;
+	outputDir: string;
+	probe: VideoProbe;
+	pacing: PacingProfile;
+	contactSheet: ContactSheetSummary;
+	sceneMetadataPath: string;
+	analysisPath: string;
+	/** Extracted narration audio; absent when the source has no audio stream. */
+	audioPath?: string;
+}
+
+const spawnCapture: CommandRunner = async ({ executable, args }) => {
+	const child = Bun.spawn([executable, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { exitCode: await child.exited, stdout, stderr };
+};
+
+async function runTool({
+	executable,
+	args,
+	runner,
+}: {
+	executable: string;
+	args: string[];
+	runner: CommandRunner;
+}): Promise<CommandOutcome> {
+	const outcome = await runner({ executable, args });
+	if (outcome.exitCode !== 0) {
+		const detail = outcome.stderr.trim().split("\n").slice(-3).join(" | ");
+		throw new Error(
+			`${executable} failed (${outcome.exitCode})${detail ? `: ${detail}` : ""}`
+		);
+	}
+	return outcome;
+}
+
+/** Read the reference film's duration, frame size, rate and audio presence. */
+export async function probeVideo({
+	input,
+	ffprobePath = "ffprobe",
+	runner = spawnCapture,
+}: {
+	input: string;
+	ffprobePath?: string;
+	runner?: CommandRunner;
+}): Promise<VideoProbe> {
+	const outcome = await runTool({
+		executable: ffprobePath,
+		args: buildProbeArgs({ input }),
+		runner,
+	});
+	return parseProbeJson({ stdout: outcome.stdout });
+}
+
+function listSheets({ outputDir }: { outputDir: string }): string[] {
+	return readdirSync(outputDir)
+		.filter((name) => /^sheet_\d+\.jpg$/.test(name))
+		.sort()
+		.map((name) => join(outputDir, name));
+}
+
+function readSceneMetadata({ filePath }: { filePath: string }): string {
+	try {
+		return readFileSync(filePath, "utf8");
+	} catch {
+		// No cut crossed the threshold, so FFmpeg never created the file.
+		return "";
+	}
+}
+
+/**
+ * Probe, sheet, scene-detect, measure pacing and extract audio in one pass,
+ * then write `analysis.json` beside the sheets.
+ *
+ * Transcription is deliberately out of scope: run the CLI the SKILL.md
+ * documents (`qcut analyze transcribe -m scribe_v2 --srt`) against the returned
+ * `audioPath`.
+ */
+export async function runAnalyze(
+	options: AnalyzeOptions
+): Promise<AnalyzeResult> {
+	const input = resolve(options.input);
+	const stem = basename(input, extname(input));
+	const outputDir = options.outputDir
+		? resolve(options.outputDir)
+		: join(dirname(input), `${stem}-analysis`);
+	const frames = options.frames ?? DEFAULT_FRAMES;
+	const columns = options.columns ?? DEFAULT_COLUMNS;
+	const rows = options.rows ?? DEFAULT_ROWS;
+	const threshold = options.sceneThreshold ?? DEFAULT_SCENE_THRESHOLD;
+	const ffmpegPath = options.ffmpegPath ?? "ffmpeg";
+	const runner = options.runner ?? spawnCapture;
+
+	mkdirSync(outputDir, { recursive: true });
+	const pattern = join(outputDir, "sheet_%02d.jpg");
+	const sceneMetadataPath = join(outputDir, "scenes.txt");
+	const analysisPath = join(outputDir, "analysis.json");
+	const audioPath = join(outputDir, `${stem}-audio.mp3`);
+
+	const probe = await probeVideo({
+		input,
+		ffprobePath: options.ffprobePath,
+		runner,
+	});
+
+	await runTool({
+		executable: ffmpegPath,
+		args: buildContactSheetArgs({
+			input,
+			durationSeconds: probe.durationSeconds,
+			frames,
+			columns,
+			rows,
+			outputPattern: pattern,
+		}),
+		runner,
+	});
+
+	await runTool({
+		executable: ffmpegPath,
+		args: buildSceneDetectArgs({
+			input,
+			threshold,
+			metadataFile: sceneMetadataPath,
+		}),
+		runner,
+	});
+
+	const pacing = parsePacing({
+		metadataText: readSceneMetadata({ filePath: sceneMetadataPath }),
+		durationSeconds: probe.durationSeconds,
+	});
+
+	if (probe.hasAudio) {
+		await runTool({
+			executable: ffmpegPath,
+			args: extractAudioArgs({ input, output: audioPath }),
+			runner,
+		});
+	}
+
+	const result: AnalyzeResult = {
+		input,
+		outputDir,
+		probe,
+		pacing,
+		contactSheet: {
+			frames,
+			columns,
+			rows,
+			pattern,
+			sheets: listSheets({ outputDir }),
+			tileTimestamps: buildTileTimestamps({
+				frames,
+				durationSeconds: probe.durationSeconds,
+			}),
+		},
+		sceneMetadataPath,
+		analysisPath,
+		audioPath: probe.hasAudio ? audioPath : undefined,
+	};
+	writeFileSync(
+		analysisPath,
+		`${JSON.stringify({ ...result, generatedAt: new Date().toISOString() }, null, 2)}\n`
+	);
+	return result;
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseArgs, parseWindows } from "./main";
+import { parseArgs, parseWindows, renderHuman } from "./main";
 
 describe("parseArgs", () => {
 	it("splits a command, positionals, and flags", () => {
@@ -56,5 +56,20 @@ describe("parseWindows", () => {
 	it("rejects malformed windows", () => {
 		expect(() => parseWindows({ value: "0:abc" })).toThrow();
 		expect(() => parseWindows({ value: "5:0" })).toThrow();
+	});
+});
+
+describe("renderHuman", () => {
+	it("renders one key per line instead of JSON", () => {
+		const text = renderHuman({
+			payload: { outputPath: "/out/final.mp4", durationSeconds: 101.8 },
+		});
+		expect(text).toBe("outputPath: /out/final.mp4\ndurationSeconds: 101.8");
+	});
+
+	it("summarises arrays by length", () => {
+		expect(renderHuman({ payload: { failed: [1, 2, 3] } })).toBe(
+			"failed: 3 item(s)"
+		);
 	});
 });

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs, parseWindows } from "./main";
+
+describe("parseArgs", () => {
+	it("splits a command, positionals, and flags", () => {
+		const parsed = parseArgs({
+			argv: ["analyze", "ref.mp4", "-o", "out", "--frames", "40"],
+		});
+		expect(parsed.command).toBe("analyze");
+		expect(parsed.positional).toEqual(["ref.mp4"]);
+		expect(parsed.flags.get("output-dir")).toBe("out");
+		expect(parsed.flags.get("frames")).toBe("40");
+	});
+
+	it("treats a flag with no value as boolean", () => {
+		const parsed = parseArgs({
+			argv: ["vo", "--plan", "p.json", "--force", "--json"],
+		});
+		expect(parsed.flags.get("force")).toBe(true);
+		expect(parsed.flags.get("json")).toBe(true);
+		expect(parsed.flags.get("plan")).toBe("p.json");
+	});
+
+	it("accepts --flag=value", () => {
+		const parsed = parseArgs({ argv: ["mix", "--video=a.mp4"] });
+		expect(parsed.flags.get("video")).toBe("a.mp4");
+	});
+
+	it("does not swallow the next flag as a value", () => {
+		const parsed = parseArgs({ argv: ["vo", "--force", "--plan", "p.json"] });
+		expect(parsed.flags.get("force")).toBe(true);
+		expect(parsed.flags.get("plan")).toBe("p.json");
+	});
+
+	it("reports no command when argv starts with a flag", () => {
+		const parsed = parseArgs({ argv: ["--help"] });
+		expect(parsed.command).toBe("");
+		expect(parsed.flags.get("help")).toBe(true);
+	});
+});
+
+describe("parseWindows", () => {
+	it("defaults to an opening and a mid-film window", () => {
+		const windows = parseWindows({});
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({ startSeconds: 0, endSeconds: 5 });
+	});
+
+	it("converts start:length pairs into start/end windows", () => {
+		expect(parseWindows({ value: "0:5,48.4:12" })).toEqual([
+			{ label: "w1", startSeconds: 0, endSeconds: 5 },
+			{ label: "w2", startSeconds: 48.4, endSeconds: 60.4 },
+		]);
+	});
+
+	it("rejects malformed windows", () => {
+		expect(() => parseWindows({ value: "0:abc" })).toThrow();
+		expect(() => parseWindows({ value: "5:0" })).toThrow();
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
@@ -137,12 +137,25 @@ export function parseWindows({ value }: { value?: string }): LevelWindow[] {
 	});
 }
 
+/** `key: value` lines, one per top-level field, for terminal reading. */
+export function renderHuman({ payload }: { payload: unknown }): string {
+	if (payload === null || typeof payload !== "object") return String(payload);
+	return Object.entries(payload as Record<string, unknown>)
+		.map(([key, value]) => {
+			if (Array.isArray(value)) return `${key}: ${value.length} item(s)`;
+			if (value !== null && typeof value === "object") {
+				return `${key}: ${JSON.stringify(value)}`;
+			}
+			return `${key}: ${String(value)}`;
+		})
+		.join("\n");
+}
+
 function emit({ json, payload }: { json: boolean; payload: unknown }): void {
-	if (json) {
-		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-		return;
-	}
-	process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+	const text = json
+		? JSON.stringify(payload, null, 2)
+		: renderHuman({ payload });
+	process.stdout.write(`${text}\n`);
 }
 
 async function main(): Promise<void> {

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/main.ts
@@ -1,0 +1,223 @@
+/**
+ * qcut-cityfilm CLI dispatcher.
+ *
+ * Subcommands mirror the stages in SKILL.md that are mechanical enough to
+ * automate: understanding a reference film, narrating a plan, mixing the
+ * final audio bed, and proving the result.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { runAnalyze } from "./analyze";
+import { type LevelWindow, measureLevels, runMix } from "./mix";
+import type { CityFilmPlan } from "./types";
+import { runVoBatch } from "./vo";
+
+const USAGE = `qcut-cityfilm — reference-driven city film workflow
+
+Usage:
+  main.ts analyze <reference-video> [-o <dir>] [--frames N] [--scene-threshold N]
+  main.ts vo --plan <plan.json> [--concurrency N] [--force] [--model <key>]
+  main.ts mix --plan <plan.json> --video <export.mp4> --output <final.mp4>
+  main.ts verify --video <final.mp4> [--windows "0:5,30:5,60:5"]
+
+Options:
+  -o, --output-dir <dir>   Where artifacts are written
+      --frames <n>         Contact-sheet frames (must fill whole sheets)
+      --scene-threshold <n> Scene-cut sensitivity (default 0.4)
+      --plan <file>        CityFilmPlan JSON
+      --video <file>       Picture exported from QCut
+      --output <file>      Mixed deliverable
+      --concurrency <n>    Parallel TTS jobs (default 4)
+      --force              Re-render VO that already exists
+      --json               Machine-readable result
+  -h, --help               Show this help
+`;
+
+interface ParsedArgs {
+	command: string;
+	positional: string[];
+	flags: Map<string, string | boolean>;
+}
+
+/** Splits argv into a command, positionals, and `--flag[=value]` pairs. */
+export function parseArgs({ argv }: { argv: string[] }): ParsedArgs {
+	// A leading flag (`--help`, `--json`) means no subcommand was given.
+	const hasCommand = argv.length > 0 && !argv[0].startsWith("-");
+	const command = hasCommand ? argv[0] : "";
+	const rest = hasCommand ? argv.slice(1) : argv;
+	const positional: string[] = [];
+	const flags = new Map<string, string | boolean>();
+	const aliases: Record<string, string> = {
+		"-o": "output-dir",
+		"-h": "help",
+	};
+
+	for (let index = 0; index < rest.length; index++) {
+		const token = rest[index];
+		if (!token.startsWith("-")) {
+			positional.push(token);
+			continue;
+		}
+		const normalized = aliases[token] ?? token.replace(/^--?/, "");
+		const [name, inlineValue] = normalized.split("=");
+		if (inlineValue !== undefined) {
+			flags.set(name, inlineValue);
+			continue;
+		}
+		const next = rest[index + 1];
+		if (next === undefined || next.startsWith("-")) {
+			flags.set(name, true);
+			continue;
+		}
+		flags.set(name, next);
+		index++;
+	}
+
+	return { command, positional, flags };
+}
+
+function requireFlag({
+	flags,
+	name,
+}: {
+	flags: Map<string, string | boolean>;
+	name: string;
+}): string {
+	const value = flags.get(name);
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Missing --${name}`);
+	}
+	return value;
+}
+
+function optionalNumber({
+	flags,
+	name,
+}: {
+	flags: Map<string, string | boolean>;
+	name: string;
+}): number | undefined {
+	const value = flags.get(name);
+	if (typeof value !== "string") return;
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		throw new Error(`--${name} must be a number, received ${value}`);
+	}
+	return parsed;
+}
+
+function loadPlan({ file }: { file: string }): CityFilmPlan {
+	const path = resolve(file);
+	const plan = JSON.parse(readFileSync(path, "utf8")) as CityFilmPlan;
+	if (!Array.isArray(plan.cues) || !Array.isArray(plan.shots)) {
+		throw new Error(`${path} is not a CityFilmPlan (missing cues/shots)`);
+	}
+	return plan;
+}
+
+/** Parses `"start:length,start:length"` into labelled measurement windows. */
+export function parseWindows({ value }: { value?: string }): LevelWindow[] {
+	if (!value) {
+		return [
+			{ label: "open", startSeconds: 0, endSeconds: 5 },
+			{ label: "mid", startSeconds: 30, endSeconds: 35 },
+		];
+	}
+	return value.split(",").map((entry, index) => {
+		const [start, length] = entry.split(":").map(Number);
+		if (!Number.isFinite(start) || !Number.isFinite(length) || length <= 0) {
+			throw new Error(`Invalid window "${entry}", expected start:length`);
+		}
+		return {
+			label: `w${index + 1}`,
+			startSeconds: start,
+			endSeconds: start + length,
+		};
+	});
+}
+
+function emit({ json, payload }: { json: boolean; payload: unknown }): void {
+	if (json) {
+		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+		return;
+	}
+	process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+	const { command, positional, flags } = parseArgs({
+		argv: process.argv.slice(2),
+	});
+	const json = flags.get("json") === true || flags.get("json") === "true";
+
+	if (!command || flags.get("help") === true || command === "help") {
+		process.stdout.write(USAGE);
+		return;
+	}
+
+	if (command === "analyze") {
+		const input = positional[0];
+		if (!input) throw new Error("analyze needs a reference video path");
+		const result = await runAnalyze({
+			input: resolve(input),
+			outputDir: (flags.get("output-dir") as string) || undefined,
+			frames: optionalNumber({ flags, name: "frames" }),
+			sceneThreshold: optionalNumber({ flags, name: "scene-threshold" }),
+		});
+		emit({ json, payload: result });
+		return;
+	}
+
+	if (command === "vo") {
+		const plan = loadPlan({ file: requireFlag({ flags, name: "plan" }) });
+		const result = await runVoBatch({
+			plan,
+			concurrency: optionalNumber({ flags, name: "concurrency" }),
+			force: flags.get("force") === true,
+			model: (flags.get("model") as string) || undefined,
+		});
+		emit({
+			json,
+			payload: {
+				generated: result.generated.length,
+				skipped: result.skipped.length,
+				failed: result.failed,
+			},
+		});
+		if (result.failed.length > 0) process.exitCode = 1;
+		return;
+	}
+
+	if (command === "mix") {
+		const plan = loadPlan({ file: requireFlag({ flags, name: "plan" }) });
+		const result = await runMix({
+			plan,
+			videoPath: resolve(requireFlag({ flags, name: "video" })),
+			outputPath: resolve(requireFlag({ flags, name: "output" })),
+		});
+		emit({ json, payload: result });
+		return;
+	}
+
+	if (command === "verify") {
+		const file = resolve(requireFlag({ flags, name: "video" }));
+		const levels = await measureLevels({
+			file,
+			windows: parseWindows({ value: flags.get("windows") as string }),
+		});
+		emit({ json, payload: { file, levels } });
+		return;
+	}
+
+	throw new Error(`Unknown command "${command}"\n\n${USAGE}`);
+}
+
+if (import.meta.main) {
+	main().catch((error: unknown) => {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : String(error)}\n`
+		);
+		process.exitCode = 1;
+	});
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test } from "vitest";
+import {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	computeTimelineDuration,
+	resolveVoFile,
+} from "./mix-graph";
+import type { CityFilmPlan } from "./types";
+
+function createPlan(overrides: Partial<CityFilmPlan> = {}): CityFilmPlan {
+	return {
+		name: "melbourne",
+		language: "zh",
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		assetsDir: "/assets/melbourne",
+		acts: [
+			{
+				id: "a1-dawn",
+				title: "第1幕·破晓",
+				startSeconds: 0,
+				endSeconds: 30,
+				shotSeconds: 3,
+				emotion: "平静",
+			},
+		],
+		shots: [
+			{ file: "dawn.mp4", startSeconds: 0, endSeconds: 30 },
+			{ file: "market.mp4", startSeconds: 10, endSeconds: 40 },
+		],
+		cues: [
+			{
+				id: "t01",
+				actId: "a1-dawn",
+				startSeconds: 0,
+				durationSeconds: 4,
+				text: "清晨",
+			},
+			{
+				id: "t02",
+				actId: "a1-dawn",
+				startSeconds: 12.5,
+				durationSeconds: 4,
+				text: "市场",
+			},
+			{
+				id: "t03",
+				actId: "a1-dawn",
+				startSeconds: 40,
+				durationSeconds: 4,
+				text: "黄昏",
+			},
+		],
+		music: [
+			{
+				file: "music/dawn-bed.mp3",
+				startSeconds: 0,
+				endSeconds: 30,
+				sourceOffsetSeconds: 12,
+				fadeInSeconds: 2,
+			},
+			{
+				file: "music/night-bed.mp3",
+				startSeconds: 30,
+				endSeconds: 55,
+				sourceOffsetSeconds: 0,
+				fadeOutSeconds: 3,
+			},
+		],
+		blackTailSeconds: 2,
+		subtitle: {
+			fontSize: 48,
+			letterSpacing: 2,
+			offsetY: 320,
+			titleFontSize: 72,
+			titleLetterSpacing: 8,
+		},
+		...overrides,
+	};
+}
+
+describe("qcut-cityfilm mix graph", () => {
+	test("wires music, narration, and ducking for a two-cue plan", () => {
+		const plan = createPlan();
+		const graph = buildMixGraph({ plan });
+
+		expect(graph.inputs).toEqual([
+			"/assets/melbourne/music/dawn-bed.mp3",
+			"/assets/melbourne/music/night-bed.mp3",
+			"/assets/melbourne/vo/vo-zh-t01.mp3",
+			"/assets/melbourne/vo/vo-zh-t02.mp3",
+			"/assets/melbourne/vo/vo-zh-t03.mp3",
+		]);
+		expect(graph.maps).toEqual(["0:v", "[aout]"]);
+
+		const chains = graph.filterComplex.split(";");
+		expect(chains[0]).toBe("[0:a]volume=0.22[amb]");
+		// Music cues take inputs 1..2, narration cues 3..5.
+		expect(chains[1]).toContain("[1:a]atrim=12:42,asetpts=PTS-STARTPTS");
+		expect(chains[1]).toContain("afade=t=in:st=0:d=2");
+		expect(chains[2]).toContain("[2:a]atrim=0:25,asetpts=PTS-STARTPTS");
+		expect(chains[2]).toContain("afade=t=out:st=22:d=3");
+
+		// 60s of shots + a 2s black tail needs a 7s pad after music ends at 55s.
+		expect(computeTimelineDuration({ plan })).toBe(62);
+		expect(graph.filterComplex).toContain("anullsrc");
+		expect(graph.filterComplex).toContain("atrim=duration=7");
+		expect(chains.find((chain) => chain.includes("concat="))).toBe(
+			"[m0][m1][mp0]concat=n=3:v=0:a=1,volume=0.5[music]"
+		);
+
+		expect(graph.filterComplex).toContain("[3:a]adelay=0|0,volume=1.6[vo0]");
+		expect(graph.filterComplex).toContain(
+			"[4:a]adelay=12500|12500,volume=1.6[vo1]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[5:a]adelay=40000|40000,volume=1.6[vo2]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[vo0][vo1][vo2]amix=inputs=3:normalize=0:dropout_transition=0,apad,atrim=0:62,asetpts=PTS-STARTPTS[vo]"
+		);
+		expect(graph.filterComplex).toContain("[vo]asplit=2[vokey][vomix]");
+		expect(graph.filterComplex).toContain(
+			"[amb][music]amix=inputs=2:normalize=0[bed]"
+		);
+		expect(graph.filterComplex).toContain(
+			"[bed][vokey]sidechaincompress=threshold=0.05:ratio=7:attack=15:release=350:makeup=1[bedduck]"
+		);
+		expect(graph.filterComplex).toMatch(
+			/\[bedduck]\[vomix]amix=inputs=2:normalize=0,alimiter=limit=0\.95,aresample=48000\[aout]$/
+		);
+	});
+
+	test("pads a mid-timeline gap so concat cannot shorten the bed", () => {
+		const plan = createPlan({
+			shots: [{ file: "dawn.mp4", startSeconds: 0, endSeconds: 20 }],
+			blackTailSeconds: 0,
+			music: [
+				{
+					file: "music/a.mp3",
+					startSeconds: 0,
+					endSeconds: 5,
+					sourceOffsetSeconds: 0,
+				},
+				{
+					file: "music/b.mp3",
+					startSeconds: 12,
+					endSeconds: 20,
+					sourceOffsetSeconds: 4,
+				},
+			],
+			cues: [],
+		});
+		const graph = buildMixGraph({ plan });
+
+		expect(graph.filterComplex).toContain("atrim=duration=7");
+		expect(graph.filterComplex).toContain("[m0][mp0][m1]concat=n=3:v=0:a=1");
+		// No narration means no duck stage; the bed goes straight to [aout].
+		expect(graph.filterComplex).not.toContain("sidechaincompress");
+		expect(graph.filterComplex).toContain(
+			"[amb][music]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	});
+
+	test("pads the voice bus so ducking cannot truncate the film", () => {
+		// Regression: sidechaincompress ends with its key input, so a voice bus
+		// that stopped at the last cue cut the exported audio short (a 62s film
+		// came back as 44s, and -shortest then clipped the picture too).
+		const plan = createPlan({
+			cues: [
+				{
+					id: "t01",
+					actId: "a1-dawn",
+					startSeconds: 2,
+					durationSeconds: 4,
+					text: "清晨",
+				},
+			],
+		});
+		const graph = buildMixGraph({ plan });
+		expect(graph.filterComplex).toContain(
+			"[vo0]amix=inputs=1:normalize=0:dropout_transition=0,apad,atrim=0:62,asetpts=PTS-STARTPTS[vo]"
+		);
+	});
+
+	test("honours custom levels and a non-zero video input index", () => {
+		const graph = buildMixGraph({
+			plan: createPlan(),
+			levels: { ambience: 0.1, music: 0.4, voice: 2, duckRatio: 12 },
+			videoInputIndex: 2,
+		});
+		expect(graph.filterComplex).toContain("[2:a]volume=0.1[amb]");
+		expect(graph.filterComplex).toContain("[3:a]atrim=12:42");
+		expect(graph.filterComplex).toContain("[5:a]adelay=0|0,volume=2[vo0]");
+		expect(graph.filterComplex).toContain("ratio=12:attack=15");
+		expect(graph.maps).toEqual(["2:v", "[aout]"]);
+	});
+
+	test("rejects overlapping or empty music cues", () => {
+		expect(() =>
+			buildMixGraph({
+				plan: createPlan({
+					music: [
+						{
+							file: "a.mp3",
+							startSeconds: 0,
+							endSeconds: 30,
+							sourceOffsetSeconds: 0,
+						},
+						{
+							file: "b.mp3",
+							startSeconds: 20,
+							endSeconds: 40,
+							sourceOffsetSeconds: 0,
+						},
+					],
+				}),
+			})
+		).toThrow("overlaps the previous cue");
+		expect(() =>
+			buildMixGraph({
+				plan: createPlan({
+					music: [
+						{
+							file: "a.mp3",
+							startSeconds: 5,
+							endSeconds: 5,
+							sourceOffsetSeconds: 0,
+						},
+					],
+				}),
+			})
+		).toThrow("non-positive length");
+	});
+
+	test("resolves VO filenames with the vo.ts naming rule", () => {
+		expect(
+			resolveVoFile({ assetsDir: "/a", language: "en", cueId: "t04" })
+		).toBe("/a/vo/vo-en-t04.mp3");
+	});
+});
+
+describe("qcut-cityfilm label guard", () => {
+	test("accepts a graph whose every label is consumed", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: graph.filterComplex,
+				outputLabels: ["aout"],
+			})
+		).not.toThrow();
+	});
+
+	test("rejects an orphan label that ffmpeg would abort on", () => {
+		const orphaned = [
+			"[0:a]volume=0.2[amb]",
+			"[1:a]volume=0.5[music]",
+			"[2:a]volume=1.6[strays]",
+			"[amb][music]amix=inputs=2:normalize=0[aout]",
+		].join(";");
+		expect(() =>
+			assertLabelsConsumed({ filterComplex: orphaned, outputLabels: ["aout"] })
+		).toThrow("[strays]");
+		expect(() =>
+			assertLabelsConsumed({ filterComplex: orphaned, outputLabels: ["aout"] })
+		).toThrow("nothing consumes");
+	});
+
+	test("rejects dangling references and duplicate labels", () => {
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: "[0:a]volume=0.2[amb];[amb][music]amix=inputs=2[aout]",
+			})
+		).toThrow("never produced");
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex:
+					"[0:a]volume=0.2[amb];[1:a]volume=0.5[amb];[amb]anull[aout]",
+			})
+		).toThrow("more than once");
+	});
+
+	test("treats the last chain's outputs as terminal by default", () => {
+		expect(() =>
+			assertLabelsConsumed({
+				filterComplex: "[0:a]volume=0.2[amb];[amb]anull[aout]",
+			})
+		).not.toThrow();
+	});
+});
+
+describe("qcut-cityfilm mix arguments", () => {
+	test("copies the picture and encodes only the new bed", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		const args = buildMixArgs({
+			videoPath: "/out/picture.mp4",
+			outputPath: "/out/final.mp4",
+			graph,
+		});
+
+		expect(args.slice(0, 3)).toEqual(["-y", "-i", "/out/picture.mp4"]);
+		expect(args.filter((value) => value === "-i")).toHaveLength(
+			1 + graph.inputs.length
+		);
+		const filterIndex = args.indexOf("-filter_complex");
+		expect(args[filterIndex + 1]).toBe(graph.filterComplex);
+		expect(args.slice(filterIndex + 2)).toEqual([
+			"-map",
+			"0:v",
+			"-map",
+			"[aout]",
+			"-c:v",
+			"copy",
+			"-c:a",
+			"aac",
+			"-b:a",
+			"192k",
+			"-shortest",
+			"/out/final.mp4",
+		]);
+	});
+
+	test("refuses to overwrite the exported picture", () => {
+		const graph = buildMixGraph({ plan: createPlan() });
+		expect(() =>
+			buildMixArgs({
+				videoPath: "/out/picture.mp4",
+				outputPath: "/out/picture.mp4",
+				graph,
+			})
+		).toThrow("cannot replace the exported picture");
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix-graph.ts
@@ -1,0 +1,398 @@
+/**
+ * Pure filter-graph construction for the qcut-cityfilm final mix.
+ *
+ * QCut's exporter currently drops CLI-imported audio from the render, so the
+ * picture is exported from QCut (it still carries the source clips' ambience)
+ * and the music + narration are mixed on top in a single ffmpeg pass that
+ * copies the video stream untouched. Nothing here spawns a process.
+ */
+import { isAbsolute, join, resolve } from "node:path";
+import { type CityFilmPlan, DEFAULT_MIX_LEVELS, type MixLevels } from "./types";
+import { voFileName } from "./vo";
+
+/** Seconds below which two timeline positions count as the same instant. */
+const EPSILON = 1e-3;
+
+/** Every concat segment must agree on format or ffmpeg rejects the join. */
+const AUDIO_FORMAT =
+	"aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo";
+
+/** Input pads (`0:a`, `1:v`) are supplied by ffmpeg, not by a filter chain. */
+const INPUT_PAD_PATTERN = /^\d+:[a-zA-Z]+$/;
+
+/** A fully wired filter graph, ready to be turned into ffmpeg arguments. */
+export interface MixGraph {
+	/** Audio files appended after the video input, in ffmpeg input order. */
+	inputs: string[];
+	filterComplex: string;
+	/** Raw `-map` values, e.g. `["0:v", "[aout]"]`. */
+	maps: string[];
+}
+
+export function formatNumber({ value }: { value: number }): string {
+	if (!Number.isFinite(value)) {
+		throw new Error(`Expected a finite number, received ${value}`);
+	}
+	return String(Math.round(value * 1000) / 1000);
+}
+
+/**
+ * Where vo.ts wrote a cue's narration: `<assetsDir>/vo/vo-<lang>-<id>.mp3`.
+ * The filename itself comes from vo.ts so the rule has one owner.
+ */
+export function resolveVoFile({
+	assetsDir,
+	language,
+	cueId,
+}: {
+	assetsDir: string;
+	language: string;
+	cueId: string;
+}): string {
+	return join(assetsDir, "vo", voFileName({ language, cueId }));
+}
+
+/**
+ * Picture length the music bed has to cover: every shot laid end to end plus
+ * the black tail held for the closing card.
+ */
+export function computeTimelineDuration({
+	plan,
+}: {
+	plan: CityFilmPlan;
+}): number {
+	const shots = plan.shots.reduce((total, shot) => {
+		const length = shot.endSeconds - shot.startSeconds;
+		if (length <= 0) {
+			throw new Error(
+				`Shot ${shot.file} has a non-positive length (${shot.startSeconds}..${shot.endSeconds})`
+			);
+		}
+		return total + length;
+	}, 0);
+	return shots + Math.max(0, plan.blackTailSeconds);
+}
+
+function splitChainLabels({ chain }: { chain: string }): {
+	inputs: string[];
+	outputs: string[];
+} {
+	const trimmed = chain.trim();
+	const leading = trimmed.match(/^(?:\[[^[\]]+\])+/);
+	const trailing = trimmed.match(/(?:\[[^[\]]+\])+$/);
+	const leadingEnd = leading ? leading[0].length : 0;
+	const names = (value: string | undefined): string[] =>
+		value ? [...value.matchAll(/\[([^[\]]+)\]/g)].map((match) => match[1]) : [];
+	const trailingIsSeparate =
+		trailing !== null &&
+		trailing.index !== undefined &&
+		trailing.index >= leadingEnd;
+	return {
+		inputs: names(leading?.[0]),
+		outputs: trailingIsSeparate ? names(trailing[0]) : [],
+	};
+}
+
+/**
+ * Guards the mistake that broke the first hand-run: ffmpeg aborts the whole
+ * render when a filter graph declares a label nothing reads. Also catches the
+ * two neighbouring failures — referencing a label that is never produced, and
+ * producing the same label twice.
+ *
+ * @param outputLabels Terminal labels meant to leave the graph via `-map`.
+ * Defaults to the outputs of the last filter chain.
+ */
+export function assertLabelsConsumed({
+	filterComplex,
+	outputLabels,
+}: {
+	filterComplex: string;
+	outputLabels?: string[];
+}): void {
+	const chains = filterComplex
+		.split(";")
+		.map((chain) => chain.trim())
+		.filter((chain) => chain.length > 0);
+	if (chains.length === 0) throw new Error("Filter graph is empty");
+
+	const produced: string[] = [];
+	const consumed = new Set<string>();
+	let lastOutputs: string[] = [];
+	for (const chain of chains) {
+		const { inputs, outputs } = splitChainLabels({ chain });
+		for (const label of inputs) {
+			if (!INPUT_PAD_PATTERN.test(label)) consumed.add(label);
+		}
+		for (const label of outputs) {
+			if (produced.includes(label)) {
+				throw new Error(
+					`Filter graph declares label [${label}] more than once; ffmpeg needs unique labels`
+				);
+			}
+			produced.push(label);
+		}
+		lastOutputs = outputs;
+	}
+
+	const terminal = new Set(outputLabels ?? lastOutputs);
+	const list = (labels: string[]): string =>
+		labels.map((label) => `[${label}]`).join(", ");
+	const undefinedLabels = [...consumed].filter(
+		(label) => !produced.includes(label)
+	);
+	if (undefinedLabels.length > 0) {
+		throw new Error(
+			`Filter graph reads labels that are never produced: ${list(undefinedLabels)}`
+		);
+	}
+	const orphans = produced.filter(
+		(label) => !consumed.has(label) && !terminal.has(label)
+	);
+	if (orphans.length > 0) {
+		throw new Error(
+			`Filter graph produces labels nothing consumes: ${list(orphans)}. ffmpeg fails on unused filter outputs; consume them or drop the chain.`
+		);
+	}
+}
+
+function buildMusicChains({
+	plan,
+	levels,
+	firstAudioIndex,
+	timelineDuration,
+}: {
+	plan: CityFilmPlan;
+	levels: MixLevels;
+	firstAudioIndex: number;
+	timelineDuration: number;
+}): { chains: string[]; inputs: string[]; concatChain: string } {
+	const ordered = [...plan.music].sort(
+		(left, right) => left.startSeconds - right.startSeconds
+	);
+	const chains: string[] = [];
+	const inputs: string[] = [];
+	const segments: string[] = [];
+	let cursor = 0;
+	let padIndex = 0;
+
+	const pad = ({ length }: { length: number }): void => {
+		const label = `mp${padIndex}`;
+		padIndex += 1;
+		chains.push(
+			`anullsrc=channel_layout=stereo:sample_rate=48000,atrim=duration=${formatNumber({ value: length })},asetpts=PTS-STARTPTS,${AUDIO_FORMAT}[${label}]`
+		);
+		segments.push(label);
+	};
+
+	for (const cue of ordered) {
+		const length = cue.endSeconds - cue.startSeconds;
+		if (length <= 0) {
+			throw new Error(
+				`Music cue ${cue.file} has a non-positive length (${cue.startSeconds}..${cue.endSeconds})`
+			);
+		}
+		if (cue.sourceOffsetSeconds < 0) {
+			throw new Error(`Music cue ${cue.file} has a negative source offset`);
+		}
+		if (cue.startSeconds < cursor - EPSILON) {
+			throw new Error(
+				`Music cue ${cue.file} at ${cue.startSeconds}s overlaps the previous cue ending at ${cursor}s`
+			);
+		}
+		if (cue.startSeconds > cursor + EPSILON) {
+			pad({ length: cue.startSeconds - cursor });
+		}
+
+		const label = `m${inputs.length}`;
+		const inputIndex = firstAudioIndex + inputs.length;
+		inputs.push(
+			isAbsolute(cue.file) ? cue.file : join(plan.assetsDir, cue.file)
+		);
+		const steps = [
+			`atrim=${formatNumber({ value: cue.sourceOffsetSeconds })}:${formatNumber({ value: cue.sourceOffsetSeconds + length })}`,
+			"asetpts=PTS-STARTPTS",
+			AUDIO_FORMAT,
+		];
+		if (cue.fadeInSeconds && cue.fadeInSeconds > 0) {
+			steps.push(
+				`afade=t=in:st=0:d=${formatNumber({ value: cue.fadeInSeconds })}`
+			);
+		}
+		if (cue.fadeOutSeconds && cue.fadeOutSeconds > 0) {
+			const start = Math.max(0, length - cue.fadeOutSeconds);
+			steps.push(
+				`afade=t=out:st=${formatNumber({ value: start })}:d=${formatNumber({ value: cue.fadeOutSeconds })}`
+			);
+		}
+		chains.push(`[${inputIndex}:a]${steps.join(",")}[${label}]`);
+		segments.push(label);
+		cursor = cue.endSeconds;
+	}
+
+	if (cursor < timelineDuration - EPSILON) {
+		pad({ length: timelineDuration - cursor });
+	}
+	if (segments.length === 0) {
+		throw new Error("Music bed has no segments; the timeline duration is zero");
+	}
+
+	return {
+		chains,
+		inputs,
+		concatChain: `${segments.map((label) => `[${label}]`).join("")}concat=n=${segments.length}:v=0:a=1,volume=${formatNumber({ value: levels.music })}[music]`,
+	};
+}
+
+function buildVoiceChains({
+	plan,
+	levels,
+	firstAudioIndex,
+}: {
+	plan: CityFilmPlan;
+	levels: MixLevels;
+	firstAudioIndex: number;
+}): { chains: string[]; inputs: string[]; labels: string[] } {
+	const chains: string[] = [];
+	const inputs: string[] = [];
+	const labels: string[] = [];
+	const ordered = [...plan.cues].sort(
+		(left, right) => left.startSeconds - right.startSeconds
+	);
+	for (const cue of ordered) {
+		if (cue.startSeconds < 0) {
+			throw new Error(`Cue ${cue.id} starts before the timeline`);
+		}
+		const label = `vo${labels.length}`;
+		const inputIndex = firstAudioIndex + inputs.length;
+		inputs.push(
+			resolveVoFile({
+				assetsDir: plan.assetsDir,
+				language: plan.language,
+				cueId: cue.id,
+			})
+		);
+		const delayMs = Math.round(cue.startSeconds * 1000);
+		chains.push(
+			`[${inputIndex}:a]adelay=${delayMs}|${delayMs},volume=${formatNumber({ value: levels.voice })}[${label}]`
+		);
+		labels.push(label);
+	}
+	return { chains, inputs, labels };
+}
+
+/**
+ * Builds the whole mix graph. Music segments are concatenated in timeline
+ * order — any stretch the cues do not cover is padded with `anullsrc` so
+ * concat cannot shorten the bed — then ducked under the narration by a
+ * sidechain compressor keyed off a split copy of the voice bus.
+ *
+ * Input order is: the picture at `videoInputIndex`, then one input per music
+ * cue in timeline order, then one input per narration cue in timeline order.
+ * A cue gets its own input even when two cues share a file, because an ffmpeg
+ * input pad can only be read once.
+ */
+export function buildMixGraph({
+	plan,
+	levels = DEFAULT_MIX_LEVELS,
+	videoInputIndex = 0,
+}: {
+	plan: CityFilmPlan;
+	levels?: MixLevels;
+	videoInputIndex?: number;
+}): MixGraph {
+	if (!Number.isInteger(videoInputIndex) || videoInputIndex < 0) {
+		throw new Error("videoInputIndex must be a non-negative integer");
+	}
+
+	const musicEnd = plan.music.reduce(
+		(latest, cue) => Math.max(latest, cue.endSeconds),
+		0
+	);
+	const timelineDuration = Math.max(
+		computeTimelineDuration({ plan }),
+		musicEnd
+	);
+
+	const music = buildMusicChains({
+		plan,
+		levels,
+		firstAudioIndex: videoInputIndex + 1,
+		timelineDuration,
+	});
+	const voice = buildVoiceChains({
+		plan,
+		levels,
+		firstAudioIndex: videoInputIndex + 1 + music.inputs.length,
+	});
+
+	const chains = [
+		`[${videoInputIndex}:a]volume=${formatNumber({ value: levels.ambience })}[amb]`,
+		...music.chains,
+		music.concatChain,
+		...voice.chains,
+	];
+
+	// `sidechaincompress` stops as soon as its key input ends, so a voice bus
+	// that runs out before the last shot would truncate the whole film. Pad the
+	// bus to the timeline before it is split into key and mix copies.
+	const voiceBus = `amix=inputs=${voice.labels.length}:normalize=0:dropout_transition=0,apad,atrim=0:${formatNumber({ value: timelineDuration })},asetpts=PTS-STARTPTS`;
+
+	if (voice.labels.length === 0) {
+		chains.push(
+			"[amb][music]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	} else {
+		chains.push(
+			`${voice.labels.map((label) => `[${label}]`).join("")}${voiceBus}[vo]`,
+			"[vo]asplit=2[vokey][vomix]",
+			"[amb][music]amix=inputs=2:normalize=0[bed]",
+			`[bed][vokey]sidechaincompress=threshold=0.05:ratio=${formatNumber({ value: levels.duckRatio })}:attack=15:release=350:makeup=1[bedduck]`,
+			"[bedduck][vomix]amix=inputs=2:normalize=0,alimiter=limit=0.95,aresample=48000[aout]"
+		);
+	}
+
+	const filterComplex = chains.join(";");
+	assertLabelsConsumed({ filterComplex, outputLabels: ["aout"] });
+	return {
+		inputs: [...music.inputs, ...voice.inputs],
+		filterComplex,
+		maps: [`${videoInputIndex}:v`, "[aout]"],
+	};
+}
+
+/**
+ * Full ffmpeg argv. The video stream is copied, so this pass only re-encodes
+ * audio. Assumes the picture occupies input 0, which is what `buildMixGraph`
+ * produces with its default `videoInputIndex`.
+ */
+export function buildMixArgs({
+	videoPath,
+	outputPath,
+	graph,
+}: {
+	videoPath: string;
+	outputPath: string;
+	graph: MixGraph;
+}): string[] {
+	if (resolve(videoPath) === resolve(outputPath)) {
+		throw new Error("Mix output cannot replace the exported picture");
+	}
+	if (graph.maps.length === 0) throw new Error("Mix graph has no output maps");
+	assertLabelsConsumed({ filterComplex: graph.filterComplex });
+
+	const args = ["-y", "-i", videoPath];
+	for (const input of graph.inputs) args.push("-i", input);
+	args.push("-filter_complex", graph.filterComplex);
+	for (const map of graph.maps) args.push("-map", map);
+	args.push(
+		"-c:v",
+		"copy",
+		"-c:a",
+		"aac",
+		"-b:a",
+		"192k",
+		"-shortest",
+		outputPath
+	);
+	return args;
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	buildVolumeDetectArgs,
+	computeTimelineDuration,
+	parseVolumeDetect,
+	resolveVoFile,
+} from "./mix";
+
+describe("qcut-cityfilm level verification", () => {
+	test("measures a single window with volumedetect", () => {
+		expect(
+			buildVolumeDetectArgs({
+				file: "/out/final.mp4",
+				window: { label: "act2", startSeconds: 12.5, endSeconds: 20 },
+			})
+		).toEqual([
+			"-hide_banner",
+			"-nostats",
+			"-ss",
+			"12.5",
+			"-t",
+			"7.5",
+			"-i",
+			"/out/final.mp4",
+			"-vn",
+			"-af",
+			"volumedetect",
+			"-f",
+			"null",
+			"-",
+		]);
+	});
+
+	test("rejects a window that cannot be measured", () => {
+		expect(() =>
+			buildVolumeDetectArgs({
+				file: "/out/final.mp4",
+				window: { label: "tail", startSeconds: 20, endSeconds: 20 },
+			})
+		).toThrow("non-positive length");
+	});
+
+	test("parses mean and max levels, including digital silence", () => {
+		expect(
+			parseVolumeDetect({
+				stderr: [
+					"[Parsed_volumedetect_0 @ 0x1] n_samples: 705600",
+					"[Parsed_volumedetect_0 @ 0x1] mean_volume: -23.4 dB",
+					"[Parsed_volumedetect_0 @ 0x1] max_volume: -3.0 dB",
+				].join("\n"),
+			})
+		).toEqual({ meanDb: -23.4, maxDb: -3 });
+
+		expect(
+			parseVolumeDetect({
+				stderr: "mean_volume: -inf dB\nmax_volume: -inf dB",
+			})
+		).toEqual({
+			meanDb: Number.NEGATIVE_INFINITY,
+			maxDb: Number.NEGATIVE_INFINITY,
+		});
+
+		expect(() => parseVolumeDetect({ stderr: "no levels here" })).toThrow(
+			"volumedetect printed no"
+		);
+	});
+});
+
+describe("qcut-cityfilm mix entry surface", () => {
+	test("re-exports the pure graph builders so callers need one import", () => {
+		expect(typeof buildMixGraph).toBe("function");
+		expect(typeof buildMixArgs).toBe("function");
+		expect(typeof assertLabelsConsumed).toBe("function");
+		expect(typeof computeTimelineDuration).toBe("function");
+		expect(
+			resolveVoFile({ assetsDir: "/a", language: "zh", cueId: "t09" })
+		).toBe("/a/vo/vo-zh-t09.mp3");
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/mix.ts
@@ -1,0 +1,288 @@
+/**
+ * Renders the qcut-cityfilm audio bed and proves it landed.
+ *
+ * The picture comes out of QCut (it carries the source clips' ambience) and
+ * this module lays music + narration over it with one ffmpeg pass, then
+ * measures the result. Graph construction lives in mix-graph.ts; everything
+ * here is process execution and output parsing.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { buildMixArgs, buildMixGraph } from "./mix-graph";
+import type { CityFilmPlan, MixLevels } from "./types";
+
+export {
+	assertLabelsConsumed,
+	buildMixArgs,
+	buildMixGraph,
+	computeTimelineDuration,
+	resolveVoFile,
+} from "./mix-graph";
+export type { MixGraph } from "./mix-graph";
+
+/** One stretch of the finished file to measure. */
+export interface LevelWindow {
+	/** Reporting label, e.g. `"act2"` or `"vo-t04"`. */
+	label: string;
+	startSeconds: number;
+	endSeconds: number;
+}
+
+/** What `volumedetect` reported for one window. */
+export interface LevelReading {
+	label: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** RMS mean in dBFS; `-Infinity` for digital silence. */
+	meanDb: number;
+	maxDb: number;
+	silent: boolean;
+}
+
+export interface MixOptions {
+	plan: CityFilmPlan;
+	/** Picture exported from QCut; must carry an audio track for ambience. */
+	videoPath: string;
+	outputPath: string;
+	levels?: MixLevels;
+	videoInputIndex?: number;
+	ffmpegPath?: string;
+	ffprobePath?: string;
+	/** Optional file to receive the command line and ffmpeg's stderr. */
+	logPath?: string;
+}
+
+export interface MixResult {
+	outputPath: string;
+	durationSeconds: number;
+}
+
+function formatSeconds({ value }: { value: number }): string {
+	if (!Number.isFinite(value)) {
+		throw new Error(`Expected a finite number, received ${value}`);
+	}
+	return String(Math.round(value * 1000) / 1000);
+}
+
+/** ffmpeg argv that measures one window with `volumedetect`. */
+export function buildVolumeDetectArgs({
+	file,
+	window,
+}: {
+	file: string;
+	window: LevelWindow;
+}): string[] {
+	const length = window.endSeconds - window.startSeconds;
+	if (length <= 0) {
+		throw new Error(
+			`Level window ${window.label} has a non-positive length (${window.startSeconds}..${window.endSeconds})`
+		);
+	}
+	return [
+		"-hide_banner",
+		"-nostats",
+		"-ss",
+		formatSeconds({ value: window.startSeconds }),
+		"-t",
+		formatSeconds({ value: length }),
+		"-i",
+		file,
+		"-vn",
+		"-af",
+		"volumedetect",
+		"-f",
+		"null",
+		"-",
+	];
+}
+
+function parseDecibels({ value }: { value: string }): number {
+	if (value === "-inf") return Number.NEGATIVE_INFINITY;
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		throw new Error(`Could not parse a dB value from "${value}"`);
+	}
+	return parsed;
+}
+
+/** Reads `mean_volume` / `max_volume` out of an ffmpeg `volumedetect` run. */
+export function parseVolumeDetect({ stderr }: { stderr: string }): {
+	meanDb: number;
+	maxDb: number;
+} {
+	const mean = stderr.match(/mean_volume:\s*(-?[\d.]+|-inf)\s*dB/);
+	const max = stderr.match(/max_volume:\s*(-?[\d.]+|-inf)\s*dB/);
+	if (!mean || !max) {
+		throw new Error(
+			"volumedetect printed no mean_volume/max_volume line; the window is probably past the end of the file"
+		);
+	}
+	return {
+		meanDb: parseDecibels({ value: mean[1] }),
+		maxDb: parseDecibels({ value: max[1] }),
+	};
+}
+
+function resolveBinary({
+	value,
+	name,
+}: {
+	value?: string;
+	name: string;
+}): string {
+	if (value) return value;
+	return Bun.which(name) ?? name;
+}
+
+async function runProcess({
+	executable,
+	args,
+}: {
+	executable: string;
+	args: string[];
+}): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const child = Bun.spawn([executable, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { stdout, stderr, exitCode: await child.exited };
+}
+
+async function probeDuration({
+	ffprobePath,
+	filePath,
+}: {
+	ffprobePath: string;
+	filePath: string;
+}): Promise<number> {
+	const result = await runProcess({
+		executable: ffprobePath,
+		args: [
+			"-v",
+			"error",
+			"-show_entries",
+			"format=duration",
+			"-of",
+			"json",
+			filePath,
+		],
+	});
+	if (result.exitCode !== 0) {
+		throw new Error(`ffprobe failed for ${filePath}: ${result.stderr.trim()}`);
+	}
+	const parsed = JSON.parse(result.stdout) as {
+		format?: { duration?: string };
+	};
+	const duration = Number(parsed.format?.duration);
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error(`Could not determine duration: ${filePath}`);
+	}
+	return duration;
+}
+
+/** Builds the graph, renders it, and reports the finished file's duration. */
+export async function runMix(options: MixOptions): Promise<MixResult> {
+	const graph = buildMixGraph({
+		plan: options.plan,
+		levels: options.levels,
+		videoInputIndex: options.videoInputIndex,
+	});
+	const missing = [options.videoPath, ...graph.inputs].filter(
+		(file) => !existsSync(file)
+	);
+	if (missing.length > 0) {
+		throw new Error(`Mix inputs are missing:\n  ${missing.join("\n  ")}`);
+	}
+
+	const args = buildMixArgs({
+		videoPath: options.videoPath,
+		outputPath: options.outputPath,
+		graph,
+	});
+	const ffmpegPath = resolveBinary({
+		value: options.ffmpegPath,
+		name: "ffmpeg",
+	});
+	mkdirSync(dirname(resolve(options.outputPath)), { recursive: true });
+	const result = await runProcess({ executable: ffmpegPath, args });
+	if (options.logPath) {
+		mkdirSync(dirname(resolve(options.logPath)), { recursive: true });
+		writeFileSync(
+			options.logPath,
+			`$ ${[ffmpegPath, ...args].join(" ")}\n${result.stderr}`,
+			"utf8"
+		);
+	}
+	if (result.exitCode !== 0) {
+		const detail = result.stderr.trim().split("\n").slice(-3).join(" | ");
+		throw new Error(`ffmpeg mix failed (${result.exitCode}): ${detail}`);
+	}
+
+	return {
+		outputPath: options.outputPath,
+		durationSeconds: await probeDuration({
+			ffprobePath: resolveBinary({
+				value: options.ffprobePath,
+				name: "ffprobe",
+			}),
+			filePath: options.outputPath,
+		}),
+	};
+}
+
+/**
+ * Measures mean/max level per window on a rendered file. The hand-run once
+ * shipped a silent cut because only the timeline was inspected — always prove
+ * the audio landed in the exported file itself.
+ */
+export async function measureLevels({
+	file,
+	windows,
+	ffmpegPath,
+	silenceFloorDb = -60,
+}: {
+	file: string;
+	windows: LevelWindow[];
+	ffmpegPath?: string;
+	silenceFloorDb?: number;
+}): Promise<LevelReading[]> {
+	if (!existsSync(file)) {
+		throw new Error(`Cannot measure a missing file: ${file}`);
+	}
+	const executable = resolveBinary({ value: ffmpegPath, name: "ffmpeg" });
+	const readings: LevelReading[] = [];
+	for (const window of windows) {
+		const result = await runProcess({
+			executable,
+			args: buildVolumeDetectArgs({ file, window }),
+		});
+		if (result.exitCode !== 0) {
+			const detail = result.stderr.trim().split("\n").slice(-2).join(" | ");
+			throw new Error(
+				`volumedetect failed for window ${window.label}: ${detail}`
+			);
+		}
+		let meanDb: number;
+		let maxDb: number;
+		try {
+			({ meanDb, maxDb } = parseVolumeDetect({ stderr: result.stderr }));
+		} catch (error) {
+			throw new Error(
+				`Could not measure window ${window.label} (${window.startSeconds}..${window.endSeconds}s) of ${file}: ${error instanceof Error ? error.message : String(error)}`
+			);
+		}
+		readings.push({
+			label: window.label,
+			startSeconds: window.startSeconds,
+			endSeconds: window.endSeconds,
+			meanDb,
+			maxDb,
+			silent: !(meanDb > silenceFloorDb),
+		});
+	}
+	return readings;
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
@@ -74,6 +74,13 @@ export interface CityFilmPlan {
 	music: MusicCue[];
 	/** Seconds of black held after the last shot for the closing card. */
 	blackTailSeconds: number;
+	/**
+	 * Hosted clip (≤30s) that anchors the narrator's timbre. Seed Audio picks a
+	 * fresh speaker per request otherwise, so cuts end up sounding like several
+	 * different people. The runner fills this from the first rendered cue when
+	 * voice locking is on.
+	 */
+	voiceAnchorUrl?: string;
 	/** Subtitle styling, in canvas pixels. */
 	subtitle: SubtitleStyle;
 }

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared contracts for the qcut-cityfilm skill.
+ *
+ * The workflow this encodes: analyze a reference film, gather licensed
+ * footage, pick segments, narrate with emotion, assemble in QCut, and mix the
+ * final audio bed outside the editor.
+ */
+
+/** One act of the film. Acts drive pacing, copy, VO emotion, and music. */
+export interface ActPlan {
+	/** Stable key used in filenames and cue ids, e.g. "a2-market". */
+	id: string;
+	/** Human label, e.g. "第2幕·市场". */
+	title: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** Target shot length inside this act, in seconds. */
+	shotSeconds: number;
+	/** Emotion directive passed to the TTS model, in the copy's language. */
+	emotion: string;
+}
+
+/** A chosen in/out range of a source clip. */
+export interface SegmentPick {
+	/** Basename of the source file, as imported into the project. */
+	file: string;
+	startSeconds: number;
+	endSeconds: number;
+	/** Why this segment was chosen — kept for review, not used by the build. */
+	note?: string;
+}
+
+/** One narration/subtitle cue. */
+export interface Cue {
+	/** Cue id, e.g. "t04". Also names the VO file: vo-<lang>-<id>.mp3. */
+	id: string;
+	/** Act this cue belongs to; supplies the TTS emotion directive. */
+	actId: string;
+	startSeconds: number;
+	durationSeconds: number;
+	/** Subtitle text; also the TTS prompt body. */
+	text: string;
+	/** Centered title card instead of a bottom subtitle. */
+	title?: boolean;
+}
+
+/** Music bed segment: one stretch of one track. */
+export interface MusicCue {
+	/** Basename of the audio file. */
+	file: string;
+	/** Where the segment lands on the timeline. */
+	startSeconds: number;
+	endSeconds: number;
+	/** Offset inside the source track. */
+	sourceOffsetSeconds: number;
+	fadeInSeconds?: number;
+	fadeOutSeconds?: number;
+}
+
+/** The full recipe for one language cut. */
+export interface CityFilmPlan {
+	name: string;
+	/** BCP-47-ish short code used in VO filenames: "zh", "en", ... */
+	language: string;
+	width: number;
+	height: number;
+	fps: number;
+	/** Directory holding footage, music, and generated VO. */
+	assetsDir: string;
+	acts: ActPlan[];
+	/** Ordered shot list; the build lays these out end to end. */
+	shots: SegmentPick[];
+	cues: Cue[];
+	music: MusicCue[];
+	/** Seconds of black held after the last shot for the closing card. */
+	blackTailSeconds: number;
+	/** Subtitle styling, in canvas pixels. */
+	subtitle: SubtitleStyle;
+}
+
+export interface SubtitleStyle {
+	fontSize: number;
+	letterSpacing: number;
+	/** Vertical offset from canvas center, positive is down. */
+	offsetY: number;
+	titleFontSize: number;
+	titleLetterSpacing: number;
+}
+
+/** Per-language mixing levels. */
+export interface MixLevels {
+	/** Source-clip ambience kept under the bed. */
+	ambience: number;
+	music: number;
+	voice: number;
+	/** Ducking depth applied to the bed while narration plays. */
+	duckRatio: number;
+}
+
+export const DEFAULT_MIX_LEVELS: MixLevels = {
+	ambience: 0.22,
+	music: 0.5,
+	voice: 1.6,
+	duckRatio: 7,
+};
+
+/** Scene-cut statistics extracted from a reference film. */
+export interface PacingProfile {
+	durationSeconds: number;
+	cutCount: number;
+	/** Cuts per minute, index 0 = first minute. */
+	cutsPerMinute: number[];
+	averageShotSeconds: number;
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
@@ -1,0 +1,85 @@
+/**
+ * Process-level helpers for the narration batch.
+ *
+ * Everything that spawns a child process or moves a file lives here, so the
+ * planning and prompt logic in vo.ts stays unit-testable without a TTS call.
+ */
+
+import { spawn } from "node:child_process";
+import { copyFileSync, renameSync, rmSync } from "node:fs";
+
+export interface SpawnOutcome {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Never rejects: a spawn error is reported as a non-zero exit instead. */
+export function spawnCollect({
+	executable,
+	args,
+	cwd,
+	env,
+}: {
+	executable: string;
+	args: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+}): Promise<SpawnOutcome> {
+	return new Promise<SpawnOutcome>((resolveOutcome) => {
+		const out: Buffer[] = [];
+		const err: Buffer[] = [];
+		const child = spawn(executable, args, {
+			cwd,
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+		child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+		const finish = (exitCode: number, extra = "") =>
+			resolveOutcome({
+				exitCode,
+				stdout: Buffer.concat(out).toString("utf8"),
+				stderr: `${Buffer.concat(err).toString("utf8")}${extra}`,
+			});
+		child.once("error", (error: Error) => finish(1, error.message));
+		child.once("close", (code) => finish(code ?? 1));
+	});
+}
+
+/** Explicit override wins, then PATH lookup, then a bare-name fallback. */
+export function resolveExecutable({
+	override,
+	name,
+	fallback,
+}: {
+	override?: string;
+	name: string;
+	fallback: string;
+}): string {
+	if (override) return override;
+	const found = typeof Bun === "undefined" ? undefined : Bun.which(name);
+	return found ?? fallback;
+}
+
+/** Last few lines of child output, collapsed into one error-sized string. */
+export function tailMessage({
+	text,
+	lines = 3,
+}: {
+	text: string;
+	lines?: number;
+}): string {
+	return text.trim().split("\n").slice(-lines).join(" | ");
+}
+
+/** Rename, falling back to copy+unlink when temp and assets differ by device. */
+export function moveFile({ from, to }: { from: string; to: string }): void {
+	try {
+		renameSync(from, to);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EXDEV") throw error;
+		copyFileSync(from, to);
+		rmSync(from, { force: true });
+	}
+}

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo-exec.ts
@@ -14,17 +14,26 @@ export interface SpawnOutcome {
 	stderr: string;
 }
 
-/** Never rejects: a spawn error is reported as a non-zero exit instead. */
+/**
+ * A hosted TTS call that never answers would otherwise pin one concurrency
+ * lane for the whole batch, so children are given a deadline.
+ */
+export const DEFAULT_SPAWN_TIMEOUT_MS = 300_000;
+
+/** Never rejects: a spawn error or timeout is reported as a non-zero exit. */
 export function spawnCollect({
 	executable,
 	args,
 	cwd,
 	env,
+	timeoutMs = DEFAULT_SPAWN_TIMEOUT_MS,
 }: {
 	executable: string;
 	args: string[];
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
+	/** Kill the child after this long; 0 or negative disables the deadline. */
+	timeoutMs?: number;
 }): Promise<SpawnOutcome> {
 	return new Promise<SpawnOutcome>((resolveOutcome) => {
 		const out: Buffer[] = [];
@@ -34,14 +43,27 @@ export function spawnCollect({
 			env,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
 		child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
-		const finish = (exitCode: number, extra = "") =>
+		const finish = (exitCode: number, extra = "") => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
 			resolveOutcome({
 				exitCode,
 				stdout: Buffer.concat(out).toString("utf8"),
 				stderr: `${Buffer.concat(err).toString("utf8")}${extra}`,
 			});
+		};
+		if (timeoutMs > 0) {
+			timer = setTimeout(() => {
+				child.kill("SIGKILL");
+				finish(124, `\ntimed out after ${timeoutMs}ms`);
+			}, timeoutMs);
+			timer.unref?.();
+		}
 		child.once("error", (error: Error) => finish(1, error.message));
 		child.once("close", (code) => finish(code ?? 1));
 	});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -12,6 +12,7 @@ import {
 	VOICE_REFERENCE_TAG,
 	voFileName,
 } from "./vo";
+import { spawnCollect } from "./vo-exec";
 import { resolveExecutable, tailMessage } from "./vo-exec";
 
 const act: ActPlan = {
@@ -316,5 +317,27 @@ describe("voice locking", () => {
 		expect(() =>
 			parseTtsAudioUrl({ stdout: JSON.stringify({ status: "ok", data: {} }) })
 		).toThrow();
+	});
+});
+
+describe("spawnCollect timeout", () => {
+	it("kills a stalled child and reports a non-zero exit", async () => {
+		const outcome = await spawnCollect({
+			executable: "sleep",
+			args: ["30"],
+			timeoutMs: 150,
+		});
+		expect(outcome.exitCode).toBe(124);
+		expect(outcome.stderr).toContain("timed out");
+	});
+
+	it("leaves a fast child untouched", async () => {
+		const outcome = await spawnCollect({
+			executable: "echo",
+			args: ["ok"],
+			timeoutMs: 5000,
+		});
+		expect(outcome.exitCode).toBe(0);
+		expect(outcome.stdout.trim()).toBe("ok");
 	});
 });

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "vitest";
+import type { ActPlan, CityFilmPlan, Cue } from "./types";
+import {
+	buildTtsArgs,
+	buildTtsPrompt,
+	checkCueFit,
+	parseDurationSeconds,
+	pickGeneratedAudioName,
+	planVoJobs,
+	runWithConcurrency,
+	voFileName,
+} from "./vo";
+import { resolveExecutable, tailMessage } from "./vo-exec";
+
+const act: ActPlan = {
+	id: "a1-return",
+	title: "第1幕·归来",
+	startSeconds: 0,
+	endSeconds: 30,
+	shotSeconds: 3,
+	emotion: "(用温柔、怀旧、带一点感慨的语气)",
+};
+
+const cue: Cue = {
+	id: "t04",
+	actId: "a1-return",
+	startSeconds: 12,
+	durationSeconds: 4,
+	text: "好久不见,墨尔本。",
+};
+
+function makePlan({ overrides }: { overrides?: Partial<CityFilmPlan> } = {}) {
+	const plan: CityFilmPlan = {
+		name: "melbourne",
+		language: "zh",
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		assetsDir: "/films/melbourne/assets",
+		acts: [
+			act,
+			{
+				id: "a2-market",
+				title: "第2幕·市场",
+				startSeconds: 30,
+				endSeconds: 60,
+				shotSeconds: 2,
+				emotion: "(用明快、好奇的语气)",
+			},
+		],
+		shots: [],
+		cues: [
+			cue,
+			{
+				id: "t05",
+				actId: "a2-market",
+				startSeconds: 31,
+				durationSeconds: 3,
+				text: "市场醒了。",
+			},
+			{
+				id: "t06",
+				actId: "a9-missing",
+				startSeconds: 40,
+				durationSeconds: 3,
+				text: "没有情绪指令。",
+			},
+		],
+		music: [],
+		blackTailSeconds: 2,
+		subtitle: {
+			fontSize: 48,
+			letterSpacing: 2,
+			offsetY: 380,
+			titleFontSize: 72,
+			titleLetterSpacing: 8,
+		},
+	};
+	return { ...plan, ...overrides };
+}
+
+describe("qcut-cityfilm vo prompts", () => {
+	test("prefixes the act emotion directive with no extra separator", () => {
+		expect(buildTtsPrompt({ cue, act })).toBe(
+			"(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。"
+		);
+	});
+
+	test("falls back to the plain copy when no directive is available", () => {
+		expect(buildTtsPrompt({ cue })).toBe("好久不见,墨尔本。");
+		expect(buildTtsPrompt({ cue, act: { ...act, emotion: "   " } })).toBe(
+			"好久不见,墨尔本。"
+		);
+	});
+
+	test("names VO files by language and cue id", () => {
+		expect(voFileName({ language: "zh", cueId: "t04" })).toBe("vo-zh-t04.mp3");
+		expect(voFileName({ language: "en", cueId: "t12" })).toBe("vo-en-t12.mp3");
+	});
+
+	test("builds the pipeline TTS argv", () => {
+		expect(
+			buildTtsArgs({
+				model: "seed_audio",
+				prompt: "(用温柔的语气)好久不见。",
+				outputDir: "/tmp/vo-t04",
+			})
+		).toEqual([
+			"run",
+			"pipeline",
+			"gen",
+			"tts",
+			"-m",
+			"seed_audio",
+			"-t",
+			"(用温柔的语气)好久不见。",
+			"-o",
+			"/tmp/vo-t04",
+			"--json",
+		]);
+	});
+});
+
+describe("qcut-cityfilm vo job planning", () => {
+	test("emits one job per cue resolved under assetsDir/vo", () => {
+		const jobs = planVoJobs({ plan: makePlan() });
+
+		expect(jobs).toHaveLength(3);
+		expect(jobs[0]).toEqual({
+			cueId: "t04",
+			prompt: "(用温柔、怀旧、带一点感慨的语气)好久不见,墨尔本。",
+			outputFile: "/films/melbourne/assets/vo/vo-zh-t04.mp3",
+		});
+		expect(jobs[1]?.prompt).toBe("(用明快、好奇的语气)市场醒了。");
+		expect(jobs[1]?.outputFile).toBe(
+			"/films/melbourne/assets/vo/vo-zh-t05.mp3"
+		);
+		// An unknown act id must not drop the cue — it renders undirected.
+		expect(jobs[2]?.prompt).toBe("没有情绪指令。");
+	});
+
+	test("follows the plan language into every filename", () => {
+		const jobs = planVoJobs({
+			plan: makePlan({ overrides: { language: "en" } }),
+		});
+		expect(jobs.map((job) => job.outputFile)).toEqual([
+			"/films/melbourne/assets/vo/vo-en-t04.mp3",
+			"/films/melbourne/assets/vo/vo-en-t05.mp3",
+			"/films/melbourne/assets/vo/vo-en-t06.mp3",
+		]);
+	});
+});
+
+describe("qcut-cityfilm cue fit", () => {
+	test("accepts narration up to the tolerance and rejects beyond it", () => {
+		expect(checkCueFit({ cue, voDurationSeconds: 3.2 })).toEqual({
+			fits: true,
+			overflowSeconds: 0,
+		});
+		expect(checkCueFit({ cue, voDurationSeconds: 4 })).toEqual({
+			fits: true,
+			overflowSeconds: 0,
+		});
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 4.25, toleranceSeconds: 0.25 })
+		).toEqual({ fits: true, overflowSeconds: 0.25 });
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 4.26, toleranceSeconds: 0.25 })
+		).toEqual({ fits: false, overflowSeconds: 0.26 });
+		expect(
+			checkCueFit({ cue, voDurationSeconds: 6.5, toleranceSeconds: 0 })
+		).toEqual({ fits: false, overflowSeconds: 2.5 });
+	});
+});
+
+describe("qcut-cityfilm vo runner helpers", () => {
+	test("prefers speech.mp3 and falls back to any mp3", () => {
+		expect(
+			pickGeneratedAudioName({ entries: ["meta.json", "speech.mp3"] })
+		).toBe("speech.mp3");
+		expect(
+			pickGeneratedAudioName({ entries: ["meta.json", "seed-out.MP3"] })
+		).toBe("seed-out.MP3");
+		expect(pickGeneratedAudioName({ entries: ["meta.json"] })).toBeUndefined();
+	});
+
+	test("reads the ffprobe duration payload", () => {
+		expect(
+			parseDurationSeconds({ stdout: '{"format":{"duration":"3.744000"}}' })
+		).toBeCloseTo(3.744, 3);
+		expect(() => parseDurationSeconds({ stdout: "not json" })).toThrow(
+			"did not return JSON"
+		);
+		expect(() => parseDurationSeconds({ stdout: "{}" })).toThrow(
+			"no usable duration"
+		);
+	});
+
+	test("bounds concurrency while preserving input order", async () => {
+		let active = 0;
+		let peak = 0;
+		const results = await runWithConcurrency<number, string>({
+			items: [1, 2, 3, 4, 5, 6, 7],
+			limit: 3,
+			worker: async (item) => {
+				active += 1;
+				peak = Math.max(peak, active);
+				await new Promise((done) => setTimeout(done, 5));
+				active -= 1;
+				return `job-${item}`;
+			},
+		});
+
+		expect(peak).toBeLessThanOrEqual(3);
+		expect(results).toEqual([
+			"job-1",
+			"job-2",
+			"job-3",
+			"job-4",
+			"job-5",
+			"job-6",
+			"job-7",
+		]);
+		expect(
+			await runWithConcurrency<number, number>({
+				items: [],
+				limit: 4,
+				worker: async (item) => item,
+			})
+		).toEqual([]);
+	});
+
+	test("condenses child output into one error line", () => {
+		expect(tailMessage({ text: "a\nb\nc\nd\ne\n" })).toBe("c | d | e");
+		expect(tailMessage({ text: "only\n", lines: 3 })).toBe("only");
+	});
+
+	test("prefers an explicit executable override over PATH lookup", () => {
+		expect(
+			resolveExecutable({
+				override: "/opt/bun/bin/bun",
+				name: "bun",
+				fallback: "/usr/bin/node",
+			})
+		).toBe("/opt/bun/bin/bun");
+		expect(
+			resolveExecutable({
+				name: "definitely-not-a-real-binary-9f2c",
+				fallback: "fallback-bin",
+			})
+		).toBe("fallback-bin");
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import type { ActPlan, CityFilmPlan, Cue } from "./types";
 import {
 	buildTtsArgs,
@@ -6,8 +6,10 @@ import {
 	checkCueFit,
 	parseDurationSeconds,
 	pickGeneratedAudioName,
+	parseTtsAudioUrl,
 	planVoJobs,
 	runWithConcurrency,
+	VOICE_REFERENCE_TAG,
 	voFileName,
 } from "./vo";
 import { resolveExecutable, tailMessage } from "./vo-exec";
@@ -249,5 +251,70 @@ describe("qcut-cityfilm vo runner helpers", () => {
 				fallback: "fallback-bin",
 			})
 		).toBe("fallback-bin");
+	});
+});
+
+describe("voice locking", () => {
+	const anchoredPlan = makePlan({
+		overrides: { voiceAnchorUrl: "https://fal.media/anchor.mp3" },
+	});
+
+	it("tags the prompt only when a reference is supplied", () => {
+		const plan = makePlan();
+		const [firstCue] = plan.cues;
+		const [firstAct] = plan.acts;
+		expect(
+			buildTtsPrompt({ cue: firstCue, act: firstAct })
+		).not.toContain(VOICE_REFERENCE_TAG);
+		expect(
+			buildTtsPrompt({
+				cue: firstCue,
+				act: firstAct,
+				referenceAudioUrl: "https://x/a.mp3",
+			})
+		).toMatch(new RegExp(`^${VOICE_REFERENCE_TAG} `));
+	});
+
+	it("passes the anchor through planVoJobs", () => {
+		const jobs = planVoJobs({ plan: anchoredPlan });
+		expect(jobs.every((job) => job.referenceAudioUrl === anchoredPlan.voiceAnchorUrl)).toBe(true);
+		expect(jobs.every((job) => job.prompt.startsWith(VOICE_REFERENCE_TAG))).toBe(
+			true
+		);
+	});
+
+	it("adds --audio-url to the CLI args when anchored", () => {
+		const args = buildTtsArgs({
+			model: "seed_audio",
+			prompt: "@Audio1 hi",
+			outputDir: "/tmp/out",
+			referenceAudioUrl: "https://fal.media/anchor.mp3",
+		});
+		expect(args).toContain("--audio-url");
+		expect(args[args.indexOf("--audio-url") + 1]).toBe(
+			"https://fal.media/anchor.mp3"
+		);
+		expect(args.at(-1)).toBe("--json");
+	});
+
+	it("omits --audio-url when no anchor is set", () => {
+		const args = buildTtsArgs({
+			model: "seed_audio",
+			prompt: "hi",
+			outputDir: "/tmp/out",
+		});
+		expect(args).not.toContain("--audio-url");
+	});
+
+	it("reads the hosted url out of a gen tts envelope", () => {
+		const stdout = `$ bun run pipeline\n${JSON.stringify({
+			status: "ok",
+			data: { data: { audioUrl: "https://fal.media/x.mp3" } },
+		})}`;
+		expect(parseTtsAudioUrl({ stdout })).toBe("https://fal.media/x.mp3");
+		expect(() => parseTtsAudioUrl({ stdout: "no json here" })).toThrow();
+		expect(() =>
+			parseTtsAudioUrl({ stdout: JSON.stringify({ status: "ok", data: {} }) })
+		).toThrow();
 	});
 });

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
@@ -41,6 +41,8 @@ export interface VoJob {
 	prompt: string;
 	/** Absolute destination, `<assetsDir>/vo/vo-<language>-<cueId>.mp3`. */
 	outputFile: string;
+	/** Voice anchor passed as `audio_urls[0]`, when the voice is locked. */
+	referenceAudioUrl?: string;
 }
 
 export type VoJobStatus = "generated" | "skipped" | "failed";
@@ -50,6 +52,8 @@ export interface VoJobOutcome {
 	status: VoJobStatus;
 	/** Present only when status is "failed". */
 	error?: string;
+	/** Hosted URL of the rendered take, reusable as a voice anchor. */
+	audioUrl?: string;
 }
 
 export interface VoJobFailure {
@@ -59,6 +63,8 @@ export interface VoJobFailure {
 }
 
 export interface VoBatchResult {
+	/** Anchor used (or discovered) for this batch; persist it into the plan. */
+	voiceAnchorUrl?: string;
 	generated: VoJob[];
 	skipped: VoJob[];
 	failed: VoJobFailure[];
@@ -80,6 +86,12 @@ export interface VoBatchOptions {
 	tempRoot?: string;
 	env?: NodeJS.ProcessEnv;
 	onProgress?: (outcome: VoJobOutcome) => void;
+	/**
+	 * Render the first cue alone, then anchor every remaining cue to it so the
+	 * whole cut keeps one voice. Defaults on; turn off only when the plan
+	 * already carries a `voiceAnchorUrl` or a single voice does not matter.
+	 */
+	lockVoice?: boolean;
 }
 
 export interface CueFit {
@@ -93,19 +105,25 @@ function roundMilliseconds({ value }: { value: number }): number {
 }
 
 /**
- * Prefix the copy with the act's emotion directive. The directive already ends
- * in its own closing paren, so nothing is inserted between the two halves.
+ * Token that binds a rendering to the first reference clip. Seed Audio only
+ * applies `audio_urls` when the prompt names the clip, so passing a reference
+ * without this tag leaves the speaker free to drift between cues.
  */
+export const VOICE_REFERENCE_TAG = "@Audio1";
+
 export function buildTtsPrompt({
 	cue,
 	act,
+	referenceAudioUrl,
 }: {
 	cue: Cue;
 	act?: ActPlan;
+	/** Anchor clip that fixes the speaker across every cue. */
+	referenceAudioUrl?: string;
 }): string {
 	const directive = act?.emotion?.trim();
-	if (!directive) return cue.text;
-	return `${directive}${cue.text}`;
+	const body = directive ? `${directive}${cue.text}` : cue.text;
+	return referenceAudioUrl ? `${VOICE_REFERENCE_TAG} ${body}` : body;
 }
 
 export function voFileName({
@@ -122,12 +140,15 @@ export function buildTtsArgs({
 	model,
 	prompt,
 	outputDir,
+	referenceAudioUrl,
 }: {
 	model: string;
 	prompt: string;
 	outputDir: string;
+	/** Sent as `audio_urls[0]`; the prompt must also carry the tag. */
+	referenceAudioUrl?: string;
 }): string[] {
-	return [
+	const args = [
 		"run",
 		"pipeline",
 		"gen",
@@ -138,24 +159,63 @@ export function buildTtsArgs({
 		prompt,
 		"-o",
 		outputDir,
-		"--json",
 	];
+	if (referenceAudioUrl) args.push("--audio-url", referenceAudioUrl);
+	args.push("--json");
+	return args;
+}
+
+/**
+ * Reads the hosted audio URL out of a `gen tts --json` envelope. The URL is
+ * what later cues reuse as their voice anchor, so it is kept rather than the
+ * downloaded file (the model needs a URL, not a local path).
+ */
+export function parseTtsAudioUrl({ stdout }: { stdout: string }): string {
+	const start = stdout.indexOf("{");
+	if (start < 0) throw new Error("gen tts did not return JSON");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout.slice(start)) as unknown;
+	} catch {
+		throw new Error("gen tts returned malformed JSON");
+	}
+	const envelope = parsed as {
+		data?: { data?: { audioUrl?: string }; audioUrl?: string };
+	};
+	const url = envelope.data?.data?.audioUrl ?? envelope.data?.audioUrl;
+	if (typeof url !== "string" || url.length === 0) {
+		throw new Error("gen tts response carried no audioUrl");
+	}
+	return url;
 }
 
 /**
  * One job per cue, in plan order. Nothing is filtered here — the runner decides
  * what already exists so callers can inspect the full intended set.
  */
-export function planVoJobs({ plan }: { plan: CityFilmPlan }): VoJob[] {
+export function planVoJobs({
+	plan,
+	referenceAudioUrl,
+}: {
+	plan: CityFilmPlan;
+	/** Anchor clip URL; when set every prompt is tagged and reference-bound. */
+	referenceAudioUrl?: string;
+}): VoJob[] {
 	const actsById = new Map(plan.acts.map((act) => [act.id, act]));
 	const voDir = join(plan.assetsDir, "vo");
+	const anchor = referenceAudioUrl ?? plan.voiceAnchorUrl;
 	return plan.cues.map((cue) => ({
 		cueId: cue.id,
-		prompt: buildTtsPrompt({ cue, act: actsById.get(cue.actId) }),
+		prompt: buildTtsPrompt({
+			cue,
+			act: actsById.get(cue.actId),
+			referenceAudioUrl: anchor,
+		}),
 		outputFile: join(
 			voDir,
 			voFileName({ language: plan.language, cueId: cue.id })
 		),
+		referenceAudioUrl: anchor,
 	}));
 }
 
@@ -293,6 +353,7 @@ async function runVoJob({
 				model: runtime.model,
 				prompt: job.prompt,
 				outputDir: workDir,
+				referenceAudioUrl: job.referenceAudioUrl,
 			}),
 			cwd: runtime.cwd,
 			env: runtime.env,
@@ -304,7 +365,13 @@ async function runVoJob({
 		const produced = pickGeneratedAudioName({ entries: readdirSync(workDir) });
 		if (!produced) throw new Error("tts produced no mp3");
 		moveFile({ from: join(workDir, produced), to: job.outputFile });
-		return { job, status: "generated" };
+		let audioUrl: string | undefined;
+		try {
+			audioUrl = parseTtsAudioUrl({ stdout: outcome.stdout });
+		} catch {
+			// The mp3 is on disk either way; only voice anchoring needs the URL.
+		}
+		return { job, status: "generated", audioUrl };
 	} catch (error) {
 		return {
 			job,
@@ -331,6 +398,7 @@ export async function runVoBatch({
 	tempRoot = tmpdir(),
 	env = process.env,
 	onProgress,
+	lockVoice = true,
 }: VoBatchOptions): Promise<VoBatchResult> {
 	const runtime: VoJobRuntime = {
 		model,
@@ -344,17 +412,47 @@ export async function runVoBatch({
 		force,
 		env,
 	};
-	const outcomes = await runWithConcurrency<VoJob, VoJobOutcome>({
-		items: jobs ?? planVoJobs({ plan }),
-		limit: concurrency,
-		worker: async (job) => {
-			const outcome = await runVoJob({ job, runtime });
-			onProgress?.(outcome);
-			return outcome;
-		},
-	});
+	const runOne = async (job: VoJob): Promise<VoJobOutcome> => {
+		const outcome = await runVoJob({ job, runtime });
+		onProgress?.(outcome);
+		return outcome;
+	};
 
-	const result: VoBatchResult = { generated: [], skipped: [], failed: [] };
+	// Seed Audio picks a new speaker per request, so the cues are rendered
+	// against a single anchor clip: either one supplied by the plan, or the
+	// first cue rendered on its own and then reused for the rest.
+	let anchorUrl = plan.voiceAnchorUrl;
+	const outcomes: VoJobOutcome[] = [];
+	let pending = jobs ?? planVoJobs({ plan, referenceAudioUrl: anchorUrl });
+
+	if (lockVoice && !anchorUrl && pending.length > 1) {
+		const [first, ...rest] = pending;
+		const firstOutcome = await runOne(first);
+		outcomes.push(firstOutcome);
+		anchorUrl = firstOutcome.audioUrl;
+		pending = anchorUrl
+			? rest.map((job) => ({
+					...job,
+					prompt: `${VOICE_REFERENCE_TAG} ${job.prompt}`,
+					referenceAudioUrl: anchorUrl,
+				}))
+			: rest;
+	}
+
+	outcomes.push(
+		...(await runWithConcurrency<VoJob, VoJobOutcome>({
+			items: pending,
+			limit: concurrency,
+			worker: runOne,
+		}))
+	);
+
+	const result: VoBatchResult = {
+		generated: [],
+		skipped: [],
+		failed: [],
+		voiceAnchorUrl: anchorUrl,
+	};
 	for (const outcome of outcomes) {
 		if (outcome.status === "generated") result.generated.push(outcome.job);
 		else if (outcome.status === "skipped") result.skipped.push(outcome.job);

--- a/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
+++ b/qcut/.claude/skills/qcut-toolkit/qcut-cityfilm/scripts/vo.ts
@@ -1,0 +1,370 @@
+/**
+ * Batch emotional narration for the city-film workflow.
+ *
+ * Each cue is spoken by ByteDance Seed Audio through the QCut pipeline CLI
+ * (`bun run pipeline gen tts -m seed_audio -t "<text>" -o <dir>`), which always
+ * writes `<dir>/speech.mp3`. Emotion is steered by prefixing the copy with the
+ * act's parenthesised directive in the copy's own language — the plain prompt
+ * reads flat, the directed one carries the cut.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ActPlan, CityFilmPlan, Cue } from "./types";
+import {
+	moveFile,
+	resolveExecutable,
+	spawnCollect,
+	tailMessage,
+} from "./vo-exec";
+
+/** Seed Audio is the only model that renders the emotion directives well. */
+export const DEFAULT_VO_MODEL = "seed_audio";
+/** Seed Audio tolerates a handful of parallel requests; four is safe. */
+export const DEFAULT_VO_CONCURRENCY = 4;
+/** A cue may run this far past its slot before the shot has to be relengthened. */
+export const DEFAULT_FIT_TOLERANCE_SECONDS = 0.25;
+/** The pipeline CLI always writes this basename into the output directory. */
+export const TTS_OUTPUT_BASENAME = "speech.mp3";
+
+/** One narration render: a prompt in, one mp3 out. */
+export interface VoJob {
+	cueId: string;
+	/** Emotion directive + copy, exactly as handed to the TTS model. */
+	prompt: string;
+	/** Absolute destination, `<assetsDir>/vo/vo-<language>-<cueId>.mp3`. */
+	outputFile: string;
+}
+
+export type VoJobStatus = "generated" | "skipped" | "failed";
+
+export interface VoJobOutcome {
+	job: VoJob;
+	status: VoJobStatus;
+	/** Present only when status is "failed". */
+	error?: string;
+}
+
+export interface VoJobFailure {
+	cueId: string;
+	outputFile: string;
+	error: string;
+}
+
+export interface VoBatchResult {
+	generated: VoJob[];
+	skipped: VoJob[];
+	failed: VoJobFailure[];
+}
+
+export interface VoBatchOptions {
+	plan: CityFilmPlan;
+	/** Defaults to `planVoJobs({ plan })`; pass a subset to re-render cues. */
+	jobs?: VoJob[];
+	model?: string;
+	concurrency?: number;
+	/** Re-render cues whose mp3 already exists. */
+	force?: boolean;
+	/** Executable that fronts `run pipeline ...`; defaults to Bun. */
+	executable?: string;
+	/** Must be the QCut repository root so `bun run pipeline` resolves. */
+	cwd?: string;
+	/** Parent directory for the per-job scratch dirs. */
+	tempRoot?: string;
+	env?: NodeJS.ProcessEnv;
+	onProgress?: (outcome: VoJobOutcome) => void;
+}
+
+export interface CueFit {
+	fits: boolean;
+	/** Seconds the narration runs past the cue slot; 0 when it fits. */
+	overflowSeconds: number;
+}
+
+function roundMilliseconds({ value }: { value: number }): number {
+	return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Prefix the copy with the act's emotion directive. The directive already ends
+ * in its own closing paren, so nothing is inserted between the two halves.
+ */
+export function buildTtsPrompt({
+	cue,
+	act,
+}: {
+	cue: Cue;
+	act?: ActPlan;
+}): string {
+	const directive = act?.emotion?.trim();
+	if (!directive) return cue.text;
+	return `${directive}${cue.text}`;
+}
+
+export function voFileName({
+	language,
+	cueId,
+}: {
+	language: string;
+	cueId: string;
+}): string {
+	return `vo-${language}-${cueId}.mp3`;
+}
+
+export function buildTtsArgs({
+	model,
+	prompt,
+	outputDir,
+}: {
+	model: string;
+	prompt: string;
+	outputDir: string;
+}): string[] {
+	return [
+		"run",
+		"pipeline",
+		"gen",
+		"tts",
+		"-m",
+		model,
+		"-t",
+		prompt,
+		"-o",
+		outputDir,
+		"--json",
+	];
+}
+
+/**
+ * One job per cue, in plan order. Nothing is filtered here — the runner decides
+ * what already exists so callers can inspect the full intended set.
+ */
+export function planVoJobs({ plan }: { plan: CityFilmPlan }): VoJob[] {
+	const actsById = new Map(plan.acts.map((act) => [act.id, act]));
+	const voDir = join(plan.assetsDir, "vo");
+	return plan.cues.map((cue) => ({
+		cueId: cue.id,
+		prompt: buildTtsPrompt({ cue, act: actsById.get(cue.actId) }),
+		outputFile: join(
+			voDir,
+			voFileName({ language: plan.language, cueId: cue.id })
+		),
+	}));
+}
+
+/**
+ * A long line overruns its shot, so every rendered cue is measured against the
+ * slot it was written for.
+ */
+export function checkCueFit({
+	cue,
+	voDurationSeconds,
+	toleranceSeconds = DEFAULT_FIT_TOLERANCE_SECONDS,
+}: {
+	cue: Cue;
+	voDurationSeconds: number;
+	toleranceSeconds?: number;
+}): CueFit {
+	const overflow = Math.max(0, voDurationSeconds - cue.durationSeconds);
+	return {
+		fits: overflow <= toleranceSeconds,
+		overflowSeconds: roundMilliseconds({ value: overflow }),
+	};
+}
+
+/** Prefer the documented `speech.mp3`, but accept a single renamed sibling. */
+export function pickGeneratedAudioName({
+	entries,
+}: {
+	entries: string[];
+}): string | undefined {
+	if (entries.includes(TTS_OUTPUT_BASENAME)) return TTS_OUTPUT_BASENAME;
+	return entries.find((entry) => entry.toLowerCase().endsWith(".mp3"));
+}
+
+export function parseDurationSeconds({ stdout }: { stdout: string }): number {
+	let parsed: { format?: { duration?: string } };
+	try {
+		parsed = JSON.parse(stdout) as { format?: { duration?: string } };
+	} catch {
+		throw new Error("ffprobe did not return JSON");
+	}
+	const duration = Number(parsed.format?.duration);
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error("ffprobe reported no usable duration");
+	}
+	return duration;
+}
+
+/** Bounded-concurrency map that preserves input order in the results. */
+export async function runWithConcurrency<TItem, TResult>({
+	items,
+	limit,
+	worker,
+}: {
+	items: TItem[];
+	limit: number;
+	worker: (item: TItem, index: number) => Promise<TResult>;
+}): Promise<TResult[]> {
+	const results = new Array<TResult>(items.length);
+	const lanes = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+	let cursor = 0;
+	const runners = Array.from({ length: lanes }, async () => {
+		while (cursor < items.length) {
+			const index = cursor;
+			cursor += 1;
+			results[index] = await worker(items[index] as TItem, index);
+		}
+	});
+	await Promise.all(runners);
+	return results;
+}
+
+/** Measure a rendered narration so callers can verify it fits its cue slot. */
+export async function probeDurationSeconds({
+	file,
+	ffprobe,
+	env = process.env,
+}: {
+	file: string;
+	ffprobe?: string;
+	env?: NodeJS.ProcessEnv;
+}): Promise<number> {
+	const outcome = await spawnCollect({
+		executable: resolveExecutable({
+			override: ffprobe ?? env.QCUT_CITYFILM_FFPROBE_BIN,
+			name: "ffprobe",
+			fallback: "ffprobe",
+		}),
+		args: [
+			"-v",
+			"error",
+			"-show_entries",
+			"format=duration",
+			"-of",
+			"json",
+			file,
+		],
+		env,
+	});
+	if (outcome.exitCode !== 0) {
+		throw new Error(
+			`ffprobe failed (${outcome.exitCode}) for ${file}: ${tailMessage({ text: outcome.stderr })}`
+		);
+	}
+	return parseDurationSeconds({ stdout: outcome.stdout });
+}
+
+interface VoJobRuntime {
+	model: string;
+	executable: string;
+	cwd?: string;
+	tempRoot: string;
+	force: boolean;
+	env?: NodeJS.ProcessEnv;
+}
+
+/** Renders one cue into its own scratch dir. Never throws. */
+async function runVoJob({
+	job,
+	runtime,
+}: {
+	job: VoJob;
+	runtime: VoJobRuntime;
+}): Promise<VoJobOutcome> {
+	if (!runtime.force && existsSync(job.outputFile)) {
+		return { job, status: "skipped" };
+	}
+	let workDir: string | undefined;
+	try {
+		mkdirSync(dirname(job.outputFile), { recursive: true });
+		mkdirSync(runtime.tempRoot, { recursive: true });
+		workDir = mkdtempSync(join(runtime.tempRoot, `cityfilm-vo-${job.cueId}-`));
+		const outcome = await spawnCollect({
+			executable: runtime.executable,
+			args: buildTtsArgs({
+				model: runtime.model,
+				prompt: job.prompt,
+				outputDir: workDir,
+			}),
+			cwd: runtime.cwd,
+			env: runtime.env,
+		});
+		if (outcome.exitCode !== 0) {
+			const detail = tailMessage({ text: outcome.stderr || outcome.stdout });
+			throw new Error(`tts exited ${outcome.exitCode}: ${detail}`);
+		}
+		const produced = pickGeneratedAudioName({ entries: readdirSync(workDir) });
+		if (!produced) throw new Error("tts produced no mp3");
+		moveFile({ from: join(workDir, produced), to: job.outputFile });
+		return { job, status: "generated" };
+	} catch (error) {
+		return {
+			job,
+			status: "failed",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		if (workDir) rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Render every cue's narration, skipping mp3s that already exist unless forced.
+ * A single failing cue never aborts the batch; it lands in `failed` instead.
+ */
+export async function runVoBatch({
+	plan,
+	jobs,
+	model = DEFAULT_VO_MODEL,
+	concurrency = DEFAULT_VO_CONCURRENCY,
+	force = false,
+	executable,
+	cwd = process.cwd(),
+	tempRoot = tmpdir(),
+	env = process.env,
+	onProgress,
+}: VoBatchOptions): Promise<VoBatchResult> {
+	const runtime: VoJobRuntime = {
+		model,
+		executable: resolveExecutable({
+			override: executable,
+			name: "bun",
+			fallback: process.execPath,
+		}),
+		cwd,
+		tempRoot,
+		force,
+		env,
+	};
+	const outcomes = await runWithConcurrency<VoJob, VoJobOutcome>({
+		items: jobs ?? planVoJobs({ plan }),
+		limit: concurrency,
+		worker: async (job) => {
+			const outcome = await runVoJob({ job, runtime });
+			onProgress?.(outcome);
+			return outcome;
+		},
+	});
+
+	const result: VoBatchResult = { generated: [], skipped: [], failed: [] };
+	for (const outcome of outcomes) {
+		if (outcome.status === "generated") result.generated.push(outcome.job);
+		else if (outcome.status === "skipped") result.skipped.push(outcome.job);
+		else {
+			result.failed.push({
+				cueId: outcome.job.cueId,
+				outputFile: outcome.job.outputFile,
+				error: outcome.error ?? "unknown error",
+			});
+		}
+	}
+	return result;
+}

--- a/qcut/vitest.config.ts
+++ b/qcut/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
 			"packages/platform-desktop/**/__tests__/**/*.{test,spec}.?(c|m)[jt]s?(x)",
 			"packages/platform-web/**/__tests__/**/*.{test,spec}.?(c|m)[jt]s?(x)",
 			"packages/editor-core/**/__tests__/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+			// Scoped to qcut-cityfilm: sibling skills (e.g. qcut-vlog) use bun:test,
+			// which Vitest cannot resolve.
+			".agents/skills/qcut-toolkit/qcut-cityfilm/scripts/**/*.{test,spec}.?(c|m)[jt]s?(x)",
 		],
 		exclude: ["**/node_modules/**", "**/dist/**", "**/tests/e2e/**"],
 		coverage: {


### PR DESCRIPTION
## Summary
Captures the Melbourne replica workflow as a reusable skill so the next reference-driven cut does not start from scratch: analyze a reference film → gather licensed footage → pick segments → plan per-act pacing and copy → narrate with emotional TTS → assemble in QCut → mix the audio bed → prove the result.

- `SKILL.md` documents all eight stages with exact CLI calls, plus the editor facts that cost real time when unknown (text `x`/`y` are canvas-pixel offsets from center, export ends at the last picture element, `timeline:import` drops transitions, CJK vs Latin subtitle sizing, CC-BY attribution is mandatory)
- `scripts/analyze.ts` + `analyze-graph.ts` — ffprobe metadata, contact sheets with computed tile timestamps (the staged ffmpeg has no `drawtext`), scene-cut pacing profile, audio extraction for speech-to-text
- `scripts/vo.ts` + `vo-exec.ts` — batched Seed Audio narration with per-act emotion directives, bounded concurrency, resume, cue-fit checking
- `scripts/mix.ts` + `mix-graph.ts` — ambience + segmented music + delayed VO with sidechain ducking, an orphan-label guard (an unused filter label aborts ffmpeg), and level measurement
- `scripts/main.ts` — `analyze` / `vo` / `mix` / `verify` dispatcher

Verification is a hard gate in the skill: measure levels on the **exported file** and look at extracted frames, because a timeline containing music can still export silent.

## Testing
- 57 tests pass across 6 files (pure arg/graph builders, pacing parsing, VO planning, mix graph, dispatcher parsing)
- `analyze` verified end to end against a real clip (duration, scene count, audio extraction)
- biome clean; `vitest.config.ts` include is scoped to this skill only — sibling skills use `bun:test` and would break under a broader glob
- Mirrored to `.claude/skills` and registered in the qcut-toolkit routing table per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reference-driven city and travel film workflow for creating multilingual promotional edits.
  * Added tools to analyze reference pacing, generate narration, assemble audio mixes, and verify exported results.
  * Added support for cue-based voiceover batches, music ducking, audio level checks, and timeline validation.
  * Added command-line workflow stages for analysis, narration, mixing, and verification.

* **Documentation**
  * Added workflow guidance, routing instructions, output requirements, licensing notes, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->