### PR TITLE
fix(export): keep trimmed audio clips audible in CLI exports

### DIFF
--- a/qcut/electron/__tests__/claude-export-trigger.test.ts
+++ b/qcut/electron/__tests__/claude-export-trigger.test.ts
@@ -239,7 +239,9 @@ describe("Claude export trigger", () => {
 				trackId: "audio-track",
 				path: "/tmp/voiceover.wav",
 				startTime: 1.25,
-				duration: 3,
+				// Source length: the filter graph subtracts the trims itself, so a
+				// 3s-on-screen clip trimmed by 0.5s + 0.25s spans 3.75s of source.
+				duration: 3.75,
 				trimStart: 0.5,
 				trimEnd: 0.25,
 				volume: 0.8,
@@ -247,6 +249,59 @@ describe("Claude export trigger", () => {
 				fadeOut: 0.3,
 			}),
 		]);
+	});
+
+	it("keeps heavily trimmed audio clips audible", async () => {
+		// A 164s music bed trimmed down to its first 48.4s used to arrive as
+		// duration 48.4 with trimEnd 115.6; the graph then subtracted the trim a
+		// second time and collapsed the clip to a 0.01s blip of silence.
+		const audioFiles = await collectTimelineAudioFiles({
+			projectId: "project_music_bed",
+			timeline: {
+				...testTimeline,
+				tracks: [
+					...testTimeline.tracks,
+					{
+						id: "music-track",
+						index: 1,
+						name: "Music",
+						type: "audio",
+						elements: [
+							{
+								id: "music-bed",
+								trackIndex: 1,
+								startTime: 0,
+								endTime: 48.4,
+								duration: 48.4,
+								type: "audio" as const,
+								sourceId: "music-media",
+								trimStart: 0,
+								trimEnd: 115.6,
+							},
+						],
+					},
+				],
+			},
+			mediaFiles: [
+				...testMediaFiles,
+				{
+					id: "music-media",
+					name: "music.mp3",
+					type: "audio" as const,
+					path: "/tmp/music.mp3",
+					size: 4096,
+					duration: 164,
+					createdAt: Date.now(),
+					modifiedAt: Date.now(),
+				},
+			],
+		});
+
+		expect(audioFiles).toHaveLength(1);
+		const [music] = audioFiles;
+		expect(music.duration).toBe(164);
+		// What the filter graph will actually play.
+		expect(music.duration - music.trimStart - music.trimEnd).toBeCloseTo(48.4);
 	});
 
 	it("starts export with nested custom settings", async () => {

--- a/qcut/electron/claude/handlers/claude-export-handler/export-engine.ts
+++ b/qcut/electron/claude/handlers/claude-export-handler/export-engine.ts
@@ -249,10 +249,16 @@ export async function collectTimelineAudioFiles({
 					: {};
 			const read = (key: string): unknown =>
 				elementRecord[key] !== undefined ? elementRecord[key] : props[key];
-			const duration =
+			const trimStart = optionalNumber(element.trimStart, 0) ?? 0;
+			const trimEnd = optionalNumber(element.trimEnd, 0) ?? 0;
+			const visibleDuration =
 				optionalNumber(element.duration) ??
 				Math.max(0, element.endTime - element.startTime);
-			if (!duration || duration <= 0) continue;
+			if (!visibleDuration || visibleDuration <= 0) continue;
+			// The serialized timeline reports how long the clip plays, while the
+			// audio filter graph expects the source length and subtracts the trims
+			// itself. Without converting back, a trimmed clip collapses to silence.
+			const duration = visibleDuration + trimStart + trimEnd;
 
 			audioFiles.push({
 				elementId: element.id,
@@ -261,8 +267,8 @@ export async function collectTimelineAudioFiles({
 				startTime: Math.max(0, element.startTime),
 				volume: optionalNumber(read("volume"), 1),
 				sourceGain: optionalNumber(read("sourceGain"), 1),
-				trimStart: optionalNumber(element.trimStart, 0),
-				trimEnd: optionalNumber(element.trimEnd, 0),
+				trimStart,
+				trimEnd,
 				duration,
 				fadeIn: optionalNumber(read("audioFadeIn"), 0),
 				fadeOut: optionalNumber(read("audioFadeOut"), 0),


### PR DESCRIPTION
## The bug
Any audio clip with a trim exported as silence. A 164s music bed trimmed to its first 48.4s produced digital silence (-91 dB) in the output; untrimmed clips (VO with trim 0) were unaffected, which is why exports had narration but no music.

## Root cause
`collectTimelineAudioFiles` (CLI export path) read `element.duration` from the serialized timeline — that field is **how long the clip plays** — and handed it to the audio filter graph, which expects the **source length** and subtracts the trims itself:

```
effectiveDuration = max(0.01, duration - trimStart - trimEnd)
                  = max(0.01, 48.4 - 0 - 115.6)   // 10ms blip
```

The trims were applied twice. Fixed by converting back to source length at that boundary.

## Verification
- Minimal repro (same music, one element trimmed, one not): trimmed exported at -91 dB, untrimmed at -25 dB. After the fix both are audible.
- Real 100s project: music bed at 0s now exports at -42.7 dB over 0-2s and -22.4 dB at 2s, matching the source track's own levels at those timestamps (-42.6 / -22.4); previously 0-7s was digital silence.
- An existing test asserted the buggy contract (`duration: 3` for a 3s-on-screen clip trimmed by 0.5s + 0.25s); updated to the correct source length 3.75 and added a regression test for the heavy-trim collapse.
- 2058 tests pass across electron/, export/, export-cli/ and claude-bridge/; tsc and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)