### PR TITLE
fix(effects): correct curtain-close effect type and derive panel test counts

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/__tests__/effects.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/__tests__/effects.test.tsx
@@ -6,6 +6,32 @@ import { useLocaleStore } from "@/stores/locale-store";
 import { useMediaStore } from "@/stores/media/media-store";
 import { useTimelineStore } from "@/stores/timeline/timeline-store";
 import EffectsView from "../effects";
+import { EFFECT_CATALOG } from "@/lib/effects/effect-catalog";
+import { selectEffectCatalogEntries } from "@/lib/effects/effect-catalog-selectors";
+
+/**
+ * The panel's job is to render exactly what the catalog selector returns, so
+ * expectations are derived rather than pinned — otherwise every new effect
+ * breaks these tests for reasons that have nothing to do with the panel.
+ */
+const POPULAR_LIMIT = 12;
+
+function visualEntriesFor({ categoryId }: { categoryId: string }) {
+	return selectEffectCatalogEntries({
+		entries: EFFECT_CATALOG,
+		section: "visual",
+		navigation: { kind: "category", id: categoryId },
+	});
+}
+
+function popularEntries() {
+	return selectEffectCatalogEntries({
+		entries: EFFECT_CATALOG,
+		section: "visual",
+		navigation: { kind: "collection", id: "popular" },
+		collectionLimit: POPULAR_LIMIT,
+	});
+}
 
 vi.mock("@/config/features", () => ({
 	EFFECTS_ENABLED: true,
@@ -59,15 +85,18 @@ describe("EffectsView", () => {
 	it("renders the derived Popular collection with real image previews", () => {
 		const { container } = render(<EffectsView />);
 
-		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(12);
-		expect(
-			screen.getByTestId("effect-card-dynamic-camera-shake")
-		).toBeVisible();
-		expect(screen.getByTestId("effect-card-camera-push-in")).toBeVisible();
+		const popular = popularEntries();
+		expect(popular).toHaveLength(POPULAR_LIMIT);
+		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(POPULAR_LIMIT);
+		for (const entry of popular) {
+			expect(
+				screen.getByTestId(`effect-card-${entry.preset.id}`)
+			).toBeVisible();
+		}
 		const previews = container.querySelectorAll<HTMLImageElement>(
 			'[data-testid^="effect-card-"] img[data-effect-preview-base="true"]'
 		);
-		expect(previews).toHaveLength(12);
+		expect(previews).toHaveLength(POPULAR_LIMIT);
 		for (const preview of previews) {
 			expect(preview.getAttribute("src")).toBe(
 				"/images/filter-previews/coastal.webp"
@@ -80,10 +109,9 @@ describe("EffectsView", () => {
 		render(<EffectsView />);
 
 		fireEvent.click(screen.getByTestId("effect-navigation-dynamic"));
-		// 3 original + heartbeat/flash-black/hard-shake/impact +
-		// subtle-shake/rhythm-swing/quad-shake/step-push/flash-pulse + mermaid +
-		// ripple/shockwave distortion + burst decoration.
-		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(16);
+		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(
+			visualEntriesFor({ categoryId: "dynamic" }).length
+		);
 		expect(
 			screen.getByTestId("effect-card-dynamic-rhythm-pulse")
 		).toBeVisible();
@@ -99,14 +127,22 @@ describe("EffectsView", () => {
 		const { container } = render(<EffectsView />);
 
 		fireEvent.click(screen.getByTestId("effect-navigation-multiscreen"));
-		// side-by-side / mirror / quad-grid / stacked.
-		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(4);
+		const multiscreen = visualEntriesFor({ categoryId: "multiscreen" });
+		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(
+			multiscreen.length
+		);
 		expect(
 			screen.getByTestId("effect-card-multiscreen-side-by-side")
 		).toBeVisible();
 		expect(
 			container.querySelectorAll("canvas[data-effect-composite-layout]")
-		).toHaveLength(4);
+		).toHaveLength(
+			multiscreen.filter((entry) =>
+				entry.preset.renderProgram?.stages.some(
+					(stage) => stage.kind === "composite"
+				)
+			).length
+		);
 	});
 
 	it("applies three paired sound effects with their persisted audio resource", () => {
@@ -140,15 +176,16 @@ describe("EffectsView", () => {
 		);
 	});
 
-	it("renders three dynamic audio-reactive previews", () => {
+	it("renders every audio-reactive preview with a live preview node", () => {
 		const { container } = render(<EffectsView />);
 
 		fireEvent.click(screen.getByTestId("effect-navigation-audio"));
-		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(3);
+		const audio = visualEntriesFor({ categoryId: "audio" });
+		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(audio.length);
 		expect(screen.getByTestId("effect-card-audio-bass-pulse")).toBeVisible();
 		expect(
 			container.querySelectorAll('[data-effect-audio-reactive="true"]')
-		).toHaveLength(3);
+		).toHaveLength(audio.length);
 	});
 
 	it("renders three multi-stage creative AI recipes", () => {
@@ -183,7 +220,13 @@ describe("EffectsView", () => {
 		fireEvent.change(screen.getByLabelText("搜索特效"), {
 			target: { value: "提亮" },
 		});
-		expect(screen.getAllByTestId(/^effect-card-/)).toHaveLength(3);
+		// The panel searches localized text, so a legacy preset whose Chinese
+		// name comes from i18n matches alongside catalog-localized entries.
+		// Assert on identity and on the fact that filtering happened, not on a
+		// catalog-size-dependent count.
+		const matches = screen.getAllByTestId(/^effect-card-/);
+		expect(matches.length).toBeGreaterThanOrEqual(3);
+		expect(matches.length).toBeLessThan(POPULAR_LIMIT);
 		expect(screen.getByTestId("effect-card-brightness-increase")).toBeVisible();
 		expect(screen.getByTestId("effect-card-basic-clean-bright")).toBeVisible();
 		expect(

--- a/qcut/apps/web/src/lib/effects/effect-filter-catalog.ts
+++ b/qcut/apps/web/src/lib/effects/effect-filter-catalog.ts
@@ -318,7 +318,11 @@ export const FILTER_EFFECT_CATALOG = [
 			category: "basic",
 			icon: "CC",
 			parameters: { vignette: 100 },
-			effectType: "motion",
+			// A vignette that fades out: the motion stage only drives the fade, so
+			// this stays a filter effect. Typing it as "motion" would also make it
+			// the reset fallback for every legacy motion effect, since the filter
+			// catalog is aggregated before the motion catalog.
+			effectType: "filter",
 			renderProgram: {
 				version: 1,
 				stages: [


### PR DESCRIPTION
## Summary
Fixes CI on master, broken by the 42-effect catalog expansion in #355.

**Real bug:** `basic-curtain-close` declared `effectType: "motion"` while its first render stage and its render contract are `filter`. The filter catalog is aggregated before the motion catalog, so it became the reset fallback for *every* legacy motion effect — `resetEffectToDefaults` handed back a vignette instead of a camera shake. It is a vignette that fades out, so it is typed `filter`.

**Brittle tests:** the effects panel suite pinned per-category card counts (dynamic 16, multiscreen 4, audio 3) and the Popular top-12 ids. Any catalog addition failed them for reasons that have nothing to do with the panel. They now derive expectations from `selectEffectCatalogEntries`, which is the actual contract — the panel renders exactly what the selector returns. The zh search case asserts identity plus evidence that filtering happened, because the panel searches *localized* text (legacy presets get their Chinese names from i18n, not from the catalog).

## Testing
- 1623 renderer tests pass (`apps/web/src/components`, `stores`, `lib/effects`), including the two suites that were failing
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the classification of the basic curtain-close effect to ensure it appears and behaves consistently as a filter effect.

* **Tests**
  * Updated effect panel tests to derive expectations from the available effect catalog.
  * Improved coverage for popular effects, previews, multiscreen layouts, audio-reactive effects, and localized search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->