### PR TITLE
feat(stickers): ship the sticker lab in released builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,10 @@ jobs:
         env:
           # vite build exceeds Node's default ~2GB heap on the macOS runner
           NODE_OPTIONS: --max-old-space-size=4096
+          # Ships the sticker lab. Everyone can browse the previews; the
+          # full-resolution originals stay behind the license server's
+          # allow list.
+          VITE_QCUT_ENABLE_STICKER_LAB: "true"
 
       - name: Build Electron scripts
         run: bun run build:electron
@@ -173,6 +177,10 @@ jobs:
         env:
           # vite build exceeds Node's default ~2GB heap on the macOS runner
           NODE_OPTIONS: --max-old-space-size=4096
+          # Ships the sticker lab. Everyone can browse the previews; the
+          # full-resolution originals stay behind the license server's
+          # allow list.
+          VITE_QCUT_ENABLE_STICKER_LAB: "true"
 
       - name: Build Electron scripts
         run: bun run build:electron
@@ -268,6 +276,10 @@ jobs:
         env:
           # vite build exceeds Node's default ~2GB heap on the macOS runner
           NODE_OPTIONS: --max-old-space-size=4096
+          # Ships the sticker lab. Everyone can browse the previews; the
+          # full-resolution originals stay behind the license server's
+          # allow list.
+          VITE_QCUT_ENABLE_STICKER_LAB: "true"
 
       - name: Build Electron scripts
         run: bun run build:electron

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
@@ -477,4 +477,32 @@ describe("LocalStickerReferencePanel", () => {
 			signal: expect.any(AbortSignal),
 		});
 	});
+
+	it("reads a missing entitlement as locked rather than broken", async () => {
+		// This is the default path for every user outside the allow list, so it
+		// must not look like a failure.
+		referenceMocks.loadFile.mockRejectedValue(
+			new Error("Asset request failed: 403")
+		);
+		const catalog = createRemoteStickerCatalog();
+		render(
+			<LocalStickerReferencePanel
+				catalog={catalog}
+				error={null}
+				isLoading={false}
+				onSelect={async () => {}}
+			/>
+		);
+
+		const button = screen.getByRole("button", {
+			name: "添加贴纸 popular-1到时间线",
+		});
+		await waitFor(() => expect(button).toBeEnabled());
+		fireEvent.click(button);
+
+		await waitFor(() =>
+			expect(screen.getByText("仅限内测账号使用")).toBeInTheDocument()
+		);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
 });

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, ImageIcon, Loader2, Play } from "lucide-react";
+import { AlertCircle, ImageIcon, Loader2, Lock, Play } from "lucide-react";
 import {
 	useEffect,
 	useRef,
@@ -87,6 +87,9 @@ function LocalStickerReferenceItem({
 	const [isAdding, setIsAdding] = useState(false);
 	const [loadAttempt, setLoadAttempt] = useState(0);
 	const [selectError, setSelectError] = useState<string | null>(null);
+	// Not an error: the lab ships to everyone, but placing an original needs
+	// an entitlement most viewers do not have.
+	const [isLocked, setIsLocked] = useState(false);
 	const referenceKey = getReferenceKey({ reference });
 	const loadKey = `${referenceKey}\0${loadAttempt}`;
 	const activeLoaded = loaded?.loadKey === loadKey ? loaded : null;
@@ -99,6 +102,7 @@ function LocalStickerReferenceItem({
 		setLoaded(null);
 		setHasError(false);
 		setSelectError(null);
+		setIsLocked(false);
 
 		const loadPreview = async () => {
 			try {
@@ -150,11 +154,11 @@ function LocalStickerReferenceItem({
 			await onSelect({ file });
 		} catch (error) {
 			debugError("[StickerLab] Failed to add local reference", error);
-			setSelectError(
-				isForbiddenError({ error })
-					? "该实验素材未对当前账号开放"
-					: "无法添加到时间线，请重试"
-			);
+			if (isForbiddenError({ error })) {
+				setIsLocked(true);
+				return;
+			}
+			setSelectError("无法添加到时间线，请重试");
 		} finally {
 			setIsAdding(false);
 		}
@@ -257,6 +261,12 @@ function LocalStickerReferenceItem({
 						重试
 					</button>
 				</div>
+			)}
+			{isLocked && (
+				<p className="flex items-center gap-1 text-[9px] text-muted-foreground">
+					<Lock className="size-2.5" />
+					仅限内测账号使用
+				</p>
 			)}
 			{selectError && (
 				<p className="text-[9px] text-destructive" role="alert">


### PR DESCRIPTION
## Description

Turns the sticker lab on in packaged builds and makes the locked state read as a product state rather than a failure.

Until now the lab was compiled out of every release: `VITE_QCUT_ENABLE_STICKER_LAB` was read in `local-sticker-lab-config.ts` but set nowhere, so `getLocalStickerLabSource()` returned `null` and the sidebar entry never rendered. This adds the flag to all three platform builds in `release.yml`.

## Why the copy changed too

With the lab shipping to everyone, the allow-list path stops being an edge case — it becomes the default for almost every user. A red `role="alert"` reading "该实验素材未对当前账号开放" made that normal state look like a bug, so a 403 now renders as a muted lock line instead:

> 🔒 仅限内测账号使用

Genuine failures still surface as an alert.

## Access model (already deployed)

| | previews | full-resolution original |
|---|---|---|
| any signed-in user | ✅ | ❌ 403 |
| allow-listed accounts | ✅ | ✅ |

The license server was deployed separately (version `c5954581-3bf6-422c-a12e-99d6556aaa76`); `/api/sticker-lab/thumbnail` and `/assets` both answer `401` unauthenticated, and `/health` plus `/api/license/verify` are unchanged.

## Verification

- `bun check-types` — 0 errors
- 191 tests passing across the stickers panel and `apps/web/src/lib/stickers`
- New test asserts a 403 renders the lock line and **not** an alert

## Note

This is the first release where users other than the allow-listed accounts will see the lab. They can browse all 420 previews; placing one shows the lock line.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled Sticker Lab previews across Windows, macOS, and Linux web builds.
  - Added clearer access messaging when full-resolution stickers are restricted.

- **Bug Fixes**
  - Restricted sticker downloads now display a lock indicator and entitlement message instead of triggering an alert.
  - Sticker access status resets correctly when content is reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->