### PR TITLE
fix(transitions): match ten Jianying transition references

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-parity-ten.test.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-parity-ten.test.ts
@@ -35,7 +35,7 @@ describe("Jianying exact-ten transition parity manifest", () => {
 		);
 
 		expect(matchingPresets, qcutPresetId).toHaveLength(1);
-		const preset = matchingPresets[0];
+		const preset = matchingPresets.at(0);
 		expect(preset, qcutPresetId).toBeDefined();
 		if (!preset) return;
 

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-parity-ten.test.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-parity-ten.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+	TRANSITION_PARITY_CASES,
+	TRANSITION_PARITY_PROGRESS_STOPS,
+} from "../transition-parity-ten";
+import {
+	getClipTransitionPresetConfig,
+	transitionPresets,
+} from "../transition-presets";
+
+describe("Jianying exact-ten transition parity manifest", () => {
+	it("contains exactly ten unique Jianying names and QCut preset ids", () => {
+		const jianyingNames = TRANSITION_PARITY_CASES.map(
+			(item) => item.jianyingName
+		);
+		const qcutPresetIds = TRANSITION_PARITY_CASES.map(
+			(item) => item.qcutPresetId
+		);
+
+		expect(TRANSITION_PARITY_CASES).toHaveLength(10);
+		expect(new Set(jianyingNames).size).toBe(10);
+		expect(new Set(qcutPresetIds).size).toBe(10);
+		expect(TRANSITION_PARITY_PROGRESS_STOPS).toEqual([0.25, 0.5, 0.75]);
+	});
+
+	it.each(
+		TRANSITION_PARITY_CASES
+	)("maps $jianyingName to the expected $visualSemantics config", ({
+		jianyingName,
+		qcutPresetId,
+		expectedConfig,
+	}) => {
+		const matchingPresets = transitionPresets.filter(
+			(preset) => preset.id === qcutPresetId
+		);
+
+		expect(matchingPresets, qcutPresetId).toHaveLength(1);
+		const preset = matchingPresets[0];
+		expect(preset, qcutPresetId).toBeDefined();
+		if (!preset) return;
+
+		expect(preset.localizedName, qcutPresetId).toBe(jianyingName);
+		expect(getClipTransitionPresetConfig({ preset }), qcutPresetId).toEqual(
+			expectedConfig
+		);
+	});
+});

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-presets.test.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-presets.test.ts
@@ -9,6 +9,7 @@ import {
 	transitionPresets,
 } from "../transition-presets";
 import { TRANSITION_CATEGORY_EXPANSIONS } from "../transition-category-expansions";
+import { TRANSITION_PARITY_CASES } from "../transition-parity-ten";
 
 function requirePreset({ presetId }: { presetId: string }): TransitionPreset {
 	const preset = getTransitionPresetById({ presetId });
@@ -114,6 +115,36 @@ describe("transition presets", () => {
 				(preset) => preset.id
 			)
 		).toContain("film-burn");
+	});
+
+	it.each(
+		TRANSITION_PARITY_CASES
+	)("finds the selected JianYing name $jianyingName", ({
+		jianyingName,
+		qcutPresetId,
+	}) => {
+		expect(
+			filterTransitionPresets({
+				category: "all",
+				query: jianyingName,
+			}).map((preset) => preset.id)
+		).toContain(qcutPresetId);
+		expect(requirePreset({ presetId: qcutPresetId }).localizedName).toBe(
+			jianyingName
+		);
+	});
+
+	it.each([
+		["圆圈扩散", "circle-expand"],
+		["爱心扩散", "heart-expand"],
+		["向左翻页", "page-flip"],
+		["横向拖影", "horizontal-motion-blur"],
+	] as const)("keeps the former localized term %s searchable", (query, presetId) => {
+		expect(
+			filterTransitionPresets({ category: "all", query }).map(
+				(preset) => preset.id
+			)
+		).toContain(presetId);
 	});
 });
 

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-preview.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transition-preview.test.tsx
@@ -117,7 +117,7 @@ describe("TransitionPreview", () => {
 		expect(fill.style.width).toBe("50%");
 
 		const { from, to } = getLayers({ container });
-		expect(from.style.opacity).toBe("0.5");
+		expect(from.style.opacity).toBe("1");
 		expect(to.style.opacity).toBe("0.5");
 	});
 

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transitions-view.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/__tests__/transitions-view.test.tsx
@@ -171,9 +171,9 @@ describe("TransitionsView", () => {
 		for (const [category, presetId, expectedCount] of [
 			["叠化", "filmic-dissolve", 20],
 			["自然", "sunrise-fade", 20],
-			["幻灯片", "album-slide-left", 28],
-			["分割", "split-signal", 26],
-			["模糊", "horizontal-smear", 21],
+			["幻灯片", "album-slide-left", 29],
+			["分割", "split-signal", 28],
+			["模糊", "horizontal-smear", 22],
 			["运镜", "crash-zoom", 29],
 			["拍摄", "exposure-pop", 20],
 			["扭曲", "digital-twist", 20],

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-category-expansions/jianying-parity-masks.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-category-expansions/jianying-parity-masks.ts
@@ -11,11 +11,15 @@ const maskParityDissolve = categoryExpansion({
 		[
 			"circle-expand",
 			"Circle Expand",
-			"圆圈扩散",
+			"圆形遮罩 II",
 			"texture",
 			"texture-mask",
 			0.6,
-			{ maskShape: "circle", tags: ["circle", "mask"], popular: true },
+			{
+				maskShape: "circle",
+				tags: ["circle", "mask", "圆圈扩散"],
+				popular: true,
+			},
 		],
 	],
 });
@@ -83,11 +87,15 @@ const maskParityEmoji = categoryExpansion({
 		[
 			"heart-expand",
 			"Heart Expand",
-			"爱心扩散",
+			"心形叠化",
 			"texture",
 			"texture-mask",
 			0.65,
-			{ maskShape: "heart", tags: ["heart", "love"], popular: true },
+			{
+				maskShape: "heart",
+				tags: ["heart", "love", "爱心扩散"],
+				popular: true,
+			},
 		],
 	],
 });

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-category-expansions/jianying-parity.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-category-expansions/jianying-parity.ts
@@ -18,7 +18,7 @@ const dissolveParity = categoryExpansion({
 			"Dissolve Zoom",
 			"叠化拉近",
 			"zoom",
-			"zoom-blur",
+			"zoom-in-blur",
 			0.6,
 			{ tuning: { intensity: 0.22 }, tags: ["zoom", "soft"], popular: true },
 		],

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-jianying-selected-presets.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-jianying-selected-presets.ts
@@ -1,0 +1,58 @@
+import {
+	defineTransitionPreset,
+	type TransitionPreset,
+} from "./transition-preset-types";
+
+export const SELECTED_JIANYING_TRANSITION_PRESETS: TransitionPreset[] = [
+	defineTransitionPreset({
+		id: "page-flip",
+		name: "Page Flip",
+		localizedName: "翻页",
+		category: "slideshow",
+		type: "page",
+		clipType: "page-flip",
+		direction: "left",
+		defaultDuration: 0.5,
+		tuning: { intensity: 0.7 },
+		tags: ["向左翻页", "page turn"],
+		popular: true,
+	}),
+	defineTransitionPreset({
+		id: "move-left",
+		name: "Move Left",
+		localizedName: "左移",
+		category: "split",
+		type: "push",
+		clipType: "push",
+		// direction is the incoming origin; right produces leftward travel
+		direction: "right",
+		defaultDuration: 0.45,
+		tags: ["向左移动", "push"],
+		popular: true,
+	}),
+	defineTransitionPreset({
+		id: "move-right",
+		name: "Move Right",
+		localizedName: "右移",
+		category: "split",
+		type: "push",
+		clipType: "push",
+		direction: "left",
+		defaultDuration: 0.45,
+		tags: ["向右移动", "push"],
+		popular: true,
+	}),
+	defineTransitionPreset({
+		id: "horizontal-motion-blur",
+		name: "Horizontal Motion Blur",
+		localizedName: "横移模糊",
+		category: "blur",
+		type: "motion-blur",
+		clipType: "motion-blur",
+		direction: "left",
+		defaultDuration: 0.48,
+		tuning: { intensity: 0.65 },
+		tags: ["横向拖影", "向左拖影", "horizontal smear"],
+		popular: true,
+	}),
+];

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten.ts
@@ -1,0 +1,114 @@
+import type { ClipTransitionPresetConfig } from "./transition-preset-types";
+
+export const TRANSITION_PARITY_PROGRESS_STOPS = [0.25, 0.5, 0.75] as const;
+
+type TransitionParityVisualSemantics =
+	| "crossfade"
+	| "zoom-crossfade"
+	| "page-flip"
+	| "cube-rotation"
+	| "move-left"
+	| "move-right"
+	| "zoom-defocus"
+	| "horizontal-motion-blur"
+	| "circle-mask"
+	| "heart-mask";
+
+export interface TransitionParityCase {
+	jianyingName: string;
+	qcutPresetId: string;
+	visualSemantics: TransitionParityVisualSemantics;
+	expectedConfig: ClipTransitionPresetConfig;
+}
+
+export const TRANSITION_PARITY_CASES = [
+	{
+		jianyingName: "叠化",
+		qcutPresetId: "dissolve",
+		visualSemantics: "crossfade",
+		expectedConfig: { type: "dissolve" },
+	},
+	{
+		jianyingName: "叠化拉近",
+		qcutPresetId: "dissolve-zoom-in",
+		visualSemantics: "zoom-crossfade",
+		expectedConfig: {
+			type: "zoom-in-blur",
+			tuning: { intensity: 0.22 },
+		},
+	},
+	{
+		jianyingName: "翻页",
+		qcutPresetId: "page-flip",
+		visualSemantics: "page-flip",
+		expectedConfig: {
+			type: "page-flip",
+			direction: "left",
+			tuning: { intensity: 0.7 },
+		},
+	},
+	{
+		jianyingName: "立方旋转",
+		qcutPresetId: "cube-rotate",
+		visualSemantics: "cube-rotation",
+		expectedConfig: {
+			type: "cube",
+			tuning: { intensity: 1 },
+		},
+	},
+	{
+		jianyingName: "左移",
+		qcutPresetId: "move-left",
+		visualSemantics: "move-left",
+		expectedConfig: {
+			type: "push",
+			direction: "right",
+		},
+	},
+	{
+		jianyingName: "右移",
+		qcutPresetId: "move-right",
+		visualSemantics: "move-right",
+		expectedConfig: {
+			type: "push",
+			direction: "left",
+		},
+	},
+	{
+		jianyingName: "推镜虚化",
+		qcutPresetId: "push-zoom-defocus",
+		visualSemantics: "zoom-defocus",
+		expectedConfig: {
+			type: "zoom-blur",
+			tuning: { intensity: 0.75 },
+		},
+	},
+	{
+		jianyingName: "横移模糊",
+		qcutPresetId: "horizontal-motion-blur",
+		visualSemantics: "horizontal-motion-blur",
+		expectedConfig: {
+			type: "motion-blur",
+			direction: "left",
+			tuning: { intensity: 0.65 },
+		},
+	},
+	{
+		jianyingName: "圆形遮罩 II",
+		qcutPresetId: "circle-expand",
+		visualSemantics: "circle-mask",
+		expectedConfig: {
+			type: "texture-mask",
+			maskShape: "circle",
+		},
+	},
+	{
+		jianyingName: "心形叠化",
+		qcutPresetId: "heart-expand",
+		visualSemantics: "heart-mask",
+		expectedConfig: {
+			type: "texture-mask",
+			maskShape: "heart",
+		},
+	},
+] as const satisfies readonly TransitionParityCase[];

--- a/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-presets.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/transitions/transition-presets.ts
@@ -3,6 +3,7 @@ import { ADDITIONAL_TRANSITION_PRESETS } from "./transition-additional-presets";
 import { TRANSITION_CATEGORY_EXPANSIONS } from "./transition-category-expansions";
 import { buildTransitionCatalogDensity } from "./transition-catalog-density";
 import { TRANSITION_ENGINE_PRESETS } from "./transition-engine-presets/index";
+import { SELECTED_JIANYING_TRANSITION_PRESETS } from "./transition-jianying-selected-presets";
 import {
 	defineTransitionPreset as definePreset,
 	type ClipTransitionPresetConfig,
@@ -288,6 +289,7 @@ const BASE_TRANSITION_PRESETS: TransitionPreset[] = [
 	...glitchPresets,
 	...mgPresets,
 	...ADDITIONAL_TRANSITION_PRESETS,
+	...SELECTED_JIANYING_TRANSITION_PRESETS,
 	...TRANSITION_CATEGORY_EXPANSIONS,
 	...TRANSITION_ENGINE_PRESETS,
 ];

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -422,6 +422,7 @@ export function PreviewPanel() {
 				tracks: renderTracks,
 				currentTime: effectiveTime,
 				forceActiveElementIds: forcedActiveElementIds,
+				activeTransitionIds: activeTransitionPreview.activeTransitionIds,
 				getElementDuration: ({ element }) => getPreviewElementDuration(element),
 			});
 			const layers = [...plan.visualLayers, ...plan.audioElements];
@@ -438,6 +439,7 @@ export function PreviewPanel() {
 		}
 	}, [
 		forcedActiveElementIds,
+		activeTransitionPreview.activeTransitionIds,
 		renderTracks,
 		currentTime,
 		playbackTime,

--- a/qcut/apps/web/src/lib/transitions/__tests__/clip-transition-presentation.test.ts
+++ b/qcut/apps/web/src/lib/transitions/__tests__/clip-transition-presentation.test.ts
@@ -52,7 +52,12 @@ describe("clip transition presentation", () => {
 			presentations({ type: "dissolve", role: "from" }).map(
 				(item) => item.opacity
 			)
-		).toEqual([1, 0.75, 0.5, 0.25, 0]);
+		).toEqual([1, 1, 1, 1, 1]);
+		expect(
+			presentations({ type: "dissolve", role: "to" }).map(
+				(item) => item.opacity
+			)
+		).toEqual([0, 0.25, 0.5, 0.75, 1]);
 		expect(
 			presentations({ type: "fade-black", role: "from" }).map(
 				(item) => item.contentOpacity
@@ -104,27 +109,28 @@ describe("clip transition presentation", () => {
 		]);
 	});
 
-	it("crossfades dissolve layers", () => {
+	it("crossfades stacked dissolve layers without dimming", () => {
 		const dissolve = transition({ type: "dissolve" });
+		const outgoing = getClipTransitionLayerPresentation({
+			transition: dissolve,
+			role: "from",
+			progress: 0.25,
+			canvasWidth: 1920,
+			canvasHeight: 1080,
+		});
+		const incoming = getClipTransitionLayerPresentation({
+			transition: dissolve,
+			role: "to",
+			progress: 0.25,
+			canvasWidth: 1920,
+			canvasHeight: 1080,
+		});
 
-		expect(
-			getClipTransitionLayerPresentation({
-				transition: dissolve,
-				role: "from",
-				progress: 0.25,
-				canvasWidth: 1920,
-				canvasHeight: 1080,
-			}).opacity
-		).toBe(0.75);
-		expect(
-			getClipTransitionLayerPresentation({
-				transition: dissolve,
-				role: "to",
-				progress: 0.25,
-				canvasWidth: 1920,
-				canvasHeight: 1080,
-			}).opacity
-		).toBe(0.25);
+		expect(outgoing.opacity).toBe(1);
+		expect(incoming.opacity).toBe(0.25);
+		expect(incoming.opacity + outgoing.opacity * (1 - incoming.opacity)).toBe(
+			1
+		);
 	});
 
 	it("uses black between fade layers", () => {
@@ -225,9 +231,19 @@ describe("clip transition presentation", () => {
 			});
 
 		expect(midpoint({ type: "zoom-blur" })).toMatchObject({
-			opacity: 0.5,
+			opacity: 1,
 			scale: 1.18,
 			blur: 12,
+		});
+		expect(midpoint({ type: "zoom-in-blur" })).toMatchObject({
+			opacity: 1,
+			scale: 1.06,
+			blur: 8,
+		});
+		expect(midpoint({ type: "zoom-in-blur", role: "to" })).toMatchObject({
+			opacity: 0.5,
+			scale: 0.94,
+			blur: 8,
 		});
 		expect(midpoint({ type: "whip-pan", direction: "left" })).toMatchObject({
 			offsetX: 50,
@@ -349,6 +365,61 @@ describe("clip transition presentation", () => {
 			position: "absolute",
 			mixBlendMode: "screen",
 		});
+	});
+
+	it("feathers the selected circle and heart reveals", () => {
+		const circle = getClipTransitionLayerPresentation({
+			transition: {
+				...transition({ type: "texture-mask" }),
+				maskShape: "circle",
+			},
+			role: "to",
+			progress: 0.5,
+			canvasWidth: 320,
+			canvasHeight: 180,
+		});
+		const heart = getClipTransitionLayerPresentation({
+			transition: {
+				...transition({ type: "texture-mask" }),
+				maskShape: "heart",
+			},
+			role: "to",
+			progress: 0.5,
+			canvasWidth: 320,
+			canvasHeight: 180,
+		});
+		const nearlyCompleteCircle = getClipTransitionLayerPresentation({
+			transition: {
+				...transition({ type: "texture-mask" }),
+				maskShape: "circle",
+			},
+			role: "to",
+			progress: 0.998,
+			canvasWidth: 320,
+			canvasHeight: 180,
+		});
+
+		expect(circle.maskImage).toContain(
+			"#000 0 91.79px, rgba(0,0,0,0.5) 97.30px, transparent 102.80px"
+		);
+		expect(circle.maskImage).not.toContain("clip-path");
+		expect(nearlyCompleteCircle.maskImage).toContain("#000 0 188.69px");
+		expect(decodeURIComponent(heart.maskImage ?? "")).toContain(
+			'feGaussianBlur stdDeviation=".65"'
+		);
+		expect(heart.maskSize).toBe("auto 101.2%");
+
+		const nearlyCompleteHeart = getClipTransitionLayerPresentation({
+			transition: {
+				...transition({ type: "texture-mask" }),
+				maskShape: "heart",
+			},
+			role: "to",
+			progress: 0.998,
+			canvasWidth: 320,
+			canvasHeight: 180,
+		});
+		expect(nearlyCompleteHeart.maskSize).toBe("auto 494.8%");
 	});
 
 	it("builds a CSS filter only when presentation effects are active", () => {

--- a/qcut/apps/web/src/lib/transitions/__tests__/clip-transition-preview.test.ts
+++ b/qcut/apps/web/src/lib/transitions/__tests__/clip-transition-preview.test.ts
@@ -55,6 +55,7 @@ describe("active clip transition preview", () => {
 			fps: 30,
 		});
 
+		expect([...result.activeTransitionIds]).toEqual(["ab"]);
 		expect([...result.forceActiveElementIds]).toEqual(["a", "b"]);
 		const outgoing = result.statesByElementId.get("a");
 		expect(outgoing).toMatchObject({
@@ -87,6 +88,7 @@ describe("active clip transition preview", () => {
 			fps: 30,
 		});
 
+		expect(result.activeTransitionIds.size).toBe(0);
 		expect(result.forceActiveElementIds.size).toBe(0);
 		expect(result.statesByElementId.size).toBe(0);
 	});

--- a/qcut/apps/web/src/lib/transitions/clip-transition-preview.ts
+++ b/qcut/apps/web/src/lib/transitions/clip-transition-preview.ts
@@ -18,6 +18,7 @@ export interface ClipTransitionPreviewState {
 }
 
 export interface ActiveClipTransitionPreview {
+	activeTransitionIds: ReadonlySet<string>;
 	forceActiveElementIds: ReadonlySet<string>;
 	statesByElementId: ReadonlyMap<string, ClipTransitionPreviewState>;
 }
@@ -41,6 +42,7 @@ export function resolveActiveClipTransitionPreview({
 	currentTime: number;
 	fps: number;
 }): ActiveClipTransitionPreview {
+	const activeTransitionIds = new Set<string>();
 	const forceActiveElementIds = new Set<string>();
 	const statesByElementId = new Map<string, ClipTransitionPreviewState>();
 	const frameRate = Math.max(1, fps);
@@ -100,10 +102,11 @@ export function resolveActiveClipTransitionPreview({
 
 			forceActiveElementIds.add(resolved.fromElement.id);
 			forceActiveElementIds.add(resolved.toElement.id);
+			activeTransitionIds.add(resolved.transition.id);
 			statesByElementId.set(resolved.fromElement.id, fromState);
 			statesByElementId.set(resolved.toElement.id, toState);
 		}
 	}
 
-	return { forceActiveElementIds, statesByElementId };
+	return { activeTransitionIds, forceActiveElementIds, statesByElementId };
 }

--- a/qcut/electron/__tests__/advanced-transition-export-real.test.ts
+++ b/qcut/electron/__tests__/advanced-transition-export-real.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
@@ -89,7 +90,7 @@ function renderTransition({ value }: { value: VideoTransition }) {
 	});
 }
 
-function renderTransitionWithFilterScript({
+async function renderTransitionWithFilterScript({
 	value,
 }: {
 	value: VideoTransition;
@@ -106,8 +107,64 @@ function renderTransitionWithFilterScript({
 			timeout: 15_000,
 		});
 	} finally {
-		prepared.cleanup();
+		await prepared.cleanup();
 	}
+}
+
+async function renderTransitionFrames({
+	value,
+	filterComplexThreads,
+}: {
+	value: VideoTransition;
+	filterComplexThreads?: number;
+}) {
+	if (!ffmpegPath) throw new Error("FFmpeg unavailable");
+	const { expression } = buildXfadeTransitionFilter({ transition: value });
+	const filterGraph =
+		"[0:v][1:v]xfade=transition=custom:duration=0.4:offset=0.2:" +
+		`expr='${expression}',format=rgb24[out]`;
+	const threadArgs =
+		filterComplexThreads === undefined
+			? []
+			: ["-filter_complex_threads", String(filterComplexThreads)];
+	const prepared = prepareFFmpegFilterScript({
+		executablePath: ffmpegPath,
+		args: [
+			"-v",
+			"error",
+			...threadArgs,
+			"-f",
+			"lavfi",
+			"-i",
+			"testsrc2=s=160x90:r=20:d=0.8",
+			"-f",
+			"lavfi",
+			"-i",
+			"smptebars=s=160x90:r=20:d=0.8",
+			"-filter_complex",
+			filterGraph,
+			"-map",
+			"[out]",
+			"-f",
+			"rawvideo",
+			"-pix_fmt",
+			"rgb24",
+			"-",
+		],
+		commandLengthThreshold: 1,
+	});
+	try {
+		return spawnSync(ffmpegPath, prepared.args, {
+			encoding: null,
+			timeout: 15_000,
+		});
+	} finally {
+		await prepared.cleanup();
+	}
+}
+
+function frameDigest({ frames }: { frames: Buffer }): string {
+	return createHash("sha256").update(frames).digest("hex");
 }
 
 function renderSolidTransitionFrame({
@@ -161,12 +218,39 @@ describe.skipIf(!ffmpegPath)(
 			expect(result.status, result.stderr).toBe(0);
 		});
 
-		it("renders a transition through filter_complex_script", () => {
-			const result = renderTransitionWithFilterScript({
-				value: transition({ type: "page-flip" }),
+		it("renders a transition through filter_complex_script", async () => {
+			const result = await renderTransitionWithFilterScript({
+				value: transition({ type: "motion-blur" }),
 			});
 
 			expect(result.status, result.stderr).toBe(0);
+		});
+
+		it("renders identical bytes with default, single, and multi-thread filters", async () => {
+			const value = transition({
+				type: "motion-blur",
+				direction: "left",
+				tuning: { intensity: 1.4 },
+			});
+			const defaultThreads = await renderTransitionFrames({ value });
+			const singleThread = await renderTransitionFrames({
+				value,
+				filterComplexThreads: 1,
+			});
+			const multiThread = await renderTransitionFrames({
+				value,
+				filterComplexThreads: 8,
+			});
+
+			expect(defaultThreads.status, defaultThreads.stderr.toString()).toBe(0);
+			expect(singleThread.status, singleThread.stderr.toString()).toBe(0);
+			expect(multiThread.status, multiThread.stderr.toString()).toBe(0);
+			expect(defaultThreads.stdout.length).toBeGreaterThan(0);
+			const expectedDigest = frameDigest({ frames: singleThread.stdout });
+			expect(frameDigest({ frames: defaultThreads.stdout })).toBe(
+				expectedDigest
+			);
+			expect(frameDigest({ frames: multiThread.stdout })).toBe(expectedDigest);
 		});
 
 		it("keeps page-flip endpoint pixels unmodified", () => {

--- a/qcut/electron/__tests__/advanced-transition-export-real.test.ts
+++ b/qcut/electron/__tests__/advanced-transition-export-real.test.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
+import { prepareFFmpegFilterScript } from "../ffmpeg/filter-complex-script";
 import { buildXfadeTransitionFilter } from "../ffmpeg/transition-filter";
 import { getFFmpegPath } from "../ffmpeg/paths";
 import type { VideoTransition } from "../ffmpeg/types";
@@ -27,8 +29,14 @@ function resolveFFmpegPath(): string | null {
 
 function transition({
 	type,
+	direction = "left",
+	maskShape,
+	tuning = { intensity: 1.1, frequency: 1.3, tint: "#ffd6a1" },
 }: {
 	type: VideoTransition["type"];
+	direction?: VideoTransition["direction"];
+	maskShape?: VideoTransition["maskShape"];
+	tuning?: VideoTransition["tuning"];
 }): VideoTransition {
 	return {
 		id: `real-${type}`,
@@ -37,50 +45,169 @@ function transition({
 		toElementId: "to",
 		presetId: type,
 		type,
-		direction: "left",
+		direction,
 		easing: "easeInOut",
 		duration: 0.4,
-		tuning: { intensity: 1.1, frequency: 1.3, tint: "#ffd6a1" },
+		maskShape,
+		tuning,
 	};
 }
 
 const ffmpegPath = resolveFFmpegPath();
+
+function buildTransitionArgs({ value }: { value: VideoTransition }): string[] {
+	const { expression } = buildXfadeTransitionFilter({ transition: value });
+	const filterGraph =
+		"[0:v][1:v]xfade=transition=custom:duration=0.4:offset=0.2:" +
+		`expr='${expression}',format=yuv420p[out]`;
+	return [
+		"-v",
+		"error",
+		"-f",
+		"lavfi",
+		"-i",
+		"testsrc2=s=96x54:r=10:d=0.8",
+		"-f",
+		"lavfi",
+		"-i",
+		"smptebars=s=96x54:r=10:d=0.8",
+		"-filter_complex",
+		filterGraph,
+		"-map",
+		"[out]",
+		"-f",
+		"null",
+		"-",
+	];
+}
+
+function renderTransition({ value }: { value: VideoTransition }) {
+	if (!ffmpegPath) throw new Error("FFmpeg unavailable");
+	return spawnSync(ffmpegPath, buildTransitionArgs({ value }), {
+		encoding: "utf8",
+		timeout: 15_000,
+	});
+}
+
+function renderTransitionWithFilterScript({
+	value,
+}: {
+	value: VideoTransition;
+}) {
+	if (!ffmpegPath) throw new Error("FFmpeg unavailable");
+	const prepared = prepareFFmpegFilterScript({
+		executablePath: ffmpegPath,
+		args: buildTransitionArgs({ value }),
+		commandLengthThreshold: 1,
+	});
+	try {
+		return spawnSync(ffmpegPath, prepared.args, {
+			encoding: "utf8",
+			timeout: 15_000,
+		});
+	} finally {
+		prepared.cleanup();
+	}
+}
+
+function renderSolidTransitionFrame({
+	value,
+	frameIndex,
+}: {
+	value: VideoTransition;
+	frameIndex: number;
+}) {
+	if (!ffmpegPath) throw new Error("FFmpeg unavailable");
+	const { expression } = buildXfadeTransitionFilter({ transition: value });
+	const filterGraph =
+		"[0:v][1:v]xfade=transition=custom:duration=0.4:offset=0.2:" +
+		`expr='${expression}',format=rgb24,select='eq(n,${frameIndex})'[out]`;
+	return spawnSync(
+		ffmpegPath,
+		[
+			"-v",
+			"error",
+			"-f",
+			"lavfi",
+			"-i",
+			"color=c=red:s=100x10:r=10:d=0.8",
+			"-f",
+			"lavfi",
+			"-i",
+			"color=c=blue:s=100x10:r=10:d=0.8",
+			"-filter_complex",
+			filterGraph,
+			"-map",
+			"[out]",
+			"-frames:v",
+			"1",
+			"-f",
+			"rawvideo",
+			"-pix_fmt",
+			"rgb24",
+			"-",
+		],
+		{ encoding: null, timeout: 15_000 }
+	);
+}
 
 describe.skipIf(!ffmpegPath)(
 	"advanced transition real FFmpeg exports",
 	{ timeout: 30_000 },
 	() => {
 		it.each(ADVANCED_TRANSITION_TYPES)("renders %s", (type) => {
-			if (!ffmpegPath) throw new Error("FFmpeg unavailable");
-			const { expression } = buildXfadeTransitionFilter({
-				transition: transition({ type }),
+			const result = renderTransition({ value: transition({ type }) });
+
+			expect(result.status, result.stderr).toBe(0);
+		});
+
+		it("renders a transition through filter_complex_script", () => {
+			const result = renderTransitionWithFilterScript({
+				value: transition({ type: "page-flip" }),
 			});
-			const filterGraph =
-				"[0:v][1:v]xfade=transition=custom:duration=0.4:offset=0.2:" +
-				`expr='${expression}',format=yuv420p[out]`;
-			const result = spawnSync(
-				ffmpegPath,
-				[
-					"-v",
-					"error",
-					"-f",
-					"lavfi",
-					"-i",
-					"testsrc2=s=96x54:r=10:d=0.8",
-					"-f",
-					"lavfi",
-					"-i",
-					"smptebars=s=96x54:r=10:d=0.8",
-					"-filter_complex",
-					filterGraph,
-					"-map",
-					"[out]",
-					"-f",
-					"null",
-					"-",
-				],
-				{ encoding: "utf8", timeout: 15_000 }
-			);
+
+			expect(result.status, result.stderr).toBe(0);
+		});
+
+		it("keeps page-flip endpoint pixels unmodified", () => {
+			const value = transition({
+				type: "page-flip",
+				direction: "left",
+				tuning: { intensity: 0.7 },
+			});
+			const first = renderSolidTransitionFrame({ value, frameIndex: 2 });
+			const last = renderSolidTransitionFrame({ value, frameIndex: 6 });
+
+			expect(first.status, first.stderr.toString()).toBe(0);
+			expect(last.status, last.stderr.toString()).toBe(0);
+			expect(first.stdout).toHaveLength(100 * 10 * 3);
+			expect(last.stdout).toHaveLength(100 * 10 * 3);
+			for (let offset = 0; offset < first.stdout.length; offset += 3) {
+				expect(first.stdout[offset]).toBeGreaterThanOrEqual(253);
+				expect(first.stdout[offset + 1]).toBeLessThanOrEqual(1);
+				expect(first.stdout[offset + 2]).toBeLessThanOrEqual(1);
+				expect(last.stdout[offset]).toBeLessThanOrEqual(1);
+				expect(last.stdout[offset + 1]).toBeLessThanOrEqual(1);
+				expect(last.stdout[offset + 2]).toBeGreaterThanOrEqual(254);
+			}
+		});
+
+		it.each(TRANSITION_PARITY_CASES)("renders exact-ten $jianyingName", ({
+			qcutPresetId,
+			expectedConfig,
+		}) => {
+			const result = renderTransition({
+				value: {
+					...transition({
+						type: expectedConfig.type,
+						direction: expectedConfig.direction,
+						maskShape: expectedConfig.maskShape,
+						tuning: expectedConfig.tuning,
+					}),
+					id: `real-${qcutPresetId}`,
+					presetId: qcutPresetId,
+				},
+			});
 
 			expect(result.status, result.stderr).toBe(0);
 		});

--- a/qcut/electron/__tests__/advanced-transition-export-real.test.ts
+++ b/qcut/electron/__tests__/advanced-transition-export-real.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
-import { prepareFFmpegFilterScript } from "../ffmpeg/filter-complex-script";
+import { prepareFFmpegFilterComplexScripts } from "../ffmpeg/filter-complex-script";
 import { buildXfadeTransitionFilter } from "../ffmpeg/transition-filter";
 import { getFFmpegPath } from "../ffmpeg/paths";
 import type { VideoTransition } from "../ffmpeg/types";
@@ -96,8 +96,7 @@ async function renderTransitionWithFilterScript({
 	value: VideoTransition;
 }) {
 	if (!ffmpegPath) throw new Error("FFmpeg unavailable");
-	const prepared = prepareFFmpegFilterScript({
-		executablePath: ffmpegPath,
+	const prepared = prepareFFmpegFilterComplexScripts({
 		args: buildTransitionArgs({ value }),
 		commandLengthThreshold: 1,
 	});
@@ -127,8 +126,7 @@ async function renderTransitionFrames({
 		filterComplexThreads === undefined
 			? []
 			: ["-filter_complex_threads", String(filterComplexThreads)];
-	const prepared = prepareFFmpegFilterScript({
-		executablePath: ffmpegPath,
+	const prepared = prepareFFmpegFilterComplexScripts({
 		args: [
 			"-v",
 			"error",

--- a/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
+++ b/qcut/electron/__tests__/ffmpeg-args-builder.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
 import {
 	buildFFmpegArgs,
 	type BuildFFmpegArgsOptions,
@@ -623,6 +624,45 @@ describe("buildFFmpegArgs", () => {
 				filter.indexOf("[0:v]trim=")
 			);
 			expect(filter).toContain("xfade=transition=custom:duration=1:offset=1.5");
+		});
+
+		it("builds all exact-ten production transitions into one graph", () => {
+			const videoSources = Array.from(
+				{ length: TRANSITION_PARITY_CASES.length + 1 },
+				(_, index) => ({
+					elementId: `clip-${index}`,
+					trackId: "main",
+					trackOrder: 0,
+					elementOrder: index,
+					path: `/clip-${index}.mp4`,
+					startTime: index * 2,
+					duration: 2,
+				})
+			);
+			const videoTransitions = TRANSITION_PARITY_CASES.map(
+				({ qcutPresetId, expectedConfig }, index) => ({
+					id: `transition-${index}`,
+					trackId: "main",
+					fromElementId: `clip-${index}`,
+					toElementId: `clip-${index + 1}`,
+					presetId: qcutPresetId,
+					duration: 0.4,
+					easing: "easeInOut" as const,
+					...expectedConfig,
+				})
+			);
+			const args = buildFFmpegArgs(
+				createBaseOptions({
+					duration: videoSources.length * 2,
+					videoSources,
+					videoTransitions,
+				})
+			);
+			const filter = args[args.indexOf("-filter_complex") + 1];
+
+			expect(filter.match(/xfade=transition=custom/g)).toHaveLength(10);
+			expect(filter).not.toContain("st(1");
+			expect(filter).not.toContain("st(2");
 		});
 	});
 

--- a/qcut/electron/__tests__/filter-complex-script.test.ts
+++ b/qcut/electron/__tests__/filter-complex-script.test.ts
@@ -15,7 +15,7 @@ function createTemporaryRoot(): string {
 }
 
 describe("FFmpeg filter complex scripts", () => {
-	it("leaves commands without complex filters unchanged", () => {
+	it("leaves commands without complex filters unchanged", async () => {
 		const prepared = prepareFFmpegFilterComplexScripts({
 			args: ["-i", "input.mp4", "-vf", "scale=320:240", "output.mp4"],
 		});
@@ -28,10 +28,10 @@ describe("FFmpeg filter complex scripts", () => {
 			"output.mp4",
 		]);
 		expect(prepared.scriptPaths).toEqual([]);
-		prepared.cleanup();
+		await prepared.cleanup();
 	});
 
-	it("keeps short complex filters inline", () => {
+	it("keeps short complex filters inline", async () => {
 		const temporaryRoot = createTemporaryRoot();
 		try {
 			const args = [
@@ -51,13 +51,13 @@ describe("FFmpeg filter complex scripts", () => {
 			expect(prepared.args).toEqual(args);
 			expect(prepared.scriptPaths).toEqual([]);
 			expect(fs.readdirSync(temporaryRoot)).toEqual([]);
-			prepared.cleanup();
+			await prepared.cleanup();
 		} finally {
 			fs.rmSync(temporaryRoot, { recursive: true, force: true });
 		}
 	});
 
-	it("moves every complex graph out of the process arguments", () => {
+	it("moves every complex graph out of the process arguments", async () => {
 		const temporaryRoot = createTemporaryRoot();
 		try {
 			const longGraph = `[0:v]${"null,".repeat(20_000)}null[first]`;
@@ -99,8 +99,8 @@ describe("FFmpeg filter complex scripts", () => {
 			const [directory] = prepared.scriptPaths.map((scriptPath) =>
 				path.dirname(scriptPath)
 			);
-			prepared.cleanup();
-			prepared.cleanup();
+			await prepared.cleanup();
+			await prepared.cleanup();
 			expect(fs.existsSync(directory)).toBe(false);
 		} finally {
 			fs.rmSync(temporaryRoot, { recursive: true, force: true });
@@ -183,7 +183,7 @@ describe("prepareFFmpegFilterScript", () => {
 		fs.rmSync(tempRoot, { recursive: true, force: true });
 	});
 
-	it("keeps a short filter command in argv without writing a script", () => {
+	it("keeps a short filter command in argv without writing a script", async () => {
 		const originalArgs = [
 			"-i",
 			"input.mp4",
@@ -203,11 +203,11 @@ describe("prepareFFmpegFilterScript", () => {
 		expect(prepared.args).toEqual(originalArgs);
 		expect(prepared.filterScriptPath).toBeUndefined();
 		expect(fs.readdirSync(tempRoot)).toEqual([]);
-		prepared.cleanup();
+		await prepared.cleanup();
 		expect(fs.readdirSync(tempRoot)).toEqual([]);
 	});
 
-	it("replaces an oversized filter graph with a byte-identical script", () => {
+	it("replaces an oversized filter graph with a byte-identical script", async () => {
 		const filterGraph =
 			"[0:v]scale=1920:1080[scaled];\n" +
 			"[scaled]drawtext=text='逐字一致; []':x=10:y=20[out]";
@@ -242,9 +242,10 @@ describe("prepareFFmpegFilterScript", () => {
 		expect(fs.readFileSync(prepared.filterScriptPath, "utf8")).toBe(
 			filterGraph
 		);
+		await prepared.cleanup();
 	});
 
-	it("scripts the production exact-ten transition graph at the default threshold", () => {
+	it("scripts the production exact-ten transition graph at the default threshold", async () => {
 		const originalArgs = buildExactTenProductionArgs({
 			inputDirectory: tempRoot,
 		});
@@ -266,11 +267,11 @@ describe("prepareFFmpegFilterScript", () => {
 		expect(filterGraph.match(/xfade=transition=custom/g)).toHaveLength(10);
 		expect(fs.existsSync(scriptDirectory)).toBe(true);
 
-		prepared.cleanup();
+		await prepared.cleanup();
 		expect(fs.existsSync(scriptDirectory)).toBe(false);
 	});
 
-	it("removes the generated directory once when cleanup is repeated", () => {
+	it("removes the generated directory once when cleanup is repeated", async () => {
 		const prepared = prepareFFmpegFilterScript({
 			executablePath: "/usr/bin/ffmpeg",
 			args: ["-filter_complex", "[0:v]null[out]"],
@@ -284,13 +285,13 @@ describe("prepareFFmpegFilterScript", () => {
 		const scriptDirectory = path.dirname(prepared.filterScriptPath);
 		expect(fs.existsSync(scriptDirectory)).toBe(true);
 
-		prepared.cleanup();
+		await prepared.cleanup();
 		expect(fs.existsSync(scriptDirectory)).toBe(false);
-		expect(() => prepared.cleanup()).not.toThrow();
+		await expect(prepared.cleanup()).resolves.toBe(true);
 		expect(fs.existsSync(scriptDirectory)).toBe(false);
 	});
 
-	it("falls back to asynchronous removal when Windows keeps the directory busy", () => {
+	it("falls back to asynchronous removal when Windows keeps the directory busy", async () => {
 		const prepared = prepareFFmpegFilterScript({
 			executablePath: "C:\\ffmpeg\\bin\\ffmpeg.exe",
 			args: ["-filter_complex", "[0:v]null[out]"],
@@ -311,14 +312,15 @@ describe("prepareFFmpegFilterScript", () => {
 		const rmSyncSpy = vi.spyOn(fs, "rmSync").mockImplementationOnce(() => {
 			throw permissionError;
 		});
-		const rmSpy = vi.spyOn(fs, "rm").mockImplementation(() => undefined);
+		const rmSpy = vi.spyOn(fs, "rm");
 
 		try {
-			expect(() => prepared.cleanup()).not.toThrow();
+			await expect(prepared.cleanup()).resolves.toBe(true);
 			expect(rmSyncSpy).toHaveBeenCalledWith(scriptDirectory, {
 				recursive: true,
 				force: true,
 			});
+			expect(rmSyncSpy).toHaveBeenCalledTimes(1);
 			expect(rmSpy).toHaveBeenCalledWith(
 				scriptDirectory,
 				{
@@ -329,14 +331,59 @@ describe("prepareFFmpegFilterScript", () => {
 				},
 				expect.any(Function)
 			);
+			expect(fs.existsSync(scriptDirectory)).toBe(false);
+		} finally {
+			rmSyncSpy.mockRestore();
+			rmSpy.mockRestore();
+		}
+
+		expect(fs.existsSync(scriptDirectory)).toBe(false);
+	});
+
+	it("reports a final cleanup failure and allows a later retry", async () => {
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "C:\\ffmpeg\\bin\\ffmpeg.exe",
+			args: ["-filter_complex", "[0:v]null[out]"],
+			commandLengthThreshold: 1,
+			tempDirectory: tempRoot,
+		});
+		if (!prepared.filterScriptPath) {
+			throw new Error("Expected an FFmpeg filter script path");
+		}
+		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const permissionError = Object.assign(
+			new Error("operation not permitted"),
+			{ code: "EPERM" }
+		);
+		const rmSyncSpy = vi.spyOn(fs, "rmSync").mockImplementation(() => {
+			throw permissionError;
+		});
+		const rmSpy = vi
+			.spyOn(fs, "rm")
+			.mockImplementation(
+				(
+					_path,
+					_options,
+					callback: (error: NodeJS.ErrnoException | null) => void
+				) => callback(permissionError)
+			);
+		const warnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
+
+		try {
+			await expect(prepared.cleanup()).resolves.toBe(false);
+			await expect(prepared.cleanup()).resolves.toBe(false);
+			expect(rmSyncSpy).toHaveBeenCalledTimes(2);
+			expect(rmSpy).toHaveBeenCalledTimes(2);
+			expect(warnSpy).toHaveBeenCalledTimes(2);
 			expect(fs.existsSync(scriptDirectory)).toBe(true);
 		} finally {
 			rmSyncSpy.mockRestore();
 			rmSpy.mockRestore();
+			warnSpy.mockRestore();
 			fs.rmSync(scriptDirectory, { recursive: true, force: true });
 		}
-
-		expect(fs.existsSync(scriptDirectory)).toBe(false);
 	});
 
 	it("rejects a filter_complex flag without its graph argument", () => {

--- a/qcut/electron/__tests__/filter-complex-script.test.ts
+++ b/qcut/electron/__tests__/filter-complex-script.test.ts
@@ -1,8 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { prepareFFmpegFilterComplexScripts } from "../ffmpeg/filter-complex-script";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
+import { buildFFmpegArgs } from "../ffmpeg-args-builder";
+import {
+	prepareFFmpegFilterComplexScripts,
+	prepareFFmpegFilterScript,
+} from "../ffmpeg/filter-complex-script";
+import type { VideoSource, VideoTransition } from "../ffmpeg/types";
 
 function createTemporaryRoot(): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "qcut-filter-test-"));
@@ -114,5 +120,234 @@ describe("FFmpeg filter complex scripts", () => {
 		} finally {
 			fs.rmSync(temporaryRoot, { recursive: true, force: true });
 		}
+	});
+});
+
+const clipDuration = 2;
+
+function buildExactTenProductionArgs({
+	inputDirectory,
+}: {
+	inputDirectory: string;
+}): string[] {
+	const videoSources: VideoSource[] = Array.from(
+		{ length: TRANSITION_PARITY_CASES.length + 1 },
+		(_, index) => {
+			const clipPath = path.join(inputDirectory, `clip-${index}.mp4`);
+			fs.writeFileSync(clipPath, "");
+			return {
+				elementId: `clip-${index}`,
+				trackId: "main",
+				trackOrder: 0,
+				elementOrder: index,
+				path: clipPath,
+				startTime: index * clipDuration,
+				duration: clipDuration,
+			};
+		}
+	);
+	const videoTransitions: VideoTransition[] = TRANSITION_PARITY_CASES.map(
+		({ qcutPresetId, expectedConfig }, index) => ({
+			id: `transition-${index}`,
+			trackId: "main",
+			fromElementId: `clip-${index}`,
+			toElementId: `clip-${index + 1}`,
+			presetId: qcutPresetId,
+			duration: 0.4,
+			easing: "easeInOut",
+			...expectedConfig,
+		})
+	);
+
+	return buildFFmpegArgs({
+		inputDir: inputDirectory,
+		outputFile: path.join(inputDirectory, "output.mp4"),
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		quality: "medium",
+		duration: videoSources.length * clipDuration,
+		videoSources,
+		videoTransitions,
+	});
+}
+
+describe("prepareFFmpegFilterScript", () => {
+	let tempRoot: string;
+
+	beforeEach(() => {
+		tempRoot = createTemporaryRoot();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempRoot, { recursive: true, force: true });
+	});
+
+	it("keeps a short filter command in argv without writing a script", () => {
+		const originalArgs = [
+			"-i",
+			"input.mp4",
+			"-filter_complex",
+			"[0:v]scale=1280:720[out]",
+			"-map",
+			"[out]",
+		];
+
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "/usr/bin/ffmpeg",
+			args: originalArgs,
+			commandLengthThreshold: Number.MAX_SAFE_INTEGER,
+			tempDirectory: tempRoot,
+		});
+
+		expect(prepared.args).toEqual(originalArgs);
+		expect(prepared.filterScriptPath).toBeUndefined();
+		expect(fs.readdirSync(tempRoot)).toEqual([]);
+		prepared.cleanup();
+		expect(fs.readdirSync(tempRoot)).toEqual([]);
+	});
+
+	it("replaces an oversized filter graph with a byte-identical script", () => {
+		const filterGraph =
+			"[0:v]scale=1920:1080[scaled];\n" +
+			"[scaled]drawtext=text='逐字一致; []':x=10:y=20[out]";
+		const originalArgs = [
+			"-i",
+			"input.mp4",
+			"-filter_complex",
+			filterGraph,
+			"-map",
+			"[out]",
+		];
+
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "/usr/bin/ffmpeg",
+			args: originalArgs,
+			commandLengthThreshold: 1,
+			tempDirectory: tempRoot,
+		});
+
+		expect(prepared.filterScriptPath).toBeDefined();
+		if (!prepared.filterScriptPath) {
+			throw new Error("Expected an FFmpeg filter script path");
+		}
+		expect(prepared.args).toEqual([
+			"-i",
+			"input.mp4",
+			"-filter_complex_script",
+			prepared.filterScriptPath,
+			"-map",
+			"[out]",
+		]);
+		expect(fs.readFileSync(prepared.filterScriptPath, "utf8")).toBe(
+			filterGraph
+		);
+	});
+
+	it("scripts the production exact-ten transition graph at the default threshold", () => {
+		const originalArgs = buildExactTenProductionArgs({
+			inputDirectory: tempRoot,
+		});
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "/usr/bin/ffmpeg",
+			args: originalArgs,
+			tempDirectory: tempRoot,
+		});
+
+		expect(prepared.filterScriptPath).toBeDefined();
+		if (!prepared.filterScriptPath) {
+			throw new Error("Expected an FFmpeg filter script path");
+		}
+		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const filterGraph = fs.readFileSync(prepared.filterScriptPath, "utf8");
+
+		expect(prepared.args).toContain("-filter_complex_script");
+		expect(prepared.args).not.toContain("-filter_complex");
+		expect(filterGraph.match(/xfade=transition=custom/g)).toHaveLength(10);
+		expect(fs.existsSync(scriptDirectory)).toBe(true);
+
+		prepared.cleanup();
+		expect(fs.existsSync(scriptDirectory)).toBe(false);
+	});
+
+	it("removes the generated directory once when cleanup is repeated", () => {
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "/usr/bin/ffmpeg",
+			args: ["-filter_complex", "[0:v]null[out]"],
+			commandLengthThreshold: 1,
+			tempDirectory: tempRoot,
+		});
+		expect(prepared.filterScriptPath).toBeDefined();
+		if (!prepared.filterScriptPath) {
+			throw new Error("Expected an FFmpeg filter script path");
+		}
+		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		expect(fs.existsSync(scriptDirectory)).toBe(true);
+
+		prepared.cleanup();
+		expect(fs.existsSync(scriptDirectory)).toBe(false);
+		expect(() => prepared.cleanup()).not.toThrow();
+		expect(fs.existsSync(scriptDirectory)).toBe(false);
+	});
+
+	it("falls back to asynchronous removal when Windows keeps the directory busy", () => {
+		const prepared = prepareFFmpegFilterScript({
+			executablePath: "C:\\ffmpeg\\bin\\ffmpeg.exe",
+			args: ["-filter_complex", "[0:v]null[out]"],
+			commandLengthThreshold: 1,
+			tempDirectory: tempRoot,
+		});
+		expect(prepared.filterScriptPath).toBeDefined();
+		if (!prepared.filterScriptPath) {
+			throw new Error("Expected an FFmpeg filter script path");
+		}
+		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const permissionError = Object.assign(
+			new Error("operation not permitted"),
+			{
+				code: "EPERM",
+			}
+		);
+		const rmSyncSpy = vi.spyOn(fs, "rmSync").mockImplementationOnce(() => {
+			throw permissionError;
+		});
+		const rmSpy = vi.spyOn(fs, "rm").mockImplementation(() => undefined);
+
+		try {
+			expect(() => prepared.cleanup()).not.toThrow();
+			expect(rmSyncSpy).toHaveBeenCalledWith(scriptDirectory, {
+				recursive: true,
+				force: true,
+			});
+			expect(rmSpy).toHaveBeenCalledWith(
+				scriptDirectory,
+				{
+					recursive: true,
+					force: true,
+					maxRetries: 5,
+					retryDelay: 100,
+				},
+				expect.any(Function)
+			);
+			expect(fs.existsSync(scriptDirectory)).toBe(true);
+		} finally {
+			rmSyncSpy.mockRestore();
+			rmSpy.mockRestore();
+			fs.rmSync(scriptDirectory, { recursive: true, force: true });
+		}
+
+		expect(fs.existsSync(scriptDirectory)).toBe(false);
+	});
+
+	it("rejects a filter_complex flag without its graph argument", () => {
+		expect(() =>
+			prepareFFmpegFilterScript({
+				executablePath: "/usr/bin/ffmpeg",
+				args: ["-hide_banner", "-filter_complex"],
+				commandLengthThreshold: 1,
+				tempDirectory: tempRoot,
+			})
+		).toThrow("FFmpeg filter graph argument is missing");
+		expect(fs.readdirSync(tempRoot)).toEqual([]);
 	});
 });

--- a/qcut/electron/__tests__/filter-complex-script.test.ts
+++ b/qcut/electron/__tests__/filter-complex-script.test.ts
@@ -4,10 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TRANSITION_PARITY_CASES } from "../../apps/web/src/components/editor/media-panel/views/transitions/transition-parity-ten";
 import { buildFFmpegArgs } from "../ffmpeg-args-builder";
-import {
-	prepareFFmpegFilterComplexScripts,
-	prepareFFmpegFilterScript,
-} from "../ffmpeg/filter-complex-script";
+import { prepareFFmpegFilterComplexScripts } from "../ffmpeg/filter-complex-script";
 import type { VideoSource, VideoTransition } from "../ffmpeg/types";
 
 function createTemporaryRoot(): string {
@@ -172,7 +169,7 @@ function buildExactTenProductionArgs({
 	});
 }
 
-describe("prepareFFmpegFilterScript", () => {
+describe("forced FFmpeg filter complex scripts", () => {
 	let tempRoot: string;
 
 	beforeEach(() => {
@@ -193,15 +190,14 @@ describe("prepareFFmpegFilterScript", () => {
 			"[out]",
 		];
 
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "/usr/bin/ffmpeg",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: originalArgs,
 			commandLengthThreshold: Number.MAX_SAFE_INTEGER,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
 
 		expect(prepared.args).toEqual(originalArgs);
-		expect(prepared.filterScriptPath).toBeUndefined();
+		expect(prepared.scriptPaths).toEqual([]);
 		expect(fs.readdirSync(tempRoot)).toEqual([]);
 		await prepared.cleanup();
 		expect(fs.readdirSync(tempRoot)).toEqual([]);
@@ -220,28 +216,25 @@ describe("prepareFFmpegFilterScript", () => {
 			"[out]",
 		];
 
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "/usr/bin/ffmpeg",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: originalArgs,
 			commandLengthThreshold: 1,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
 
-		expect(prepared.filterScriptPath).toBeDefined();
-		if (!prepared.filterScriptPath) {
+		const [filterScriptPath] = prepared.scriptPaths;
+		if (!filterScriptPath) {
 			throw new Error("Expected an FFmpeg filter script path");
 		}
 		expect(prepared.args).toEqual([
 			"-i",
 			"input.mp4",
 			"-filter_complex_script",
-			prepared.filterScriptPath,
+			filterScriptPath,
 			"-map",
 			"[out]",
 		]);
-		expect(fs.readFileSync(prepared.filterScriptPath, "utf8")).toBe(
-			filterGraph
-		);
+		expect(fs.readFileSync(filterScriptPath, "utf8")).toBe(filterGraph);
 		await prepared.cleanup();
 	});
 
@@ -249,18 +242,17 @@ describe("prepareFFmpegFilterScript", () => {
 		const originalArgs = buildExactTenProductionArgs({
 			inputDirectory: tempRoot,
 		});
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "/usr/bin/ffmpeg",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: originalArgs,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
 
-		expect(prepared.filterScriptPath).toBeDefined();
-		if (!prepared.filterScriptPath) {
+		const [filterScriptPath] = prepared.scriptPaths;
+		if (!filterScriptPath) {
 			throw new Error("Expected an FFmpeg filter script path");
 		}
-		const scriptDirectory = path.dirname(prepared.filterScriptPath);
-		const filterGraph = fs.readFileSync(prepared.filterScriptPath, "utf8");
+		const scriptDirectory = path.dirname(filterScriptPath);
+		const filterGraph = fs.readFileSync(filterScriptPath, "utf8");
 
 		expect(prepared.args).toContain("-filter_complex_script");
 		expect(prepared.args).not.toContain("-filter_complex");
@@ -272,17 +264,16 @@ describe("prepareFFmpegFilterScript", () => {
 	});
 
 	it("removes the generated directory once when cleanup is repeated", async () => {
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "/usr/bin/ffmpeg",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: ["-filter_complex", "[0:v]null[out]"],
 			commandLengthThreshold: 1,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
-		expect(prepared.filterScriptPath).toBeDefined();
-		if (!prepared.filterScriptPath) {
+		const [filterScriptPath] = prepared.scriptPaths;
+		if (!filterScriptPath) {
 			throw new Error("Expected an FFmpeg filter script path");
 		}
-		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const scriptDirectory = path.dirname(filterScriptPath);
 		expect(fs.existsSync(scriptDirectory)).toBe(true);
 
 		await prepared.cleanup();
@@ -292,17 +283,16 @@ describe("prepareFFmpegFilterScript", () => {
 	});
 
 	it("falls back to asynchronous removal when Windows keeps the directory busy", async () => {
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "C:\\ffmpeg\\bin\\ffmpeg.exe",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: ["-filter_complex", "[0:v]null[out]"],
 			commandLengthThreshold: 1,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
-		expect(prepared.filterScriptPath).toBeDefined();
-		if (!prepared.filterScriptPath) {
+		const [filterScriptPath] = prepared.scriptPaths;
+		if (!filterScriptPath) {
 			throw new Error("Expected an FFmpeg filter script path");
 		}
-		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const scriptDirectory = path.dirname(filterScriptPath);
 		const permissionError = Object.assign(
 			new Error("operation not permitted"),
 			{
@@ -341,16 +331,16 @@ describe("prepareFFmpegFilterScript", () => {
 	});
 
 	it("reports a final cleanup failure and allows a later retry", async () => {
-		const prepared = prepareFFmpegFilterScript({
-			executablePath: "C:\\ffmpeg\\bin\\ffmpeg.exe",
+		const prepared = prepareFFmpegFilterComplexScripts({
 			args: ["-filter_complex", "[0:v]null[out]"],
 			commandLengthThreshold: 1,
-			tempDirectory: tempRoot,
+			temporaryDirectory: tempRoot,
 		});
-		if (!prepared.filterScriptPath) {
+		const [filterScriptPath] = prepared.scriptPaths;
+		if (!filterScriptPath) {
 			throw new Error("Expected an FFmpeg filter script path");
 		}
-		const scriptDirectory = path.dirname(prepared.filterScriptPath);
+		const scriptDirectory = path.dirname(filterScriptPath);
 		const permissionError = Object.assign(
 			new Error("operation not permitted"),
 			{ code: "EPERM" }
@@ -388,13 +378,12 @@ describe("prepareFFmpegFilterScript", () => {
 
 	it("rejects a filter_complex flag without its graph argument", () => {
 		expect(() =>
-			prepareFFmpegFilterScript({
-				executablePath: "/usr/bin/ffmpeg",
+			prepareFFmpegFilterComplexScripts({
 				args: ["-hide_banner", "-filter_complex"],
 				commandLengthThreshold: 1,
-				tempDirectory: tempRoot,
+				temporaryDirectory: tempRoot,
 			})
-		).toThrow("FFmpeg filter graph argument is missing");
+		).toThrow("FFmpeg filter_complex is missing its graph");
 		expect(fs.readdirSync(tempRoot)).toEqual([]);
 	});
 });

--- a/qcut/electron/__tests__/transition-filter.test.ts
+++ b/qcut/electron/__tests__/transition-filter.test.ts
@@ -211,9 +211,32 @@ describe("FFmpeg transition filters", () => {
 			transition: transition({ type: "page-flip", direction: "left" }),
 		});
 
-		expect(filter.expression).toContain(
-			"if(lte(ld(0),0.001),A,if(gte(ld(0),0.999),B,"
+		expect(filter.expression).toMatch(
+			/^if\(lte\(.+,0\.001\),A,if\(gte\(.+,0\.999\),B,/
 		);
+	});
+
+	it("keeps custom expressions stateless for FFmpeg slice threading", () => {
+		for (const preset of transitionPresets) {
+			const config = getClipTransitionPresetConfig({ preset });
+			expect(config).not.toBeNull();
+			if (!config) continue;
+
+			const filter = buildXfadeTransitionFilter({
+				transition: {
+					...transition({
+						type: config.type,
+						direction: config.direction,
+						duration: preset.defaultDuration,
+						tuning: config.tuning,
+					}),
+					presetId: preset.id,
+					maskShape: config.maskShape,
+				},
+			});
+
+			expect(filter.expression, preset.id).not.toMatch(/\b(?:st|ld)\(/);
+		}
 	});
 
 	it("preserves motion-blur travel direction in the export expression", () => {

--- a/qcut/electron/__tests__/transition-filter.test.ts
+++ b/qcut/electron/__tests__/transition-filter.test.ts
@@ -163,6 +163,11 @@ describe("FFmpeg transition filters", () => {
 		{ type: "push", direction: "up", expected: "a0(" },
 		{ type: "wipe", direction: "right", expected: "gte(X" },
 		{ type: "zoom-blur", direction: undefined, expected: "W/2+(X-W/2)" },
+		{
+			type: "zoom-in-blur",
+			direction: undefined,
+			expected: "1+0.12*(",
+		},
 		{ type: "whip-pan", direction: "left", expected: "0.045*W" },
 		{ type: "flash", direction: undefined, expected: "eq(PLANE,0),255" },
 		{ type: "light-leak", direction: undefined, expected: "eq(PLANE,0),90" },
@@ -199,6 +204,44 @@ describe("FFmpeg transition filters", () => {
 		expect(filter.transition).toBe("custom");
 		expect(filter.expression).toContain(expected);
 		expect(filter.expression).toContain("pow((1-P),3)");
+	});
+
+	it("keeps page-flip endpoint frames unmodified", () => {
+		const filter = buildXfadeTransitionFilter({
+			transition: transition({ type: "page-flip", direction: "left" }),
+		});
+
+		expect(filter.expression).toContain(
+			"if(lte(ld(0),0.001),A,if(gte(ld(0),0.999),B,"
+		);
+	});
+
+	it("preserves motion-blur travel direction in the export expression", () => {
+		const left = buildXfadeTransitionFilter({
+			transition: transition({ type: "motion-blur", direction: "left" }),
+		});
+		const right = buildXfadeTransitionFilter({
+			transition: transition({ type: "motion-blur", direction: "right" }),
+		});
+
+		expect(left.expression).not.toBe(right.expression);
+		expect(left.expression).toContain("0.055*W");
+		expect(left.expression).toContain("1+0.035*");
+	});
+
+	it("keeps zoom-in blur monotonic and distinct from symmetric zoom blur", () => {
+		const zoomIn = buildXfadeTransitionFilter({
+			transition: transition({ type: "zoom-in-blur" }),
+		});
+		const symmetric = buildXfadeTransitionFilter({
+			transition: transition({ type: "zoom-blur" }),
+		});
+
+		expect(zoomIn.expression).toContain("1+0.12*(");
+		expect(zoomIn.expression).toContain("1-0.12*(1-(");
+		expect(zoomIn.expression).toContain("-0.035*(");
+		expect(zoomIn.expression).toContain("4*(");
+		expect(zoomIn.expression).not.toBe(symmetric.expression);
 	});
 
 	it("serializes tuning into visibly distinct export expressions", () => {
@@ -238,6 +281,7 @@ describe("FFmpeg transition filters", () => {
 			"wipe",
 			"push",
 			"zoom-blur",
+			"zoom-in-blur",
 			"whip-pan",
 			"flash",
 			"light-leak",
@@ -286,6 +330,13 @@ describe("FFmpeg transition filters", () => {
 				transition: { ...transition({ type: "texture-mask" }), maskShape },
 			});
 			expect(filter.expression.length).toBeGreaterThan(4);
+			if (maskShape === "circle") {
+				expect(filter.expression).toContain("sqrt(W*W+H*H)/2");
+			}
+			if (maskShape === "heart") {
+				expect(filter.expression).toContain("0.1185");
+				expect(filter.expression).toContain("0.78");
+			}
 			expressions.add(filter.expression);
 		}
 		// Every shape must produce distinct export geometry.

--- a/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
+++ b/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
@@ -10,14 +10,10 @@ const mocks = vi.hoisted(() => ({
 	cleanup: vi.fn(),
 }));
 
-vi.mock("child_process", async (importOriginal) => {
-	const original = await importOriginal<typeof import("child_process")>();
-	return {
-		...original,
-		default: { ...original, spawn: mocks.spawn },
-		spawn: mocks.spawn,
-	};
-});
+vi.mock("child_process", () => ({
+	default: { spawn: mocks.spawn },
+	spawn: mocks.spawn,
+}));
 
 vi.mock("../ffmpeg/utils", () => ({
 	getFFmpegPath: () => "/mock/ffmpeg",

--- a/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
+++ b/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
@@ -45,11 +45,11 @@ interface FakeChildProcess extends EventEmitter {
 }
 
 function createFakeChildProcess(): FakeChildProcess {
-	const process = new EventEmitter() as FakeChildProcess;
-	process.stdout = new EventEmitter();
-	process.stderr = new EventEmitter();
-	process.kill = vi.fn(() => true);
-	return process;
+	const child = new EventEmitter() as FakeChildProcess;
+	child.stdout = new EventEmitter();
+	child.stderr = new EventEmitter();
+	child.kill = vi.fn(() => true);
+	return child;
 }
 
 function previewOptions({
@@ -93,8 +93,8 @@ describe("video frame preview process lifecycle", () => {
 		);
 		const sourcePath = path.join(tempDirectory, "source.mp4");
 		fs.writeFileSync(sourcePath, "fixture");
-		const process = createFakeChildProcess();
-		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		const child = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(child as unknown as ChildProcess);
 		mocks.cleanup.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
 		try {
@@ -109,10 +109,10 @@ describe("video frame preview process lifecycle", () => {
 			);
 
 			await vi.advanceTimersByTimeAsync(20_000);
-			expect(process.kill).toHaveBeenCalledTimes(1);
+			expect(child.kill).toHaveBeenCalledTimes(1);
 			expect(mocks.cleanup).not.toHaveBeenCalled();
 
-			process.emit("close", null, "SIGTERM");
+			child.emit("close", null, "SIGTERM");
 			await Promise.resolve();
 			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
 
@@ -131,8 +131,8 @@ describe("video frame preview process lifecycle", () => {
 		);
 		const sourcePath = path.join(tempDirectory, "source.mp4");
 		fs.writeFileSync(sourcePath, "fixture");
-		const process = createFakeChildProcess();
-		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		const child = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(child as unknown as ChildProcess);
 		mocks.cleanup.mockResolvedValue(true);
 
 		try {
@@ -147,33 +147,37 @@ describe("video frame preview process lifecycle", () => {
 			);
 
 			await vi.advanceTimersByTimeAsync(20_000);
-			expect(process.kill).toHaveBeenCalledTimes(1);
+			expect(child.kill).toHaveBeenCalledTimes(1);
 			expect(mocks.cleanup).not.toHaveBeenCalled();
 
 			await vi.advanceTimersByTimeAsync(1_000);
 			await rejection;
-			expect(process.kill).toHaveBeenCalledTimes(2);
-			expect(process.kill).toHaveBeenNthCalledWith(1);
-			expect(process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+			expect(child.kill).toHaveBeenCalledTimes(2);
+			expect(child.kill).toHaveBeenNthCalledWith(1);
+			expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
 			expect(
 				cancelVideoFramePreview({ requestId: "never-close-request" })
 			).toBe(false);
 			expect(mocks.cleanup).not.toHaveBeenCalled();
+
+			child.emit("exit", null, "SIGKILL");
+			await Promise.resolve();
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
 		} finally {
 			fs.rmSync(tempDirectory, { recursive: true, force: true });
 		}
 	});
 
-	it("defers cleanup until a child that rejected kill eventually closes", async () => {
+	it("defers cleanup until a child that rejected kill eventually exits", async () => {
 		vi.useFakeTimers();
 		const tempDirectory = fs.mkdtempSync(
 			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
 		);
 		const sourcePath = path.join(tempDirectory, "source.mp4");
 		fs.writeFileSync(sourcePath, "fixture");
-		const process = createFakeChildProcess();
-		process.kill.mockReturnValue(false);
-		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		const child = createFakeChildProcess();
+		child.kill.mockReturnValue(false);
+		mocks.spawn.mockReturnValue(child as unknown as ChildProcess);
 		mocks.cleanup.mockResolvedValue(true);
 
 		try {
@@ -189,17 +193,88 @@ describe("video frame preview process lifecycle", () => {
 
 			await vi.advanceTimersByTimeAsync(21_000);
 			await rejection;
-			expect(process.kill).toHaveBeenCalledTimes(2);
-			expect(process.kill).toHaveBeenNthCalledWith(1);
-			expect(process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+			expect(child.kill).toHaveBeenCalledTimes(2);
+			expect(child.kill).toHaveBeenNthCalledWith(1);
+			expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
 			expect(cancelVideoFramePreview({ requestId: "kill-false-request" })).toBe(
 				false
 			);
 			expect(mocks.cleanup).not.toHaveBeenCalled();
 
-			process.emit("close", 0, null);
+			child.emit("exit", null, null);
 			await Promise.resolve();
 			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("cleans on exit but waits for close before resolving output", async () => {
+		const tempDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
+		);
+		const sourcePath = path.join(tempDirectory, "source.mp4");
+		fs.writeFileSync(sourcePath, "fixture");
+		const child = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(child as unknown as ChildProcess);
+		mocks.cleanup.mockResolvedValue(true);
+
+		try {
+			const renderPromise = renderVideoFramePreview({
+				options: previewOptions({
+					requestId: "exit-before-close-request",
+					sourcePath,
+				}),
+			});
+			const settled = vi.fn();
+			void renderPromise.then(settled);
+			child.stdout.emit("data", Buffer.alloc(128, 1));
+
+			child.emit("exit", 0, null);
+			await Promise.resolve();
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+			expect(settled).not.toHaveBeenCalled();
+
+			child.emit("close", 0, null);
+			await expect(renderPromise).resolves.toMatchObject({
+				requestId: "exit-before-close-request",
+				cacheHit: false,
+			});
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("times out without signaling a child that exited but never closed", async () => {
+		vi.useFakeTimers();
+		const tempDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
+		);
+		const sourcePath = path.join(tempDirectory, "source.mp4");
+		fs.writeFileSync(sourcePath, "fixture");
+		const child = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(child as unknown as ChildProcess);
+		mocks.cleanup.mockResolvedValue(true);
+
+		try {
+			const renderPromise = renderVideoFramePreview({
+				options: previewOptions({
+					requestId: "exit-without-close-request",
+					sourcePath,
+				}),
+			});
+			const rejection = expect(renderPromise).rejects.toThrow(
+				"Video frame preview timed out"
+			);
+
+			child.emit("exit", 0, null);
+			await Promise.resolve();
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(21_000);
+			await rejection;
+			expect(child.kill).not.toHaveBeenCalled();
 		} finally {
 			fs.rmSync(tempDirectory, { recursive: true, force: true });
 		}

--- a/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
+++ b/qcut/electron/__tests__/video-frame-preview-lifecycle.test.ts
@@ -1,0 +1,207 @@
+import type { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	spawn: vi.fn(),
+	cleanup: vi.fn(),
+}));
+
+vi.mock("child_process", async (importOriginal) => {
+	const original = await importOriginal<typeof import("child_process")>();
+	return {
+		...original,
+		default: { ...original, spawn: mocks.spawn },
+		spawn: mocks.spawn,
+	};
+});
+
+vi.mock("../ffmpeg/utils", () => ({
+	getFFmpegPath: () => "/mock/ffmpeg",
+}));
+
+vi.mock("../ffmpeg/filter-complex-script", () => ({
+	prepareFFmpegFilterComplexScripts: ({ args }: { args: string[] }) => ({
+		args,
+		scriptPaths: ["/mock/filter.ffscript"],
+		cleanup: mocks.cleanup,
+	}),
+}));
+
+import {
+	cancelVideoFramePreview,
+	clearVideoFramePreviewCache,
+	renderVideoFramePreview,
+} from "../ffmpeg/video-frame-preview";
+import type { VideoFramePreviewOptions } from "../ffmpeg/types";
+
+interface FakeChildProcess extends EventEmitter {
+	kill: ReturnType<typeof vi.fn>;
+	stderr: EventEmitter;
+	stdout: EventEmitter;
+}
+
+function createFakeChildProcess(): FakeChildProcess {
+	const process = new EventEmitter() as FakeChildProcess;
+	process.stdout = new EventEmitter();
+	process.stderr = new EventEmitter();
+	process.kill = vi.fn(() => true);
+	return process;
+}
+
+function previewOptions({
+	requestId,
+	sourcePath,
+}: {
+	requestId: string;
+	sourcePath: string;
+}): VideoFramePreviewOptions {
+	return {
+		requestId,
+		sourcePath,
+		sourceTime: 0,
+		width: 320,
+		height: 180,
+		fps: 30,
+		fitMode: "contain",
+		enhancements: {
+			stabilization: 0,
+			denoise: 0,
+			clarity: 0,
+			upscale: 1,
+			relight: 0,
+			beauty: 0,
+		},
+	};
+}
+
+describe("video frame preview process lifecycle", () => {
+	afterEach(() => {
+		clearVideoFramePreviewCache();
+		mocks.spawn.mockReset();
+		mocks.cleanup.mockReset();
+		vi.useRealTimers();
+	});
+
+	it("waits for close before cleanup and retries a transient removal failure", async () => {
+		vi.useFakeTimers();
+		const tempDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
+		);
+		const sourcePath = path.join(tempDirectory, "source.mp4");
+		fs.writeFileSync(sourcePath, "fixture");
+		const process = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		mocks.cleanup.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+		try {
+			const renderPromise = renderVideoFramePreview({
+				options: previewOptions({
+					requestId: "timeout-request",
+					sourcePath,
+				}),
+			});
+			const rejection = expect(renderPromise).rejects.toThrow(
+				"Video frame preview timed out"
+			);
+
+			await vi.advanceTimersByTimeAsync(20_000);
+			expect(process.kill).toHaveBeenCalledTimes(1);
+			expect(mocks.cleanup).not.toHaveBeenCalled();
+
+			process.emit("close", null, "SIGTERM");
+			await Promise.resolve();
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(100);
+			await rejection;
+			expect(mocks.cleanup).toHaveBeenCalledTimes(2);
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("settles after the close grace period when the child never closes", async () => {
+		vi.useFakeTimers();
+		const tempDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
+		);
+		const sourcePath = path.join(tempDirectory, "source.mp4");
+		fs.writeFileSync(sourcePath, "fixture");
+		const process = createFakeChildProcess();
+		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		mocks.cleanup.mockResolvedValue(true);
+
+		try {
+			const renderPromise = renderVideoFramePreview({
+				options: previewOptions({
+					requestId: "never-close-request",
+					sourcePath,
+				}),
+			});
+			const rejection = expect(renderPromise).rejects.toThrow(
+				"Video frame preview timed out"
+			);
+
+			await vi.advanceTimersByTimeAsync(20_000);
+			expect(process.kill).toHaveBeenCalledTimes(1);
+			expect(mocks.cleanup).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(1_000);
+			await rejection;
+			expect(process.kill).toHaveBeenCalledTimes(2);
+			expect(process.kill).toHaveBeenNthCalledWith(1);
+			expect(process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+			expect(
+				cancelVideoFramePreview({ requestId: "never-close-request" })
+			).toBe(false);
+			expect(mocks.cleanup).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("defers cleanup until a child that rejected kill eventually closes", async () => {
+		vi.useFakeTimers();
+		const tempDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "qcut-preview-lifecycle-")
+		);
+		const sourcePath = path.join(tempDirectory, "source.mp4");
+		fs.writeFileSync(sourcePath, "fixture");
+		const process = createFakeChildProcess();
+		process.kill.mockReturnValue(false);
+		mocks.spawn.mockReturnValue(process as unknown as ChildProcess);
+		mocks.cleanup.mockResolvedValue(true);
+
+		try {
+			const renderPromise = renderVideoFramePreview({
+				options: previewOptions({
+					requestId: "kill-false-request",
+					sourcePath,
+				}),
+			});
+			const rejection = expect(renderPromise).rejects.toThrow(
+				"Video frame preview timed out"
+			);
+
+			await vi.advanceTimersByTimeAsync(21_000);
+			await rejection;
+			expect(process.kill).toHaveBeenCalledTimes(2);
+			expect(process.kill).toHaveBeenNthCalledWith(1);
+			expect(process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+			expect(cancelVideoFramePreview({ requestId: "kill-false-request" })).toBe(
+				false
+			);
+			expect(mocks.cleanup).not.toHaveBeenCalled();
+
+			process.emit("close", 0, null);
+			await Promise.resolve();
+			expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/electron/ffmpeg-export-handler.ts
+++ b/qcut/electron/ffmpeg-export-handler.ts
@@ -401,7 +401,7 @@ export function setupExportHandler(tempManager: TempManager): void {
 					}
 
 					// Try to run FFmpeg directly
-					let cleanupFilterScripts: () => void = () => undefined;
+					let cleanupFilterScripts: () => Promise<boolean> = async () => true;
 					try {
 						const preparedFilterScripts = prepareFFmpegFilterComplexScripts({
 							args,
@@ -434,15 +434,15 @@ export function setupExportHandler(tempManager: TempManager): void {
 							}
 						});
 
-						ffmpegProc.on("error", (err: Error) => {
-							cleanupFilterScripts();
+						ffmpegProc.on("error", async (err: Error) => {
+							await cleanupFilterScripts();
 							reject(err);
 						});
 
 						ffmpegProc.on(
 							"close",
-							(code: number | null, signal: string | null) => {
-								cleanupFilterScripts();
+							async (code: number | null, signal: string | null) => {
+								await cleanupFilterScripts();
 								if (code === 0) {
 									resolve({
 										success: true,
@@ -464,7 +464,7 @@ export function setupExportHandler(tempManager: TempManager): void {
 
 						return;
 					} catch {
-						cleanupFilterScripts();
+						await cleanupFilterScripts();
 						// Direct spawn failed
 					}
 

--- a/qcut/electron/ffmpeg-export-handler.ts
+++ b/qcut/electron/ffmpeg-export-handler.ts
@@ -402,6 +402,13 @@ export function setupExportHandler(tempManager: TempManager): void {
 
 					// Try to run FFmpeg directly
 					let cleanupFilterScripts: () => Promise<boolean> = async () => true;
+					const cleanupFilterScriptsSafely = async (): Promise<void> => {
+						try {
+							await cleanupFilterScripts();
+						} catch (error) {
+							console.warn("[FFmpeg] Filter script cleanup failed", error);
+						}
+					};
 					try {
 						const preparedFilterScripts = prepareFFmpegFilterComplexScripts({
 							args,
@@ -435,14 +442,14 @@ export function setupExportHandler(tempManager: TempManager): void {
 						});
 
 						ffmpegProc.on("error", async (err: Error) => {
-							await cleanupFilterScripts();
+							await cleanupFilterScriptsSafely();
 							reject(err);
 						});
 
 						ffmpegProc.on(
 							"close",
 							async (code: number | null, signal: string | null) => {
-								await cleanupFilterScripts();
+								await cleanupFilterScriptsSafely();
 								if (code === 0) {
 									resolve({
 										success: true,
@@ -464,7 +471,7 @@ export function setupExportHandler(tempManager: TempManager): void {
 
 						return;
 					} catch {
-						await cleanupFilterScripts();
+						await cleanupFilterScriptsSafely();
 						// Direct spawn failed
 					}
 

--- a/qcut/electron/ffmpeg/advanced-transition-expressions.ts
+++ b/qcut/electron/ffmpeg/advanced-transition-expressions.ts
@@ -40,20 +40,39 @@ function directionalCoordinates({
 	throw new Error("Unsupported transition direction");
 }
 
+function scaledCoordinates({
+	x,
+	y,
+	scale,
+}: {
+	x: string;
+	y: string;
+	scale: string;
+}): { x: string; y: string } {
+	return {
+		x: `W/2+((${x})-W/2)/${scale}`,
+		y: `H/2+((${y})-H/2)/${scale}`,
+	};
+}
+
 function averagedDirectionalSamples({
 	input,
 	direction,
 	radius,
+	x = "X",
+	y = "Y",
 }: {
 	input: "a" | "b";
 	direction: VideoTransition["direction"];
 	radius: string;
+	x?: string;
+	y?: string;
 }): string {
 	const samples = [-2, -1, 0, 1, 2].map((tap) => {
 		const coordinates = directionalCoordinates({
 			direction,
-			x: "X",
-			y: "Y",
+			x,
+			y,
 			offset: `${tap}*(${radius})`,
 		});
 		return clampedPlaneSample({ input, ...coordinates });
@@ -73,17 +92,33 @@ export function motionBlurExpression({
 	const peak = transitionPeakExpression({ progress });
 	const axisSize = direction === "up" || direction === "down" ? "H" : "W";
 	const radius = `${0.012 * intensity}*${axisSize}*(${peak})`;
+	const travel = `${0.055 * intensity}*${axisSize}*(${peak})`;
+	const scale = `(1+${0.035 * intensity}*(${peak}))`;
+	const outgoingCoordinates = directionalCoordinates({
+		direction,
+		x: "X",
+		y: "Y",
+		offset: `-1*(${travel})`,
+	});
+	const incomingCoordinates = directionalCoordinates({
+		direction,
+		x: "X",
+		y: "Y",
+		offset: travel,
+	});
 	return blendSamples({
 		progress,
 		outgoing: averagedDirectionalSamples({
 			input: "a",
 			direction,
 			radius,
+			...scaledCoordinates({ ...outgoingCoordinates, scale }),
 		}),
 		incoming: averagedDirectionalSamples({
 			input: "b",
 			direction,
 			radius,
+			...scaledCoordinates({ ...incomingCoordinates, scale }),
 		}),
 	});
 }
@@ -242,7 +277,8 @@ export function pageFlipExpression({
 	const foldWidth = Math.min(0.16, 0.07 * intensity);
 	const shade = `(0.58+0.42*min(1,(${foldDistance})/(${foldWidth}*${axisSize})))`;
 	const highlight = `max(0,1-(${foldDistance})/(${foldWidth * 0.32}*${axisSize}))*34`;
-	return `if(eq(PLANE,3),${base},min(255,(${base})*(${shade})+(${highlight})))`;
+	const folded = `if(eq(PLANE,3),${base},min(255,(${base})*(${shade})+(${highlight})))`;
+	return `if(lte(${progress},0.001),A,if(gte(${progress},0.999),B,${folded}))`;
 }
 
 function swirledSample({
@@ -363,6 +399,22 @@ export function cubeExpression({
 	return `if(eq(PLANE,3),${base},(${base})*(${shading}))`;
 }
 
+function heartMaskExpression({ progress }: { progress: string }): string {
+	const scale = `((0.78*max(0.001,(${progress}))+pow((${progress}),8))*H)`;
+	const x = `((X-W/2)/${scale})`;
+	const y = `(-((Y-H/2)/${scale})+0.1185)`;
+	const xSquared = `pow(${x},2)`;
+	const ySquared = `pow(${y},2)`;
+	const equation = `(pow((${xSquared})+(${ySquared})-1,3)-(${xSquared})*pow(${y},3))`;
+	const localMix = `min(1,max(0,0.5-(${equation})/0.08))`;
+	const shapedBlend = blendSamples({
+		progress: localMix,
+		outgoing: "A",
+		incoming: "B",
+	});
+	return `if(lte(${progress},0.001),A,if(gte(${progress},0.999),B,${shapedBlend}))`;
+}
+
 /**
  * Shaped wipe fields for texture-mask transitions with a maskShape. Each
  * shape maps every pixel to a scalar in [0,1] describing when the incoming
@@ -376,9 +428,13 @@ export function maskShapeExpression({
 	shape: string;
 	progress: string;
 }): string {
+	if (shape === "heart") {
+		return heartMaskExpression({ progress });
+	}
 	const dx = "(X/W-0.5)";
 	const dy = "(Y/H-0.5)";
-	const radius = `(sqrt(pow(${dx},2)+pow(${dy},2))/0.7071)`;
+	const normalizedRadius = `(sqrt(pow(${dx},2)+pow(${dy},2))/0.7071)`;
+	const circularRadius = "(sqrt(pow(X-W/2,2)+pow(Y-H/2,2))/(sqrt(W*W+H*H)/2))";
 	const angle = `((atan2(${dy},${dx})+PI)/(2*PI))`;
 	const organicNoise =
 		"((sin(X/W*13+sin(Y/H*17)*2)+cos(Y/H*11+sin(X/W*7)*2)+2)/4)";
@@ -386,7 +442,7 @@ export function maskShapeExpression({
 	let feather = 0.03;
 	switch (shape) {
 		case "circle":
-			field = radius;
+			field = circularRadius;
 			break;
 		case "clock":
 			field = angle;
@@ -407,16 +463,12 @@ export function maskShapeExpression({
 			field = "((X+abs(Y-H/2))/(W+H/2))";
 			feather = 0.02;
 			break;
-		case "heart":
-			field = `(sqrt(pow(${dx},2)+pow(${dy},2))/(0.34*(1.35-sin(atan2(-(${dy}),${dx})))+0.08))`;
-			feather = 0.05;
-			break;
 		case "star":
 			field = `(sqrt(pow(${dx},2)+pow(${dy},2))/(0.42+0.24*cos(5*atan2(${dy},${dx})+PI/2)))`;
 			feather = 0.05;
 			break;
 		case "ink":
-			field = `(0.6*${organicNoise}+0.4*${radius})`;
+			field = `(0.6*${organicNoise}+0.4*${normalizedRadius})`;
 			feather = 0.09;
 			break;
 		case "cloud":
@@ -424,7 +476,7 @@ export function maskShapeExpression({
 			feather = 0.09;
 			break;
 		case "fog":
-			field = `(0.7*${organicNoise}+0.3*${radius})`;
+			field = `(0.7*${organicNoise}+0.3*${normalizedRadius})`;
 			feather = 0.11;
 			break;
 		case "diagonal":
@@ -440,7 +492,7 @@ export function maskShapeExpression({
 			feather = 0.07;
 			break;
 		default:
-			field = radius;
+			field = circularRadius;
 			break;
 	}
 	const scaledProgress = `((${progress})*${(1 + 2 * feather).toFixed(3)})`;

--- a/qcut/electron/ffmpeg/filter-complex-script.ts
+++ b/qcut/electron/ffmpeg/filter-complex-script.ts
@@ -31,9 +31,11 @@ function retryableDirectoryCleanup({
 export function prepareFFmpegFilterComplexScripts({
 	args,
 	temporaryDirectory = os.tmpdir(),
+	commandLengthThreshold = MAX_INLINE_FFMPEG_ARGUMENT_CODE_UNITS,
 }: {
 	args: readonly string[];
 	temporaryDirectory?: string;
+	commandLengthThreshold?: number;
 }): PreparedFFmpegFilterScripts {
 	let filterCount = 0;
 	for (let index = 0; index < args.length; index += 1) {
@@ -55,7 +57,7 @@ export function prepareFFmpegFilterComplexScripts({
 			cleanup: async () => true,
 		};
 	}
-	if (estimatedCommandCodeUnits <= MAX_INLINE_FFMPEG_ARGUMENT_CODE_UNITS) {
+	if (estimatedCommandCodeUnits <= commandLengthThreshold) {
 		return {
 			args: [...args],
 			scriptPaths: [],
@@ -98,76 +100,4 @@ export function prepareFFmpegFilterComplexScripts({
 		void cleanup();
 		throw error;
 	}
-}
-
-const DEFAULT_COMMAND_LENGTH_THRESHOLD = 28_000;
-
-export interface PreparedFFmpegFilterScript {
-	args: string[];
-	cleanup: () => Promise<boolean>;
-	filterScriptPath?: string;
-}
-
-function estimateCommandLength({
-	executablePath,
-	args,
-}: {
-	executablePath: string;
-	args: string[];
-}): number {
-	return args.reduce(
-		(total, argument) => total + argument.length + 3,
-		executablePath.length
-	);
-}
-
-export function prepareFFmpegFilterScript({
-	executablePath,
-	args,
-	commandLengthThreshold = DEFAULT_COMMAND_LENGTH_THRESHOLD,
-	tempDirectory = os.tmpdir(),
-}: {
-	executablePath: string;
-	args: string[];
-	commandLengthThreshold?: number;
-	tempDirectory?: string;
-}): PreparedFFmpegFilterScript {
-	const filterIndex = args.indexOf("-filter_complex");
-	if (filterIndex < 0) {
-		return { args, cleanup: async () => true };
-	}
-
-	const filterGraph = args[filterIndex + 1];
-	if (typeof filterGraph !== "string") {
-		throw new Error("FFmpeg filter graph argument is missing");
-	}
-
-	const commandLength = estimateCommandLength({ executablePath, args });
-	if (commandLength <= commandLengthThreshold) {
-		return { args, cleanup: async () => true };
-	}
-
-	const scriptDirectory = fs.mkdtempSync(
-		path.join(tempDirectory, "qcut-ffmpeg-filter-")
-	);
-	const filterScriptPath = path.join(scriptDirectory, "filter-complex.ffgraph");
-	try {
-		fs.writeFileSync(filterScriptPath, filterGraph, {
-			encoding: "utf8",
-			mode: 0o600,
-		});
-	} catch (error) {
-		fs.rmSync(scriptDirectory, { recursive: true, force: true });
-		throw error;
-	}
-
-	const cleanup = retryableDirectoryCleanup({ directory: scriptDirectory });
-	const preparedArgs = [...args];
-	preparedArgs.splice(
-		filterIndex,
-		2,
-		"-filter_complex_script",
-		filterScriptPath
-	);
-	return { args: preparedArgs, filterScriptPath, cleanup };
 }

--- a/qcut/electron/ffmpeg/filter-complex-script.ts
+++ b/qcut/electron/ffmpeg/filter-complex-script.ts
@@ -7,10 +7,26 @@ import { removeTemporaryDirectory } from "./temporary-files.js";
 export interface PreparedFFmpegFilterScripts {
 	args: string[];
 	scriptPaths: string[];
-	cleanup: () => void;
+	cleanup: () => Promise<boolean>;
 }
 
 const MAX_INLINE_FFMPEG_ARGUMENT_CODE_UNITS = 16_000;
+
+function retryableDirectoryCleanup({
+	directory,
+}: {
+	directory: string;
+}): () => Promise<boolean> {
+	let cleanupPromise: Promise<boolean> | undefined;
+	return () => {
+		if (cleanupPromise) return cleanupPromise;
+		cleanupPromise = removeTemporaryDirectory({ directory });
+		cleanupPromise.then((removed) => {
+			if (!removed) cleanupPromise = undefined;
+		});
+		return cleanupPromise;
+	};
+}
 
 export function prepareFFmpegFilterComplexScripts({
 	args,
@@ -36,14 +52,14 @@ export function prepareFFmpegFilterComplexScripts({
 		return {
 			args: [...args],
 			scriptPaths: [],
-			cleanup: () => undefined,
+			cleanup: async () => true,
 		};
 	}
 	if (estimatedCommandCodeUnits <= MAX_INLINE_FFMPEG_ARGUMENT_CODE_UNITS) {
 		return {
 			args: [...args],
 			scriptPaths: [],
-			cleanup: () => undefined,
+			cleanup: async () => true,
 		};
 	}
 
@@ -51,16 +67,7 @@ export function prepareFFmpegFilterComplexScripts({
 		path.join(temporaryDirectory, "qcut-ffmpeg-filter-")
 	);
 	const scriptPaths: string[] = [];
-	let cleaned = false;
-	const cleanup = () => {
-		if (cleaned) return;
-		try {
-			fs.rmSync(directory, { recursive: true, force: true });
-			cleaned = true;
-		} catch {
-			return;
-		}
-	};
+	const cleanup = retryableDirectoryCleanup({ directory });
 
 	try {
 		const preparedArgs: string[] = [];
@@ -88,7 +95,7 @@ export function prepareFFmpegFilterComplexScripts({
 		}
 		return { args: preparedArgs, scriptPaths, cleanup };
 	} catch (error) {
-		cleanup();
+		void cleanup();
 		throw error;
 	}
 }
@@ -97,7 +104,7 @@ const DEFAULT_COMMAND_LENGTH_THRESHOLD = 28_000;
 
 export interface PreparedFFmpegFilterScript {
 	args: string[];
-	cleanup: () => void;
+	cleanup: () => Promise<boolean>;
 	filterScriptPath?: string;
 }
 
@@ -127,7 +134,7 @@ export function prepareFFmpegFilterScript({
 }): PreparedFFmpegFilterScript {
 	const filterIndex = args.indexOf("-filter_complex");
 	if (filterIndex < 0) {
-		return { args, cleanup: () => undefined };
+		return { args, cleanup: async () => true };
 	}
 
 	const filterGraph = args[filterIndex + 1];
@@ -137,7 +144,7 @@ export function prepareFFmpegFilterScript({
 
 	const commandLength = estimateCommandLength({ executablePath, args });
 	if (commandLength <= commandLengthThreshold) {
-		return { args, cleanup: () => undefined };
+		return { args, cleanup: async () => true };
 	}
 
 	const scriptDirectory = fs.mkdtempSync(
@@ -154,12 +161,7 @@ export function prepareFFmpegFilterScript({
 		throw error;
 	}
 
-	let cleaned = false;
-	const cleanup = () => {
-		if (cleaned) return;
-		cleaned = true;
-		removeTemporaryDirectory({ directory: scriptDirectory });
-	};
+	const cleanup = retryableDirectoryCleanup({ directory: scriptDirectory });
 	const preparedArgs = [...args];
 	preparedArgs.splice(
 		filterIndex,

--- a/qcut/electron/ffmpeg/filter-complex-script.ts
+++ b/qcut/electron/ffmpeg/filter-complex-script.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { removeTemporaryDirectory } from "./temporary-files.js";
 
 export interface PreparedFFmpegFilterScripts {
 	args: string[];
@@ -90,4 +91,81 @@ export function prepareFFmpegFilterComplexScripts({
 		cleanup();
 		throw error;
 	}
+}
+
+const DEFAULT_COMMAND_LENGTH_THRESHOLD = 28_000;
+
+export interface PreparedFFmpegFilterScript {
+	args: string[];
+	cleanup: () => void;
+	filterScriptPath?: string;
+}
+
+function estimateCommandLength({
+	executablePath,
+	args,
+}: {
+	executablePath: string;
+	args: string[];
+}): number {
+	return args.reduce(
+		(total, argument) => total + argument.length + 3,
+		executablePath.length
+	);
+}
+
+export function prepareFFmpegFilterScript({
+	executablePath,
+	args,
+	commandLengthThreshold = DEFAULT_COMMAND_LENGTH_THRESHOLD,
+	tempDirectory = os.tmpdir(),
+}: {
+	executablePath: string;
+	args: string[];
+	commandLengthThreshold?: number;
+	tempDirectory?: string;
+}): PreparedFFmpegFilterScript {
+	const filterIndex = args.indexOf("-filter_complex");
+	if (filterIndex < 0) {
+		return { args, cleanup: () => undefined };
+	}
+
+	const filterGraph = args[filterIndex + 1];
+	if (typeof filterGraph !== "string") {
+		throw new Error("FFmpeg filter graph argument is missing");
+	}
+
+	const commandLength = estimateCommandLength({ executablePath, args });
+	if (commandLength <= commandLengthThreshold) {
+		return { args, cleanup: () => undefined };
+	}
+
+	const scriptDirectory = fs.mkdtempSync(
+		path.join(tempDirectory, "qcut-ffmpeg-filter-")
+	);
+	const filterScriptPath = path.join(scriptDirectory, "filter-complex.ffgraph");
+	try {
+		fs.writeFileSync(filterScriptPath, filterGraph, {
+			encoding: "utf8",
+			mode: 0o600,
+		});
+	} catch (error) {
+		fs.rmSync(scriptDirectory, { recursive: true, force: true });
+		throw error;
+	}
+
+	let cleaned = false;
+	const cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
+		removeTemporaryDirectory({ directory: scriptDirectory });
+	};
+	const preparedArgs = [...args];
+	preparedArgs.splice(
+		filterIndex,
+		2,
+		"-filter_complex_script",
+		filterScriptPath
+	);
+	return { args: preparedArgs, filterScriptPath, cleanup };
 }

--- a/qcut/electron/ffmpeg/filter-complex-script.ts
+++ b/qcut/electron/ffmpeg/filter-complex-script.ts
@@ -20,11 +20,18 @@ function retryableDirectoryCleanup({
 	let cleanupPromise: Promise<boolean> | undefined;
 	return () => {
 		if (cleanupPromise) return cleanupPromise;
-		cleanupPromise = removeTemporaryDirectory({ directory });
-		cleanupPromise.then((removed) => {
-			if (!removed) cleanupPromise = undefined;
-		});
-		return cleanupPromise;
+		const pendingCleanup = removeTemporaryDirectory({ directory }).then(
+			(removed) => {
+				if (!removed) cleanupPromise = undefined;
+				return removed;
+			},
+			(error) => {
+				cleanupPromise = undefined;
+				throw error;
+			}
+		);
+		cleanupPromise = pendingCleanup;
+		return pendingCleanup;
 	};
 }
 
@@ -97,7 +104,7 @@ export function prepareFFmpegFilterComplexScripts({
 		}
 		return { args: preparedArgs, scriptPaths, cleanup };
 	} catch (error) {
-		void cleanup();
+		void cleanup().catch(() => undefined);
 		throw error;
 	}
 }

--- a/qcut/electron/ffmpeg/temporary-files.ts
+++ b/qcut/electron/ffmpeg/temporary-files.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+
+export function removeTemporaryDirectory({
+	directory,
+}: {
+	directory: string;
+}): void {
+	try {
+		fs.rmSync(directory, { recursive: true, force: true });
+	} catch {
+		fs.rm(
+			directory,
+			{ recursive: true, force: true, maxRetries: 5, retryDelay: 100 },
+			() => undefined
+		);
+	}
+}

--- a/qcut/electron/ffmpeg/temporary-files.ts
+++ b/qcut/electron/ffmpeg/temporary-files.ts
@@ -1,17 +1,38 @@
 import fs from "fs";
 
-export function removeTemporaryDirectory({
+const IMMEDIATE_REMOVAL_OPTIONS = {
+	recursive: true,
+	force: true,
+} as const;
+
+const ASYNC_REMOVAL_OPTIONS = {
+	...IMMEDIATE_REMOVAL_OPTIONS,
+	maxRetries: 5,
+	retryDelay: 100,
+} as const;
+
+export async function removeTemporaryDirectory({
 	directory,
 }: {
 	directory: string;
-}): void {
+}): Promise<boolean> {
 	try {
-		fs.rmSync(directory, { recursive: true, force: true });
-	} catch {
-		fs.rm(
-			directory,
-			{ recursive: true, force: true, maxRetries: 5, retryDelay: 100 },
-			() => undefined
-		);
+		fs.rmSync(directory, IMMEDIATE_REMOVAL_OPTIONS);
+		return true;
+	} catch (syncError) {
+		return new Promise((resolve) => {
+			fs.rm(directory, ASYNC_REMOVAL_OPTIONS, (error) => {
+				if (!error) {
+					resolve(true);
+					return;
+				}
+				console.warn("[FFmpeg] Temporary directory cleanup failed", {
+					directory,
+					syncError,
+					error,
+				});
+				resolve(false);
+			});
+		});
 	}
 }

--- a/qcut/electron/ffmpeg/temporary-files.ts
+++ b/qcut/electron/ffmpeg/temporary-files.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 
 const IMMEDIATE_REMOVAL_OPTIONS = {
 	recursive: true,

--- a/qcut/electron/ffmpeg/transition-filter.ts
+++ b/qcut/electron/ffmpeg/transition-filter.ts
@@ -375,6 +375,65 @@ function zoomBlurExpression({
 	});
 }
 
+function zoomInBlurPlaneSample({
+	input,
+	progress,
+	peak,
+	intensity,
+}: {
+	input: "a" | "b";
+	progress: string;
+	peak: string;
+	intensity: number;
+}): string {
+	const zoomDistance = 0.12 * intensity;
+	const baseZoom =
+		input === "a"
+			? "(1+" + zoomDistance + "*(" + progress + "))"
+			: "(1-" + zoomDistance + "*(1-(" + progress + ")))";
+	const samples: string[] = [];
+	for (const strength of [0, 0.5, 1]) {
+		const trailDistance = 0.035 * strength * intensity;
+		const zoom =
+			strength === 0
+				? baseZoom
+				: "(" + baseZoom + "-" + trailDistance + "*(" + peak + "))";
+		samples.push(
+			clampedPlaneSample({
+				input,
+				x: "W/2+(X-W/2)/" + zoom,
+				y: "H/2+(Y-H/2)/" + zoom,
+			})
+		);
+	}
+	return "(" + samples.join("+") + ")/" + samples.length;
+}
+
+function zoomInBlurExpression({
+	progress,
+	intensity,
+}: {
+	progress: string;
+	intensity: number;
+}): string {
+	const peak = transitionPeakExpression({ progress });
+	return blendSamples({
+		progress,
+		outgoing: zoomInBlurPlaneSample({
+			input: "a",
+			progress,
+			peak,
+			intensity,
+		}),
+		incoming: zoomInBlurPlaneSample({
+			input: "b",
+			progress,
+			peak,
+			intensity,
+		}),
+	});
+}
+
 function whipPanExpression({
 	direction,
 	progress,
@@ -519,7 +578,8 @@ export function buildXfadeTransitionFilter({
 }: {
 	transition: VideoTransition;
 }): XfadeTransitionFilter {
-	const progress = semanticProgressExpression({ transition });
+	const semanticProgress = semanticProgressExpression({ transition });
+	const progress = "ld(0)";
 	const type = transition.type;
 	const tuning = transitionTuning({ transition });
 	let expression: string;
@@ -554,6 +614,12 @@ export function buildXfadeTransitionFilter({
 			break;
 		case "zoom-blur":
 			expression = zoomBlurExpression({
+				progress,
+				intensity: tuning.intensity,
+			});
+			break;
+		case "zoom-in-blur":
+			expression = zoomInBlurExpression({
 				progress,
 				intensity: tuning.intensity,
 			});
@@ -684,5 +750,13 @@ export function buildXfadeTransitionFilter({
 			throw new Error(`Unsupported transition type: ${unsupportedType}`);
 		}
 	}
-	return { transition: "custom", expression };
+	const peak = transitionPeakExpression({ progress });
+	const usesPeak = expression.includes(peak);
+	if (usesPeak) {
+		expression = expression.split(peak).join("ld(3)");
+	}
+	return {
+		transition: "custom",
+		expression: `st(0,${semanticProgress});${usesPeak ? `st(3,${peak});` : ""}${expression}`,
+	};
 }

--- a/qcut/electron/ffmpeg/transition-filter.ts
+++ b/qcut/electron/ffmpeg/transition-filter.ts
@@ -578,8 +578,7 @@ export function buildXfadeTransitionFilter({
 }: {
 	transition: VideoTransition;
 }): XfadeTransitionFilter {
-	const semanticProgress = semanticProgressExpression({ transition });
-	const progress = "ld(0)";
+	const progress = semanticProgressExpression({ transition });
 	const type = transition.type;
 	const tuning = transitionTuning({ transition });
 	let expression: string;
@@ -750,13 +749,5 @@ export function buildXfadeTransitionFilter({
 			throw new Error(`Unsupported transition type: ${unsupportedType}`);
 		}
 	}
-	const peak = transitionPeakExpression({ progress });
-	const usesPeak = expression.includes(peak);
-	if (usesPeak) {
-		expression = expression.split(peak).join("ld(3)");
-	}
-	return {
-		transition: "custom",
-		expression: `st(0,${semanticProgress});${usesPeak ? `st(3,${peak});` : ""}${expression}`,
-	};
+	return { transition: "custom", expression };
 }

--- a/qcut/electron/ffmpeg/types.ts
+++ b/qcut/electron/ffmpeg/types.ts
@@ -242,6 +242,7 @@ export interface VideoTransition {
 		| "wipe"
 		| "push"
 		| "zoom-blur"
+		| "zoom-in-blur"
 		| "whip-pan"
 		| "flash"
 		| "light-leak"

--- a/qcut/electron/ffmpeg/video-frame-preview.ts
+++ b/qcut/electron/ffmpeg/video-frame-preview.ts
@@ -17,6 +17,7 @@ import {
 	normalizeVideoEnhancements,
 } from "./video-enhancement-filter.js";
 import { prepareFFmpegFilterComplexScripts } from "./filter-complex-script.js";
+import { removeTemporaryDirectory } from "./temporary-files.js";
 import { buildVideoFitFilter } from "./video-fit-filter.js";
 import { getFFmpegPath } from "./utils.js";
 
@@ -561,7 +562,7 @@ export async function renderVideoCompositionFramePreview({
 		};
 	} finally {
 		if (preparedText.directory) {
-			fs.rmSync(preparedText.directory, { recursive: true, force: true });
+			removeTemporaryDirectory({ directory: preparedText.directory });
 		}
 	}
 }

--- a/qcut/electron/ffmpeg/video-frame-preview.ts
+++ b/qcut/electron/ffmpeg/video-frame-preview.ts
@@ -431,32 +431,48 @@ function runPreviewProcess({
 	args: string[];
 	timeoutMs?: number;
 }): Promise<Buffer> {
-	const preparedFilterScripts = prepareFFmpegFilterComplexScripts({ args });
 	const ffmpegPath = getFFmpegPath();
+	const preparedFilterScripts = prepareFFmpegFilterComplexScripts({ args });
 	return new Promise<Buffer>((resolve, reject) => {
-		let process: ChildProcess;
+		let child: ChildProcess;
 		try {
-			process = spawn(ffmpegPath, preparedFilterScripts.args, {
+			child = spawn(ffmpegPath, preparedFilterScripts.args, {
 				windowsHide: true,
 				stdio: ["ignore", "pipe", "pipe"],
 			});
 		} catch (error) {
-			void preparedFilterScripts.cleanup().then(() => reject(error));
+			void preparedFilterScripts.cleanup().then(
+				() => reject(error),
+				() => reject(error)
+			);
 			return;
 		}
 		let requestSettled = false;
-		let processClosed = false;
+		let childTerminated = false;
 		let processTimer: ReturnType<typeof setTimeout> | undefined;
 		let closeGraceTimer: ReturnType<typeof setTimeout> | undefined;
 		let cleanupStarted = false;
-		const cleanupAfterClose = async () => {
+		const cleanupAfterProcessExit = async () => {
 			if (cleanupStarted) return;
 			cleanupStarted = true;
-			const removed = await preparedFilterScripts.cleanup();
-			if (removed) return;
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
-			await preparedFilterScripts.cleanup();
+			try {
+				const removed = await preparedFilterScripts.cleanup();
+				if (removed) return;
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+				const removedAfterRetry = await preparedFilterScripts.cleanup();
+				if (!removedAfterRetry) cleanupStarted = false;
+			} catch (error) {
+				cleanupStarted = false;
+				console.warn("[FFmpeg] Video frame preview cleanup failed", {
+					requestId,
+					error,
+				});
+			}
 		};
+		child.once("exit", () => {
+			childTerminated = true;
+			void cleanupAfterProcessExit();
+		});
 		const settleRequest = ({
 			error,
 			data,
@@ -468,7 +484,7 @@ function runPreviewProcess({
 			requestSettled = true;
 			if (processTimer) clearTimeout(processTimer);
 			if (closeGraceTimer) clearTimeout(closeGraceTimer);
-			if (activeRequests.get(requestId) === process) {
+			if (activeRequests.get(requestId) === child) {
 				activeRequests.delete(requestId);
 			}
 			if (error) reject(error);
@@ -481,52 +497,54 @@ function runPreviewProcess({
 			error?: Error;
 			data?: Buffer;
 		}) => {
-			processClosed = true;
+			childTerminated = true;
 			settleRequest({ error, data });
-			void cleanupAfterClose();
+			void cleanupAfterProcessExit();
 		};
 		const scheduleCloseGrace = ({ error }: { error: Error }) => {
-			if (requestSettled || processClosed || closeGraceTimer) return;
+			if (requestSettled || closeGraceTimer) return;
 			closeGraceTimer = setTimeout(() => {
-				try {
-					process.kill("SIGKILL");
-				} catch (error) {
-					console.warn("[FFmpeg] Failed to force-stop video frame preview", {
-						requestId,
-						error,
-					});
+				if (!childTerminated) {
+					try {
+						child.kill("SIGKILL");
+					} catch (killError) {
+						console.warn("[FFmpeg] Failed to force-stop video frame preview", {
+							requestId,
+							error: killError,
+						});
+					}
 				}
 				settleRequest({ error });
 			}, PROCESS_CLOSE_GRACE_MS);
 		};
-		if (!(process.stdout && process.stderr)) {
+		if (!(child.stdout && child.stderr)) {
 			const pipeError = new Error("Video frame preview pipes are unavailable");
-			process.once("error", () => undefined);
-			process.once("close", () => {
+			child.once("error", () => undefined);
+			child.once("close", () => {
 				finishAfterClose({ error: pipeError });
 			});
 			scheduleCloseGrace({ error: pipeError });
-			process.kill();
+			child.kill();
 			return;
 		}
-		activeRequests.set(requestId, process);
+		activeRequests.set(requestId, child);
 		const stdout: Buffer[] = [];
 		let stderr = "";
 		let terminalError: Error | undefined;
 		processTimer = setTimeout(() => {
 			terminalError = new Error("Video frame preview timed out");
 			scheduleCloseGrace({ error: terminalError });
-			process.kill();
+			if (!childTerminated) child.kill();
 		}, timeoutMs);
-		process.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-		process.stderr.on("data", (chunk: Buffer) => {
+		child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+		child.stderr.on("data", (chunk: Buffer) => {
 			stderr += chunk.toString();
 		});
-		process.on("error", (error) => {
+		child.on("error", (error) => {
 			terminalError = error;
 			scheduleCloseGrace({ error });
 		});
-		process.on("close", (code, signal) => {
+		child.on("close", (code, signal) => {
 			if (terminalError) {
 				finishAfterClose({ error: terminalError });
 				return;
@@ -635,10 +653,10 @@ export function cancelVideoFramePreview({
 }: {
 	requestId: string;
 }): boolean {
-	const process = activeRequests.get(requestId);
-	if (!process) return false;
+	const child = activeRequests.get(requestId);
+	if (!child) return false;
 	activeRequests.delete(requestId);
-	return process.kill();
+	return child.kill();
 }
 
 export function clearVideoFramePreviewCache(): void {

--- a/qcut/electron/ffmpeg/video-frame-preview.ts
+++ b/qcut/electron/ffmpeg/video-frame-preview.ts
@@ -26,6 +26,7 @@ const MAX_CACHE_BYTES = 64 * 1024 * 1024;
 const MAX_PREVIEW_DIMENSION = 4096;
 const PROCESS_TIMEOUT_MS = 20_000;
 const COMPOSITION_PROCESS_TIMEOUT_MS = 60_000;
+const PROCESS_CLOSE_GRACE_MS = 1_000;
 const TEMPORAL_PREROLL_SECONDS = 0.5;
 const MAX_TEXT_ASS_LAYERS = 1_000;
 const MAX_TEXT_ASS_BYTES = 16 * 1024 * 1024;
@@ -431,27 +432,90 @@ function runPreviewProcess({
 	timeoutMs?: number;
 }): Promise<Buffer> {
 	const preparedFilterScripts = prepareFFmpegFilterComplexScripts({ args });
+	const ffmpegPath = getFFmpegPath();
 	return new Promise<Buffer>((resolve, reject) => {
-		const process = spawn(getFFmpegPath(), preparedFilterScripts.args, {
-			windowsHide: true,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-		activeRequests.set(requestId, process);
-		const stdout: Buffer[] = [];
-		let stderr = "";
-		let processError: Error | undefined;
-		let timeoutError: Error | undefined;
-		let settled = false;
-		const finish = ({ error, data }: { error?: Error; data?: Buffer }) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timer);
-			activeRequests.delete(requestId);
+		let process: ChildProcess;
+		try {
+			process = spawn(ffmpegPath, preparedFilterScripts.args, {
+				windowsHide: true,
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+		} catch (error) {
+			void preparedFilterScripts.cleanup().then(() => reject(error));
+			return;
+		}
+		let requestSettled = false;
+		let processClosed = false;
+		let processTimer: ReturnType<typeof setTimeout> | undefined;
+		let closeGraceTimer: ReturnType<typeof setTimeout> | undefined;
+		let cleanupStarted = false;
+		const cleanupAfterClose = async () => {
+			if (cleanupStarted) return;
+			cleanupStarted = true;
+			const removed = await preparedFilterScripts.cleanup();
+			if (removed) return;
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+			await preparedFilterScripts.cleanup();
+		};
+		const settleRequest = ({
+			error,
+			data,
+		}: {
+			error?: Error;
+			data?: Buffer;
+		}) => {
+			if (requestSettled) return;
+			requestSettled = true;
+			if (processTimer) clearTimeout(processTimer);
+			if (closeGraceTimer) clearTimeout(closeGraceTimer);
+			if (activeRequests.get(requestId) === process) {
+				activeRequests.delete(requestId);
+			}
 			if (error) reject(error);
 			else resolve(data ?? Buffer.alloc(0));
 		};
-		const timer = setTimeout(() => {
-			timeoutError = new Error("Video frame preview timed out");
+		const finishAfterClose = ({
+			error,
+			data,
+		}: {
+			error?: Error;
+			data?: Buffer;
+		}) => {
+			processClosed = true;
+			settleRequest({ error, data });
+			void cleanupAfterClose();
+		};
+		const scheduleCloseGrace = ({ error }: { error: Error }) => {
+			if (requestSettled || processClosed || closeGraceTimer) return;
+			closeGraceTimer = setTimeout(() => {
+				try {
+					process.kill("SIGKILL");
+				} catch (error) {
+					console.warn("[FFmpeg] Failed to force-stop video frame preview", {
+						requestId,
+						error,
+					});
+				}
+				settleRequest({ error });
+			}, PROCESS_CLOSE_GRACE_MS);
+		};
+		if (!(process.stdout && process.stderr)) {
+			const pipeError = new Error("Video frame preview pipes are unavailable");
+			process.once("error", () => undefined);
+			process.once("close", () => {
+				finishAfterClose({ error: pipeError });
+			});
+			scheduleCloseGrace({ error: pipeError });
+			process.kill();
+			return;
+		}
+		activeRequests.set(requestId, process);
+		const stdout: Buffer[] = [];
+		let stderr = "";
+		let terminalError: Error | undefined;
+		processTimer = setTimeout(() => {
+			terminalError = new Error("Video frame preview timed out");
+			scheduleCloseGrace({ error: terminalError });
 			process.kill();
 		}, timeoutMs);
 		process.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
@@ -459,19 +523,16 @@ function runPreviewProcess({
 			stderr += chunk.toString();
 		});
 		process.on("error", (error) => {
-			processError = error;
+			terminalError = error;
+			scheduleCloseGrace({ error });
 		});
 		process.on("close", (code, signal) => {
-			if (timeoutError) {
-				finish({ error: timeoutError });
-				return;
-			}
-			if (processError) {
-				finish({ error: processError });
+			if (terminalError) {
+				finishAfterClose({ error: terminalError });
 				return;
 			}
 			if (code !== 0) {
-				finish({
+				finishAfterClose({
 					error: new Error(
 						signal
 							? `Video frame preview cancelled (${signal})`
@@ -482,12 +543,14 @@ function runPreviewProcess({
 			}
 			const pngData = Buffer.concat(stdout);
 			if (pngData.byteLength < 100) {
-				finish({ error: new Error("Video frame preview returned no image") });
+				finishAfterClose({
+					error: new Error("Video frame preview returned no image"),
+				});
 				return;
 			}
-			finish({ data: pngData });
+			finishAfterClose({ data: pngData });
 		});
-	}).finally(preparedFilterScripts.cleanup);
+	});
 }
 
 export async function renderVideoFramePreview({
@@ -562,7 +625,7 @@ export async function renderVideoCompositionFramePreview({
 		};
 	} finally {
 		if (preparedText.directory) {
-			removeTemporaryDirectory({ directory: preparedText.directory });
+			await removeTemporaryDirectory({ directory: preparedText.directory });
 		}
 	}
 }

--- a/qcut/packages/editor-core/src/__tests__/composition-plan.test.ts
+++ b/qcut/packages/editor-core/src/__tests__/composition-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildCompositionPlan } from "../timeline/composition-plan.js";
 import type {
+	ClipTransition,
 	MediaElement,
 	TextElement,
 	TimelineElement,
@@ -64,20 +65,40 @@ function createMediaElement({
 	};
 }
 
+function createTransition({
+	fromElementId,
+	toElementId,
+}: {
+	fromElementId: string;
+	toElementId: string;
+}): ClipTransition {
+	return {
+		id: `${fromElementId}-${toElementId}`,
+		fromElementId,
+		toElementId,
+		presetId: "dissolve",
+		type: "dissolve",
+		duration: 0.6,
+		easing: "linear",
+	};
+}
+
 function createTrack({
 	id,
 	order,
 	type = "text",
 	elements,
+	transitions,
 	hidden = false,
 }: {
 	id: string;
 	order: number;
 	type?: TimelineTrack["type"];
 	elements: TimelineElement[];
+	transitions?: ClipTransition[];
 	hidden?: boolean;
 }): TimelineTrack {
-	return { id, name: id, type, order, elements, hidden };
+	return { id, name: id, type, order, elements, transitions, hidden };
 }
 
 describe("buildCompositionPlan", () => {
@@ -111,7 +132,41 @@ describe("buildCompositionPlan", () => {
 		]);
 	});
 
-	it("draws the incoming transition clip above the outgoing clip regardless of storage order", () => {
+	it("preserves storage order for ordinary overlapping elements", () => {
+		const later = createMediaElement({
+			id: "later",
+			startTime: 1,
+			duration: 3,
+		});
+		const earlier = createMediaElement({
+			id: "earlier",
+			startTime: 0,
+			duration: 3,
+		});
+		const track = createTrack({
+			id: "media-track",
+			order: 0,
+			type: "media",
+			elements: [later, earlier],
+		});
+
+		const plan = buildCompositionPlan({
+			tracks: [track],
+			currentTime: 1.5,
+		});
+
+		expect(
+			plan.visualLayers.map(({ element: item, elementOrder }) => ({
+				id: item.id,
+				elementOrder,
+			}))
+		).toEqual([
+			{ id: "later", elementOrder: 0 },
+			{ id: "earlier", elementOrder: 1 },
+		]);
+	});
+
+	it("preserves storage order outside an attached transition window", () => {
 		const outgoing = createMediaElement({
 			id: "outgoing",
 			startTime: 0,
@@ -127,12 +182,60 @@ describe("buildCompositionPlan", () => {
 			order: 0,
 			type: "media",
 			elements: [incoming, outgoing],
+			transitions: [
+				createTransition({
+					fromElementId: outgoing.id,
+					toElementId: incoming.id,
+				}),
+			],
+		});
+
+		const plan = buildCompositionPlan({
+			tracks: [track],
+			currentTime: 0.2,
+			forceActiveElementIds: new Set(["incoming"]),
+		});
+
+		expect(plan.visualLayers.map(({ element: item }) => item.id)).toEqual([
+			"incoming",
+			"outgoing",
+		]);
+	});
+
+	it("groups an active transition at the outgoing clip layer position", () => {
+		const outgoing = createMediaElement({
+			id: "outgoing",
+			startTime: 0,
+			duration: 2,
+		});
+		const incoming = createMediaElement({
+			id: "incoming",
+			startTime: 2,
+			duration: 2,
+		});
+		const ordinaryOverlap = createMediaElement({
+			id: "a-ordinary-overlap",
+			startTime: 0,
+			duration: 5,
+		});
+		const track = createTrack({
+			id: "media-track",
+			order: 0,
+			type: "media",
+			elements: [incoming, outgoing, ordinaryOverlap],
+			transitions: [
+				createTransition({
+					fromElementId: outgoing.id,
+					toElementId: incoming.id,
+				}),
+			],
 		});
 
 		const plan = buildCompositionPlan({
 			tracks: [track],
 			currentTime: 1.8,
 			forceActiveElementIds: new Set(["incoming"]),
+			activeTransitionIds: new Set(["outgoing-incoming"]),
 		});
 
 		expect(
@@ -143,6 +246,7 @@ describe("buildCompositionPlan", () => {
 		).toEqual([
 			{ id: "outgoing", elementOrder: 1 },
 			{ id: "incoming", elementOrder: 0 },
+			{ id: "a-ordinary-overlap", elementOrder: 2 },
 		]);
 	});
 

--- a/qcut/packages/editor-core/src/__tests__/composition-plan.test.ts
+++ b/qcut/packages/editor-core/src/__tests__/composition-plan.test.ts
@@ -110,6 +110,42 @@ describe("buildCompositionPlan", () => {
 			"incoming",
 		]);
 	});
+
+	it("draws the incoming transition clip above the outgoing clip regardless of storage order", () => {
+		const outgoing = createMediaElement({
+			id: "outgoing",
+			startTime: 0,
+			duration: 2,
+		});
+		const incoming = createMediaElement({
+			id: "incoming",
+			startTime: 2,
+			duration: 2,
+		});
+		const track = createTrack({
+			id: "media-track",
+			order: 0,
+			type: "media",
+			elements: [incoming, outgoing],
+		});
+
+		const plan = buildCompositionPlan({
+			tracks: [track],
+			currentTime: 1.8,
+			forceActiveElementIds: new Set(["incoming"]),
+		});
+
+		expect(
+			plan.visualLayers.map(({ element: item, elementOrder }) => ({
+				id: item.id,
+				elementOrder,
+			}))
+		).toEqual([
+			{ id: "outgoing", elementOrder: 1 },
+			{ id: "incoming", elementOrder: 0 },
+		]);
+	});
+
 	it("draws lower UI tracks first and top tracks last", () => {
 		const top = createTrack({
 			id: "top",

--- a/qcut/packages/editor-core/src/__tests__/transition-tuning.test.ts
+++ b/qcut/packages/editor-core/src/__tests__/transition-tuning.test.ts
@@ -114,6 +114,17 @@ describe("transition tuning", () => {
 			intensity: 1,
 			tint: "#ff5a1f",
 		});
+		expect(getClipTransitionTuningControls({ type: "zoom-in-blur" })).toEqual([
+			{
+				defaultValue: 1,
+				kind: "number",
+				label: "拉近强度",
+				max: 2,
+				min: 0.1,
+				property: "intensity",
+				step: 0.05,
+			},
+		]);
 		expect(clipTransitionSupportsDirection({ type: "slide" })).toBe(true);
 		expect(clipTransitionSupportsDirection({ type: "dissolve" })).toBe(false);
 	});

--- a/qcut/packages/editor-core/src/__tests__/transitions.test.ts
+++ b/qcut/packages/editor-core/src/__tests__/transitions.test.ts
@@ -100,7 +100,8 @@ function audioCrossfade({
 
 describe("clip transitions", () => {
 	it("recognizes every persisted transition engine", () => {
-		expect(CLIP_TRANSITION_TYPES).toHaveLength(24);
+		expect(CLIP_TRANSITION_TYPES).toHaveLength(25);
+		expect(CLIP_TRANSITION_TYPES).toContain("zoom-in-blur");
 		for (const type of CLIP_TRANSITION_TYPES) {
 			expect(isClipTransitionType({ value: type })).toBe(true);
 		}

--- a/qcut/packages/editor-core/src/timeline/composition-plan.ts
+++ b/qcut/packages/editor-core/src/timeline/composition-plan.ts
@@ -36,7 +36,13 @@ export interface BuildCompositionPlanOptions {
 	currentTime?: number;
 	includeHidden?: boolean;
 	forceActiveElementIds?: ReadonlySet<string>;
+	activeTransitionIds?: ReadonlySet<string>;
 	getElementDuration?: (context: CompositionDurationContext) => number;
+}
+
+interface IndexedTimelineElement {
+	element: TimelineElement;
+	elementOrder: number;
 }
 
 function isElementActive({
@@ -61,6 +67,52 @@ function isElementActive({
 	);
 }
 
+function groupActiveTransitionElements({
+	track,
+	activeTrackElements,
+	activeTransitionIds,
+}: {
+	track: TimelineTrack;
+	activeTrackElements: IndexedTimelineElement[];
+	activeTransitionIds: ReadonlySet<string> | undefined;
+}): IndexedTimelineElement[] {
+	if (
+		track.type !== "media" ||
+		!track.transitions?.length ||
+		!activeTransitionIds?.size
+	) {
+		return activeTrackElements;
+	}
+
+	const orderedElements = [...activeTrackElements];
+	for (const transition of track.transitions) {
+		if (!activeTransitionIds.has(transition.id)) continue;
+
+		const outgoingIndex = orderedElements.findIndex(
+			({ element }) => element.id === transition.fromElementId
+		);
+		const incomingIndex = orderedElements.findIndex(
+			({ element }) => element.id === transition.toElementId
+		);
+		if (
+			outgoingIndex < 0 ||
+			incomingIndex < 0 ||
+			incomingIndex === outgoingIndex + 1
+		) {
+			continue;
+		}
+
+		// Native export anchors the combined transition run at the outgoing layer.
+		const [incoming] = orderedElements.splice(incomingIndex, 1);
+		const updatedOutgoingIndex = orderedElements.findIndex(
+			({ element }) => element.id === transition.fromElementId
+		);
+		orderedElements.splice(updatedOutgoingIndex + 1, 0, incoming);
+	}
+
+	return orderedElements;
+}
+
 /**
  * Build the canonical layer plan shared by preview and export renderers.
  * UI order is top-to-bottom; visual draw order is deliberately reversed.
@@ -70,6 +122,7 @@ export function buildCompositionPlan({
 	currentTime,
 	includeHidden = false,
 	forceActiveElementIds,
+	activeTransitionIds,
 	getElementDuration = ({ element }) => getEffectiveDuration(element),
 }: BuildCompositionPlanOptions): CompositionPlan {
 	const orderedTracks = normalizeTrackOrder({ tracks });
@@ -116,23 +169,22 @@ export function buildCompositionPlan({
 		const trackOrder = orderedTracks.findIndex(
 			(candidate) => candidate.id === track.id
 		);
-		const activeTrackElements = track.elements
-			.map((element, elementOrder) => ({ element, elementOrder }))
-			.filter(({ element }) => {
-				if (!includeHidden && element.hidden) return false;
-				return isElementActive({
-					element,
-					track,
-					currentTime,
-					getElementDuration,
-					forceActiveElementIds,
-				});
-			})
-			.sort(
-				(a, b) =>
-					a.element.startTime - b.element.startTime ||
-					a.elementOrder - b.elementOrder
-			);
+		const activeTrackElements = groupActiveTransitionElements({
+			track,
+			activeTransitionIds,
+			activeTrackElements: track.elements
+				.map((element, elementOrder) => ({ element, elementOrder }))
+				.filter(({ element }) => {
+					if (!includeHidden && element.hidden) return false;
+					return isElementActive({
+						element,
+						track,
+						currentTime,
+						getElementDuration,
+						forceActiveElementIds,
+					});
+				}),
+		});
 
 		for (const { element, elementOrder } of activeTrackElements) {
 			visualLayers.push({

--- a/qcut/packages/editor-core/src/timeline/composition-plan.ts
+++ b/qcut/packages/editor-core/src/timeline/composition-plan.ts
@@ -116,26 +116,25 @@ export function buildCompositionPlan({
 		const trackOrder = orderedTracks.findIndex(
 			(candidate) => candidate.id === track.id
 		);
-
-		for (
-			let elementOrder = 0;
-			elementOrder < track.elements.length;
-			elementOrder++
-		) {
-			const element = track.elements[elementOrder];
-			if (!includeHidden && element.hidden) continue;
-			if (
-				!isElementActive({
+		const activeTrackElements = track.elements
+			.map((element, elementOrder) => ({ element, elementOrder }))
+			.filter(({ element }) => {
+				if (!includeHidden && element.hidden) return false;
+				return isElementActive({
 					element,
 					track,
 					currentTime,
 					getElementDuration,
 					forceActiveElementIds,
-				})
-			) {
-				continue;
-			}
+				});
+			})
+			.sort(
+				(a, b) =>
+					a.element.startTime - b.element.startTime ||
+					a.elementOrder - b.elementOrder
+			);
 
+		for (const { element, elementOrder } of activeTrackElements) {
 			visualLayers.push({
 				track,
 				element,

--- a/qcut/packages/editor-core/src/timeline/transition-presentation.ts
+++ b/qcut/packages/editor-core/src/timeline/transition-presentation.ts
@@ -128,6 +128,18 @@ function stackedLayerOpacity({
 	return role === "from" ? 1 : progress;
 }
 
+function pageFlipOpacity({
+	role,
+	progress,
+}: {
+	role: ClipTransitionRole;
+	progress: number;
+}): number {
+	if (role === "from" && progress >= 0.999) return 0;
+	if (role === "to" && progress <= 0.001) return 0;
+	return 1;
+}
+
 function maskVisibility({
 	role,
 	progress,
@@ -796,8 +808,7 @@ export function getClipTransitionLayerPresentation({
 					role,
 					progress: eased,
 				}),
-				opacity:
-					role === "from" ? (eased >= 0.999 ? 0 : 1) : eased <= 0.001 ? 0 : 1,
+				opacity: pageFlipOpacity({ role, progress: eased }),
 				brightness: 1 - peak * 0.28 * tuning.intensity,
 				overlayBackground:
 					"linear-gradient(90deg, rgba(0,0,0,0.5), transparent 18%, transparent 82%, rgba(255,255,255,0.28))",

--- a/qcut/packages/editor-core/src/timeline/transition-presentation.ts
+++ b/qcut/packages/editor-core/src/timeline/transition-presentation.ts
@@ -118,14 +118,14 @@ function enteringOffset({
 	}
 }
 
-function crossfadeOpacity({
+function stackedLayerOpacity({
 	role,
 	progress,
 }: {
 	role: ClipTransitionRole;
 	progress: number;
 }): number {
-	return role === "from" ? 1 - progress : progress;
+	return role === "from" ? 1 : progress;
 }
 
 function maskVisibility({
@@ -168,7 +168,7 @@ function hash01(seed: number): number {
 }
 
 const HEART_MASK_SVG = encodeURIComponent(
-	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="#000" d="M16 29C7 21.5 2 16.5 2 10.6 2 6.4 5.4 3 9.6 3c2.6 0 5 1.3 6.4 3.4C17.4 4.3 19.8 3 22.4 3 26.6 3 30 6.4 30 10.6 30 16.5 25 21.5 16 29z"/></svg>'
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 36 36"><defs><filter id="soft" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation=".65"/></filter></defs><path fill="#000" filter="url(#soft)" d="M16 29C7 21.5 2 16.5 2 10.6 2 6.4 5.4 3 9.6 3c2.6 0 5 1.3 6.4 3.4C17.4 4.3 19.8 3 22.4 3 26.6 3 30 6.4 30 10.6 30 16.5 25 21.5 16 29z"/></svg>'
 );
 
 const STAR_MASK_SVG = encodeURIComponent(
@@ -206,8 +206,25 @@ function noiseBlobMask({
 
 type ShapeMaskPresentation = Partial<ClipTransitionLayerPresentation>;
 
-function circleMask({ progress }: { progress: number }): ShapeMaskPresentation {
-	return { clipPath: `circle(${(progress * 75).toFixed(2)}% at 50% 50%)` };
+function circleMask({
+	progress,
+	canvasWidth,
+	canvasHeight,
+}: {
+	progress: number;
+	canvasWidth: number;
+	canvasHeight: number;
+}): ShapeMaskPresentation {
+	const maximumRadius = Math.hypot(canvasWidth, canvasHeight) / 2;
+	const featherRadius = maximumRadius * 0.03;
+	const radius = progress * 1.06 * maximumRadius;
+	const solidRadius = Math.max(0, radius - featherRadius);
+	const outerRadius = radius + featherRadius;
+	return {
+		maskImage: `radial-gradient(circle at 50% 50%, #000 0 ${solidRadius.toFixed(2)}px, rgba(0,0,0,0.5) ${radius.toFixed(2)}px, transparent ${outerRadius.toFixed(2)}px)`,
+		maskSize: "100% 100%",
+		maskRepeat: "no-repeat",
+	};
 }
 
 function clockMask({ progress }: { progress: number }): ShapeMaskPresentation {
@@ -266,13 +283,18 @@ function arrowMask({ progress }: { progress: number }): ShapeMaskPresentation {
 function svgMask({
 	svg,
 	progress,
+	scaleByHeight = false,
 }: {
 	svg: string;
 	progress: number;
+	scaleByHeight?: boolean;
 }): ShapeMaskPresentation {
+	const heightScale = progress * 200 + progress ** 8 * 300;
 	return {
 		maskImage: `url("data:image/svg+xml,${svg}")`,
-		maskSize: `${(progress * 260).toFixed(1)}%`,
+		maskSize: scaleByHeight
+			? `auto ${heightScale.toFixed(1)}%`
+			: `${(progress * 260).toFixed(1)}%`,
 		maskPosition: "center",
 		maskRepeat: "no-repeat",
 	};
@@ -345,15 +367,19 @@ function shapeMask({
 	shape,
 	role,
 	progress,
+	canvasWidth,
+	canvasHeight,
 }: {
 	shape: NonNullable<ClipTransition["maskShape"]>;
 	role: ClipTransitionRole;
 	progress: number;
+	canvasWidth: number;
+	canvasHeight: number;
 }): ShapeMaskPresentation {
 	if (role === "from") return {};
 	switch (shape) {
 		case "circle":
-			return circleMask({ progress });
+			return circleMask({ progress, canvasWidth, canvasHeight });
 		case "clock":
 			return clockMask({ progress });
 		case "blinds":
@@ -365,7 +391,7 @@ function shapeMask({
 		case "arrow":
 			return arrowMask({ progress });
 		case "heart":
-			return svgMask({ svg: HEART_MASK_SVG, progress });
+			return svgMask({ svg: HEART_MASK_SVG, progress, scaleByHeight: true });
 		case "star":
 			return svgMask({ svg: STAR_MASK_SVG, progress });
 		case "ink":
@@ -479,7 +505,10 @@ export function getClipTransitionLayerPresentation({
 
 	switch (transition.type) {
 		case "dissolve":
-			return { ...base, opacity: role === "from" ? 1 - eased : eased };
+			return {
+				...base,
+				opacity: stackedLayerOpacity({ role, progress: eased }),
+			};
 		case "fade-black":
 			return role === "from"
 				? {
@@ -545,9 +574,22 @@ export function getClipTransitionLayerPresentation({
 			const peak = transitionPeak({ progress: eased });
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				scale: 1 + peak * 0.18 * tuning.intensity,
 				blur: peak * 12 * tuning.intensity,
+			};
+		}
+		case "zoom-in-blur": {
+			const peak = transitionPeak({ progress: eased });
+			const zoomAmount = 0.12 * tuning.intensity;
+			return {
+				...base,
+				opacity: stackedLayerOpacity({ role, progress: eased }),
+				scale:
+					role === "from"
+						? 1 + zoomAmount * eased
+						: 1 - zoomAmount * (1 - eased),
+				blur: peak * 8 * tuning.intensity,
 			};
 		}
 		case "whip-pan": {
@@ -582,7 +624,7 @@ export function getClipTransitionLayerPresentation({
 			const peak = transitionPeak({ progress: eased });
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				contentOpacity: Math.max(0, 1 - peak * 0.55 * tuning.intensity),
 				backgroundColor: tuning.tint ?? "#ffffff",
 				brightness: 1 + peak * 2.2 * tuning.intensity,
@@ -593,7 +635,7 @@ export function getClipTransitionLayerPresentation({
 			const peak = transitionPeak({ progress: eased });
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				contentOpacity: Math.max(0, 1 - peak * 0.3 * tuning.intensity),
 				backgroundColor: tuning.tint ?? "#ff5a1f",
 				brightness: 1 + peak * 0.65 * tuning.intensity,
@@ -607,7 +649,7 @@ export function getClipTransitionLayerPresentation({
 			const roleSign = role === "from" ? -1 : 1;
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				offsetX: normalizedOffset({
 					value:
 						roleSign *
@@ -635,7 +677,7 @@ export function getClipTransitionLayerPresentation({
 			const peak = transitionPeak({ progress: eased });
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				offsetX: normalizedOffset({
 					value:
 						Math.sin(eased * Math.PI * 16 * tuning.frequency) *
@@ -671,7 +713,7 @@ export function getClipTransitionLayerPresentation({
 			const roleSign = role === "from" ? -1 : 1;
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				offsetX: normalizedOffset({ value: offset.offsetX * roleSign }),
 				offsetY: normalizedOffset({ value: offset.offsetY * roleSign }),
 				blur: peak * 18 * tuning.intensity,
@@ -682,7 +724,7 @@ export function getClipTransitionLayerPresentation({
 			const peak = transitionPeak({ progress: eased });
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				pixelScale: 1 + Math.round(peak * 22 * tuning.intensity),
 				saturation: 1 + peak * 0.15 * tuning.intensity,
 			};
@@ -695,7 +737,7 @@ export function getClipTransitionLayerPresentation({
 				tuning.intensity;
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				scale: 1 + wave * 0.018,
 				rotation: wave * (role === "from" ? -0.45 : 0.45),
 				blur: peak * 1.5 * tuning.intensity,
@@ -726,7 +768,7 @@ export function getClipTransitionLayerPresentation({
 				transition.direction === "up" || transition.direction === "down";
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				offsetX: vertical
 					? 0
 					: roleSign * peak * canvasWidth * 0.018 * tuning.intensity,
@@ -754,7 +796,8 @@ export function getClipTransitionLayerPresentation({
 					role,
 					progress: eased,
 				}),
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity:
+					role === "from" ? (eased >= 0.999 ? 0 : 1) : eased <= 0.001 ? 0 : 1,
 				brightness: 1 - peak * 0.28 * tuning.intensity,
 				overlayBackground:
 					"linear-gradient(90deg, rgba(0,0,0,0.5), transparent 18%, transparent 82%, rgba(255,255,255,0.28))",
@@ -786,6 +829,8 @@ export function getClipTransitionLayerPresentation({
 						shape: transition.maskShape,
 						role,
 						progress: eased,
+						canvasWidth,
+						canvasHeight,
 					}),
 					opacity: 1,
 					contentOpacity: 1,
@@ -850,7 +895,7 @@ export function getClipTransitionLayerPresentation({
 			const spin = 160 * tuning.intensity;
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				rotation: role === "from" ? eased * spin : -(1 - eased) * spin,
 				scale: 1 + peak * 0.24 * tuning.intensity,
 				blur: peak * 7 * tuning.intensity,
@@ -862,7 +907,7 @@ export function getClipTransitionLayerPresentation({
 			const ring = Math.min(100, eased * 130);
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				scale: 1 + peak * 0.1 * tuning.intensity,
 				blur: peak * 3 * tuning.intensity,
 				brightness: 1 + peak * 0.2 * tuning.intensity,
@@ -878,7 +923,7 @@ export function getClipTransitionLayerPresentation({
 			const tint = tuning.tint ?? "#ffd6a1";
 			return {
 				...base,
-				opacity: crossfadeOpacity({ role, progress: eased }),
+				opacity: stackedLayerOpacity({ role, progress: eased }),
 				brightness: 1 + peak * 0.85 * tuning.intensity,
 				saturation: 1 + peak * 0.35,
 				overlayBackground: `radial-gradient(circle at ${flareX.toFixed(2)}% ${flareY.toFixed(2)}%, ${tint} 0, rgba(255,255,255,0.72) 8%, transparent 34%), linear-gradient(${(eased * 18 - 9).toFixed(2)}deg, transparent 42%, ${tint} 49%, transparent 56%)`,

--- a/qcut/packages/editor-core/src/timeline/transition-tuning.ts
+++ b/qcut/packages/editor-core/src/timeline/transition-tuning.ts
@@ -45,6 +45,7 @@ const TUNING_CONTROLS: Partial<
 	Record<ClipTransitionType, ClipTransitionTuningControl[]>
 > = {
 	"zoom-blur": [{ ...INTENSITY_CONTROL, label: "模糊强度" }],
+	"zoom-in-blur": [{ ...INTENSITY_CONTROL, label: "拉近强度" }],
 	"whip-pan": [{ ...INTENSITY_CONTROL, label: "甩镜强度" }],
 	flash: [
 		{ ...INTENSITY_CONTROL, label: "闪光强度" },

--- a/qcut/packages/editor-core/src/timeline/transitions.ts
+++ b/qcut/packages/editor-core/src/timeline/transitions.ts
@@ -74,6 +74,7 @@ export const CLIP_TRANSITION_TYPES = [
 	"wipe",
 	"push",
 	"zoom-blur",
+	"zoom-in-blur",
 	"whip-pan",
 	"flash",
 	"light-leak",

--- a/qcut/packages/editor-core/src/types/timeline.ts
+++ b/qcut/packages/editor-core/src/types/timeline.ts
@@ -182,6 +182,7 @@ export type ClipTransitionType =
 	| "wipe"
 	| "push"
 	| "zoom-blur"
+	| "zoom-in-blur"
 	| "whip-pan"
 	| "flash"
 	| "light-leak"


### PR DESCRIPTION
## What changed

- Adds an exact ten-transition parity manifest and searchable QCut presets for 叠化、叠化拉近、翻页、立方旋转、左移、右移、推镜虚化、横移模糊、圆形遮罩 II、心形叠化.
- Aligns browser preview and FFmpeg export semantics for stacked alpha, zoom, page flip, motion blur, circle masks, and heart masks.
- Stabilizes visual layer ordering so an active transition keeps the incoming clip above the outgoing clip without changing ordinary overlap ordering.
- Removes stateful FFmpeg expressions so default, single-thread, and multi-thread rendering produce identical bytes.
- Reuses the multi-graph filter-script infrastructure from #360 and hardens temporary-file cleanup and child-process shutdown, especially for Windows file locking.

## Why

The selected QCut transitions were visually and behaviorally inconsistent with their Jianying references. The main gaps were mismatched preview/export geometry, stacked-opacity darkening, reversed transition composition, mask scaling, motion-blur direction, thread-sensitive expressions, and long FFmpeg command lines on Windows.

## Impact

Users can search the ten Jianying names directly, preview the intended motion in QCut, and export the same transition semantics across macOS, Windows, and Linux. Large transition compositions use the existing `filter_complex_script` path rather than risking the Windows command-line limit.

## Validation

- 233 focused Vitest tests passed across Web, Editor Core, and Electron.
- All workspace TypeScript checks passed.
- Biome passed for all 33 changed files.
- Real transition renders passed with the staged FFmpeg 8.1.2 binary.
- Default-thread, single-thread, and multi-thread renders were byte-identical.
- Inline and `filter_complex_script` execution were byte-identical for the audited transition.
- The branch is rebased onto the current `master`; the 18 commits contain only the 33 transition-related files.

