### PR TITLE
feat(stickers): serve the private jianying reference catalog to allow-listed users

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
@@ -58,7 +58,7 @@ function installTimelineState({
 		},
 	];
 	const pushHistory = vi.fn();
-	const addTrack = vi.fn(() => "adjustment-track");
+	const insertTrackAt = vi.fn(() => "adjustment-track");
 	const getTotalDuration = vi.fn(() => 12);
 	const addElementToTrack = vi.fn(() => "adjustment-2");
 	const updateAdjustmentElement = vi.fn();
@@ -69,7 +69,7 @@ function installTimelineState({
 			? [{ trackId: "adjustment-track", elementId: "adjustment-1" }]
 			: [],
 		pushHistory,
-		addTrack: addTrack as TimelineStore["addTrack"],
+		insertTrackAt: insertTrackAt as TimelineStore["insertTrackAt"],
 		getTotalDuration: getTotalDuration as TimelineStore["getTotalDuration"],
 		addElementToTrack:
 			addElementToTrack as unknown as TimelineStore["addElementToTrack"],
@@ -77,7 +77,12 @@ function installTimelineState({
 			updateAdjustmentElement as unknown as TimelineStore["updateAdjustmentElement"],
 	});
 	usePlaybackStore.setState({ currentTime: 2 });
-	return { addTrack, addElementToTrack, pushHistory, updateAdjustmentElement };
+	return {
+		insertTrackAt,
+		addElementToTrack,
+		pushHistory,
+		updateAdjustmentElement,
+	};
 }
 
 const cubeLut = [
@@ -117,7 +122,8 @@ describe("AdjustmentsView", () => {
 
 		fireEvent.click(screen.getByText("新建调节"));
 
-		expect(timeline.addTrack).toHaveBeenCalledWith("adjustment");
+		// Above the topmost media track (index 1 in the fixture), never appended.
+		expect(timeline.insertTrackAt).toHaveBeenCalledWith("adjustment", 1);
 		expect(timeline.addElementToTrack).toHaveBeenCalledWith(
 			"adjustment-track",
 			expect.objectContaining({

--- a/qcut/apps/web/src/components/editor/media-panel/views/adjustments.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/adjustments.tsx
@@ -57,7 +57,7 @@ export function AdjustmentsView() {
 	const [activeShelf, setActiveShelf] = useState<AdjustmentShelf>("mine");
 	const selectedElements = useTimelineStore((state) => state.selectedElements);
 	const tracks = useTimelineStore((state) => state.tracks);
-	const addTrack = useTimelineStore((state) => state.addTrack);
+	const insertTrackAt = useTimelineStore((state) => state.insertTrackAt);
 	const addElementToTrack = useTimelineStore(
 		(state) => state.addElementToTrack
 	);
@@ -77,7 +77,7 @@ export function AdjustmentsView() {
 		name?: string;
 	} = {}) => {
 		const created = addAdjustmentLayer({
-			timeline: { addTrack, addElementToTrack, getTotalDuration },
+			timeline: { tracks, insertTrackAt, addElementToTrack, getTotalDuration },
 			currentTime,
 			name,
 		});

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
@@ -8,6 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createLocalStickerCatalog,
+	createPrivateStickerCatalog,
 	createRemoteStickerCatalog,
 } from "@/lib/stickers/__tests__/fixtures/local-sticker-catalog";
 import { LocalStickerReferencePanel } from "../components/local-sticker-reference-panel";
@@ -504,5 +505,63 @@ describe("LocalStickerReferencePanel", () => {
 			expect(screen.getByText("仅限内测账号使用")).toBeInTheDocument()
 		);
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("renders the private catalogue even while the public manifest fails", async () => {
+		render(
+			<LocalStickerReferencePanel
+				catalog={null}
+				error="Invalid local sticker manifest"
+				isLoading={false}
+				onSelect={async () => {}}
+				privateCatalog={createPrivateStickerCatalog()}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId("sticker-lab-catalog-private"));
+
+		await waitFor(() =>
+			expect(
+				screen.getByTestId("local-sticker-category-grid")
+			).toBeInTheDocument()
+		);
+		// The public catalog's failure must not mask the private view.
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(screen.getAllByTestId("local-sticker-reference-item")).toHaveLength(
+			2
+		);
+	});
+
+	it("previews private references through the cached original loader", async () => {
+		render(
+			<LocalStickerReferencePanel
+				catalog={createRemoteStickerCatalog()}
+				error={null}
+				isLoading={false}
+				onSelect={async () => {}}
+				privateCatalog={createPrivateStickerCatalog()}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId("sticker-lab-catalog-private"));
+		await waitFor(() =>
+			expect(referenceMocks.loadFile).toHaveBeenCalledTimes(2)
+		);
+
+		// Private previews go through the IndexedDB-cached original loader —
+		// the uncached thumbnail tier would re-download megabytes of GIF on
+		// every category switch. (The public tab rendered first and may use
+		// thumbnails freely; none of those calls may carry a private key.)
+		for (const call of referenceMocks.loadThumbnail.mock.calls) {
+			expect(call[0].reference.asset.objectKey).not.toMatch(/^jianying\//);
+		}
+		expect(referenceMocks.loadFile).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provenance: expect.objectContaining({
+					creator: "Jianying (harvested reference)",
+					license: expect.objectContaining({ commercialUse: "restricted" }),
+				}),
+			})
+		);
 	});
 });

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/use-local-sticker-catalog.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/use-local-sticker-catalog.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createLocalStickerCatalog,
+	createPrivateStickerCatalog,
 	createRemoteStickerCatalog,
 } from "@/lib/stickers/__tests__/fixtures/local-sticker-catalog";
 import type { LocalStickerLabSource } from "@/lib/stickers/local-sticker-lab-config";
@@ -10,6 +11,7 @@ import { useLocalStickerCatalog } from "../hooks/use-local-sticker-catalog";
 const catalogMocks = vi.hoisted(() => ({
 	getSource: vi.fn<() => LocalStickerLabSource | null>(),
 	loadManifest: vi.fn(),
+	loadPrivateManifest: vi.fn(),
 	loadRemoteManifest: vi.fn(),
 }));
 
@@ -32,6 +34,7 @@ vi.mock("@/lib/stickers/local-sticker-manifest", async (importOriginal) => {
 	return {
 		...actual,
 		loadLocalStickerManifest: catalogMocks.loadManifest,
+		loadPrivateStickerManifest: catalogMocks.loadPrivateManifest,
 		loadRemoteStickerManifest: catalogMocks.loadRemoteManifest,
 	};
 });
@@ -40,7 +43,12 @@ describe("useLocalStickerCatalog", () => {
 	beforeEach(() => {
 		catalogMocks.getSource.mockReset();
 		catalogMocks.loadManifest.mockReset();
+		catalogMocks.loadPrivateManifest.mockReset();
 		catalogMocks.loadRemoteManifest.mockReset();
+		// Default: the viewer is not on the allow list.
+		catalogMocks.loadPrivateManifest.mockRejectedValue(
+			new Error("Unable to fetch sticker lab manifest (403)")
+		);
 	});
 
 	it("stays unavailable when the local lab is not configured", () => {
@@ -53,7 +61,9 @@ describe("useLocalStickerCatalog", () => {
 			error: null,
 			isAvailable: false,
 			isLoading: false,
+			privateCatalog: null,
 		});
+		expect(catalogMocks.loadPrivateManifest).not.toHaveBeenCalled();
 		expect(catalogMocks.loadManifest).not.toHaveBeenCalled();
 	});
 
@@ -130,7 +140,50 @@ describe("useLocalStickerCatalog", () => {
 			error: "Invalid local sticker manifest",
 			isAvailable: true,
 			isLoading: false,
+			privateCatalog: null,
 		});
+	});
+
+	it("loads the private reference catalog for entitled users", async () => {
+		const catalog = createLocalStickerCatalog();
+		const privateCatalog = createPrivateStickerCatalog();
+		catalogMocks.getSource.mockReturnValue({
+			kind: "manifest",
+			manifestPath: "/tmp/sticker-manifest.json",
+		});
+		catalogMocks.loadManifest.mockResolvedValue(catalog);
+		catalogMocks.loadPrivateManifest.mockResolvedValue(privateCatalog);
+
+		const { result } = renderHook(() => useLocalStickerCatalog());
+
+		await waitFor(() =>
+			expect(result.current.privateCatalog).toEqual(privateCatalog)
+		);
+		expect(result.current.catalog).toEqual(catalog);
+		expect(catalogMocks.loadPrivateManifest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				manifestUrl: expect.stringContaining(
+					"/api/sticker-lab/private-manifest"
+				),
+				signal: expect.any(AbortSignal),
+			})
+		);
+	});
+
+	it("keeps the private catalog null when the server denies access", async () => {
+		const catalog = createLocalStickerCatalog();
+		catalogMocks.getSource.mockReturnValue({
+			kind: "manifest",
+			manifestPath: "/tmp/sticker-manifest.json",
+		});
+		catalogMocks.loadManifest.mockResolvedValue(catalog);
+
+		const { result } = renderHook(() => useLocalStickerCatalog());
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.privateCatalog).toBeNull();
+		// A 403 on the private tier is not an error state for the lab.
+		expect(result.current.error).toBeNull();
 	});
 
 	it("hydrates the legacy single-file source without reading a manifest", async () => {

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
@@ -11,12 +11,15 @@ import { debugError } from "@/lib/debug/debug-config";
 import {
 	loadStickerLabReferenceFile,
 	loadStickerLabThumbnail,
+	PRIVATE_REFERENCE_PROVENANCE,
 	type StickerLabReference,
 } from "@/lib/stickers/local-sticker-reference";
-import type {
-	LocalStickerPlayback,
-	RemoteStickerProvenance,
-	StickerLabCatalog,
+import {
+	isRemoteStickerCatalog,
+	type LocalStickerPlayback,
+	type PrivateStickerCatalog,
+	type RemoteStickerProvenance,
+	type StickerLabCatalog,
 } from "@/lib/stickers/local-sticker-manifest";
 import { cn } from "@/lib/utils";
 
@@ -282,21 +285,46 @@ export function LocalStickerReferencePanel({
 	error,
 	isLoading,
 	onSelect,
+	privateCatalog = null,
 }: {
 	catalog: StickerLabCatalog | null;
 	error: string | null;
 	isLoading: boolean;
 	onSelect: ({ file }: { file: File }) => Promise<void>;
+	privateCatalog?: PrivateStickerCatalog | null;
 }) {
 	const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
 		null
 	);
+	const [activeCatalogKey, setActiveCatalogKey] = useState<
+		"public" | "private"
+	>("public");
 	const categoryTabRefs = useRef(new Map<string, HTMLButtonElement>());
-	const categories = catalog?.categories ?? [];
-	const provenance = catalog?.version === 2 ? catalog.provenance : undefined;
+	const activeCatalog =
+		activeCatalogKey === "private" && privateCatalog ? privateCatalog : catalog;
+	const categories = activeCatalog?.categories ?? [];
+	// Check the public catalogue first: its shape is a superset of the private
+	// one, so the negated private guard would (structurally) swallow it.
+	const provenance = activeCatalog
+		? isRemoteStickerCatalog(activeCatalog)
+			? activeCatalog.provenance
+			: activeCatalog.version === 2
+				? PRIVATE_REFERENCE_PROVENANCE
+				: undefined
+		: undefined;
 	const selectedCategory =
 		categories.find((category) => category.id === selectedCategoryId) ??
 		categories[0];
+
+	const switchCatalog = ({
+		catalogKey,
+	}: {
+		catalogKey: "public" | "private";
+	}) => {
+		if (catalogKey === activeCatalogKey) return;
+		setActiveCatalogKey(catalogKey);
+		setSelectedCategoryId(null);
+	};
 
 	const selectAndFocusCategory = ({
 		categoryIndex,
@@ -345,6 +373,44 @@ export function LocalStickerReferencePanel({
 				<p className="mt-0.5 text-[10px] leading-4 text-muted-foreground">
 					实验素材按需载入，不随 QCut 安装包分发
 				</p>
+				{privateCatalog ? (
+					<div
+						className="mt-1.5 flex gap-1"
+						role="tablist"
+						aria-label="贴纸实验室目录"
+					>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={activeCatalogKey === "public"}
+							data-testid="sticker-lab-catalog-public"
+							className={cn(
+								"rounded-full px-2 py-0.5 text-[10px] transition-colors",
+								activeCatalogKey === "public"
+									? "bg-primary/15 font-medium text-primary"
+									: "bg-foreground/5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+							)}
+							onClick={() => switchCatalog({ catalogKey: "public" })}
+						>
+							QCut 原创
+						</button>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={activeCatalogKey === "private"}
+							data-testid="sticker-lab-catalog-private"
+							className={cn(
+								"rounded-full px-2 py-0.5 text-[10px] transition-colors",
+								activeCatalogKey === "private"
+									? "bg-primary/15 font-medium text-primary"
+									: "bg-foreground/5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+							)}
+							onClick={() => switchCatalog({ catalogKey: "private" })}
+						>
+							剪映参照 · 内部
+						</button>
+					</div>
+				) : null}
 			</div>
 
 			{isLoading ? (

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
@@ -109,21 +109,26 @@ function LocalStickerReferenceItem({
 
 		const loadPreview = async () => {
 			try {
-				// Browsing only needs the preview tier, which every signed-in
-				// user may sign. The full-resolution file is fetched when the
-				// sticker is actually placed, so a viewer without the lab
-				// entitlement still sees the catalogue instead of error tiles.
-				const blob =
-					"filePath" in reference
-						? await loadStickerLabReferenceFile({
-								provenance,
-								reference,
-								signal: abortController.signal,
-							})
-						: await loadStickerLabThumbnail({
-								reference,
-								signal: abortController.signal,
-							});
+				// Public references browse via the preview tier, which every
+				// signed-in user may sign; the full-resolution file is fetched
+				// when the sticker is placed, so a viewer without the lab
+				// entitlement sees the catalogue instead of error tiles.
+				// Private references have no un-entitled viewers and their
+				// "thumbnail" is the original GIF anyway, so they go through
+				// the cached loader — otherwise every category switch would
+				// re-download megabytes of animation.
+				const usesUncachedThumbnail =
+					!("filePath" in reference) && "sourceAsset" in reference;
+				const blob = usesUncachedThumbnail
+					? await loadStickerLabThumbnail({
+							reference,
+							signal: abortController.signal,
+						})
+					: await loadStickerLabReferenceFile({
+							provenance,
+							reference,
+							signal: abortController.signal,
+						});
 				previewUrl = URL.createObjectURL(blob);
 				if (disposed) {
 					URL.revokeObjectURL(previewUrl);
@@ -413,7 +418,9 @@ export function LocalStickerReferencePanel({
 				) : null}
 			</div>
 
-			{isLoading ? (
+			{/* Public-catalog loading and errors must not mask the private
+			    catalogue, which loads independently. */}
+			{isLoading && activeCatalogKey === "public" ? (
 				<div
 					className="flex min-h-0 flex-1 items-center justify-center gap-2 text-xs text-muted-foreground"
 					data-testid="local-sticker-catalog-loading"
@@ -421,7 +428,7 @@ export function LocalStickerReferencePanel({
 					<Loader2 className="size-4 animate-spin" aria-hidden="true" />
 					<span>正在读取贴纸实验目录</span>
 				</div>
-			) : error ? (
+			) : error && activeCatalogKey === "public" ? (
 				<div
 					className="m-3 flex gap-2 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
 					role="alert"

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/hooks/use-local-sticker-catalog.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/hooks/use-local-sticker-catalog.ts
@@ -1,17 +1,30 @@
 import { useEffect, useMemo, useState } from "react";
+import { debugError } from "@/lib/debug/debug-config";
 import { getLocalStickerLabSource } from "@/lib/stickers/local-sticker-lab-config";
 import { buildLegacyLocalStickerCatalog } from "@/lib/stickers/local-sticker-legacy-catalog";
 import {
 	loadLocalStickerManifest,
+	loadPrivateStickerManifest,
 	loadRemoteStickerManifest,
+	type PrivateStickerCatalog,
 	type StickerLabCatalog,
 } from "@/lib/stickers/local-sticker-manifest";
+import {
+	createStickerLabAssetFetch,
+	stickerLabPrivateManifestUrl,
+} from "@/lib/stickers/local-sticker-reference";
 
 export interface LocalStickerCatalogState {
 	catalog: StickerLabCatalog | null;
 	error: string | null;
 	isAvailable: boolean;
 	isLoading: boolean;
+	/**
+	 * The harvested reference catalogue, present only when the license server
+	 * accepts this user's entitlement. Everyone else silently gets null and
+	 * sees just the public catalogue.
+	 */
+	privateCatalog: PrivateStickerCatalog | null;
 }
 
 function initialCatalogState({
@@ -24,6 +37,7 @@ function initialCatalogState({
 		error: null,
 		isAvailable: hasSource,
 		isLoading: hasSource,
+		privateCatalog: null,
 	};
 }
 
@@ -36,14 +50,15 @@ export function useLocalStickerCatalog(): LocalStickerCatalogState {
 	useEffect(() => {
 		if (!source) return;
 		if (source.kind === "legacy") {
-			setState({
+			setState((previous) => ({
+				...previous,
 				catalog: buildLegacyLocalStickerCatalog({
 					filePath: source.filePath,
 				}),
 				error: null,
 				isAvailable: true,
 				isLoading: false,
-			});
+			}));
 			return;
 		}
 
@@ -61,15 +76,17 @@ export function useLocalStickerCatalog(): LocalStickerCatalogState {
 								signal: abortController.signal,
 							});
 				if (disposed) return;
-				setState({
+				setState((previous) => ({
+					...previous,
 					catalog,
 					error: null,
 					isAvailable: true,
 					isLoading: false,
-				});
+				}));
 			} catch (error) {
 				if (disposed) return;
-				setState({
+				setState((previous) => ({
+					...previous,
 					catalog: null,
 					error:
 						error instanceof Error
@@ -77,11 +94,40 @@ export function useLocalStickerCatalog(): LocalStickerCatalogState {
 							: "Unable to load sticker lab manifest",
 					isAvailable: true,
 					isLoading: false,
-				});
+				}));
 			}
 		};
 
 		loadCatalog();
+		return () => {
+			disposed = true;
+			abortController.abort();
+		};
+	}, [source]);
+
+	useEffect(() => {
+		if (!source) return;
+
+		let disposed = false;
+		const abortController = new AbortController();
+		const loadPrivateCatalog = async () => {
+			try {
+				const privateCatalog = await loadPrivateStickerManifest({
+					fetchImpl: createStickerLabAssetFetch(),
+					manifestUrl: stickerLabPrivateManifestUrl(),
+					signal: abortController.signal,
+				});
+				if (disposed) return;
+				setState((previous) => ({ ...previous, privateCatalog }));
+			} catch (error) {
+				// Expected for everyone outside the allow list (403), signed-out
+				// sessions, and offline runs — the lab is fully usable without it.
+				if (disposed) return;
+				debugError("[StickerLab] Private reference catalog unavailable", error);
+			}
+		};
+
+		loadPrivateCatalog();
 		return () => {
 			disposed = true;
 			abortController.abort();

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/stickers-view.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/stickers-view.tsx
@@ -217,6 +217,7 @@ export function StickersView() {
 							error={localStickerCatalog.error}
 							isLoading={localStickerCatalog.isLoading}
 							onSelect={handleLocalReferenceSelect}
+							privateCatalog={localStickerCatalog.privateCatalog}
 						/>
 					) : (
 						<div className="flex h-full min-h-0 flex-col">

--- a/qcut/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
+++ b/qcut/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
@@ -97,6 +97,7 @@ export function TimelineToolbar({
 	const { locale, t } = useTranslation();
 	const tracks = useTimelineStore((s) => s.tracks);
 	const addTrack = useTimelineStore((s) => s.addTrack);
+	const insertTrackAt = useTimelineStore((s) => s.insertTrackAt);
 	const addElementToTrack = useTimelineStore((s) => s.addElementToTrack);
 	const getTotalDuration = useTimelineStore((s) => s.getTotalDuration);
 	const addMarkdownAtTime = useTimelineStore((s) => s.addMarkdownAtTime);
@@ -387,7 +388,7 @@ export function TimelineToolbar({
 			return;
 		}
 		addAdjustmentLayer({
-			timeline: { addTrack, addElementToTrack, getTotalDuration },
+			timeline: { tracks, insertTrackAt, addElementToTrack, getTotalDuration },
 			currentTime,
 		});
 	};

--- a/qcut/apps/web/src/lib/stickers/__tests__/fixtures/local-sticker-catalog.ts
+++ b/qcut/apps/web/src/lib/stickers/__tests__/fixtures/local-sticker-catalog.ts
@@ -2,6 +2,8 @@ import type {
 	LocalStickerCatalog,
 	LocalStickerCategory,
 	LocalStickerReference,
+	PrivateStickerCatalog,
+	PrivateStickerReference,
 	RemoteStickerCatalog,
 	RemoteStickerReference,
 } from "../../local-sticker-manifest";
@@ -102,6 +104,57 @@ export function createRemoteStickerReference({
 			byteSize: 4,
 			checksumSha256,
 		},
+	};
+}
+
+export function createPrivateStickerReference({
+	checksumSha256 = "b964a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+	numericId,
+}: {
+	checksumSha256?: string;
+	numericId: string;
+}): PrivateStickerReference {
+	return {
+		id: numericId,
+		displayName: `参照贴纸 ${numericId}`,
+		fileName: `${numericId}-参照.gif`,
+		mimeType: "image/gif",
+		sourceKind: "preview-gif",
+		playback: {
+			kind: "animated",
+			frameCount: 8,
+			frameRate: 5,
+			cycleDuration: 1.6,
+			loop: true,
+		},
+		asset: {
+			kind: "supabase-storage",
+			objectKey: `jianying/2026-07-31/assets/${numericId}.gif`,
+			byteSize: 4,
+			checksumSha256,
+		},
+	};
+}
+
+export function createPrivateStickerCatalog(): PrivateStickerCatalog {
+	return {
+		version: 2,
+		catalogId: "jianying-2026-07-31",
+		categories: [
+			{
+				id: "hot",
+				label: "热门",
+				sourcePanel: "剪映贴纸面板 / 热门",
+				items: [
+					createPrivateStickerReference({ numericId: "7437023238108105995" }),
+					createPrivateStickerReference({
+						checksumSha256:
+							"c964a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+						numericId: "6911930254453984525",
+					}),
+				],
+			},
+		],
 	};
 }
 

--- a/qcut/apps/web/src/lib/stickers/__tests__/local-sticker-manifest.test.ts
+++ b/qcut/apps/web/src/lib/stickers/__tests__/local-sticker-manifest.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	createLocalStickerCatalog,
+	createPrivateStickerCatalog,
+	createPrivateStickerReference,
 	createRemoteStickerCatalog,
 } from "./fixtures/local-sticker-catalog";
 import {
+	isPrivateStickerCatalog,
 	loadLocalStickerManifest,
+	loadPrivateStickerManifest,
 	loadRemoteStickerManifest,
 	parseLocalStickerManifest,
 } from "../local-sticker-manifest";
@@ -616,5 +620,120 @@ describe("local sticker manifest", () => {
 		expect(() =>
 			parseLocalStickerManifest({ jsonText: JSON.stringify(candidate) })
 		).toThrow("must not contain dot path segments");
+	});
+});
+
+describe("private reference manifests", () => {
+	it("parses a version 2 catalog without provenance as a private reference", () => {
+		const catalog = parseLocalStickerManifest({
+			jsonText: JSON.stringify(createPrivateStickerCatalog()),
+		});
+
+		expect(catalog.version).toBe(2);
+		expect(isPrivateStickerCatalog(catalog)).toBe(true);
+	});
+
+	it("rejects private catalogs outside the jianying namespace", () => {
+		const catalog = createPrivateStickerCatalog();
+		const candidate = { ...catalog, catalogId: "qcut-original-test" };
+
+		expect(() =>
+			parseLocalStickerManifest({ jsonText: JSON.stringify(candidate) })
+		).toThrow("jianying- prefix");
+	});
+
+	it("rejects object keys from another catalog's namespace", () => {
+		const catalog = createPrivateStickerCatalog();
+		const foreign = createPrivateStickerReference({
+			checksumSha256:
+				"d964a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+			numericId: "7000000000000000001",
+		});
+		foreign.asset.objectKey =
+			"jianying/2026-08-01/assets/7000000000000000001.gif";
+		const candidate = {
+			...catalog,
+			categories: [
+				{
+					...catalog.categories[0],
+					items: [...catalog.categories[0].items, foreign],
+				},
+			],
+		};
+
+		expect(() =>
+			parseLocalStickerManifest({ jsonText: JSON.stringify(candidate) })
+		).toThrow("must belong to catalog jianying-2026-07-31");
+	});
+
+	it("rejects public catalog object keys inside a private manifest", () => {
+		const catalog = createPrivateStickerCatalog();
+		const candidate = JSON.parse(JSON.stringify(catalog));
+		candidate.categories[0].items[0].asset.objectKey =
+			"catalogs/qcut-original-test/assets/sticker-1.gif";
+
+		expect(() =>
+			parseLocalStickerManifest({ jsonText: JSON.stringify(candidate) })
+		).toThrow("Invalid sticker lab manifest");
+	});
+
+	it("allows the animated-GIF budgets the harvested catalog needs", () => {
+		// The public v2 budgets (1MB per category) would reject the harvested
+		// GIF catalogue outright; the private schema has its own budgets.
+		const catalog = createPrivateStickerCatalog();
+		const candidate = JSON.parse(JSON.stringify(catalog));
+		candidate.categories[0].items[0].asset.byteSize = 16 * 1024 * 1024;
+		candidate.categories[0].items[1].asset.byteSize = 16 * 1024 * 1024;
+
+		const parsed = parseLocalStickerManifest({
+			jsonText: JSON.stringify(candidate),
+		});
+		expect(isPrivateStickerCatalog(parsed)).toBe(true);
+	});
+
+	it("loads the private manifest and rejects a public manifest in its place", async () => {
+		const privateCatalog = createPrivateStickerCatalog();
+		const fetchPrivate = vi.fn(async () =>
+			Promise.resolve(
+				new Response(JSON.stringify(privateCatalog), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				})
+			)
+		);
+
+		await expect(
+			loadPrivateStickerManifest({
+				manifestUrl: "/api/sticker-lab/private-manifest",
+				fetchImpl: fetchPrivate,
+			})
+		).resolves.toEqual(privateCatalog);
+
+		const fetchPublic = async () =>
+			new Response(JSON.stringify(createRemoteStickerCatalog()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		await expect(
+			loadPrivateStickerManifest({
+				manifestUrl: "/api/sticker-lab/private-manifest",
+				fetchImpl: fetchPublic,
+			})
+		).rejects.toThrow("without provenance");
+	});
+
+	it("keeps the remote loader strict about provenance", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify(createPrivateStickerCatalog()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		await expect(
+			loadRemoteStickerManifest({
+				manifestUrl: "/sticker-lab/catalog.json",
+				fetchImpl,
+			})
+		).rejects.toThrow("with provenance");
 	});
 });

--- a/qcut/apps/web/src/lib/stickers/__tests__/sticker-lab-inventory.test.ts
+++ b/qcut/apps/web/src/lib/stickers/__tests__/sticker-lab-inventory.test.ts
@@ -3,7 +3,10 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { describe, expect, it } from "vitest";
-import { parseLocalStickerManifest } from "../local-sticker-manifest";
+import {
+	isRemoteStickerCatalog,
+	parseLocalStickerManifest,
+} from "../local-sticker-manifest";
 
 const repositoryRootCandidate = cwd();
 const REPOSITORY_ROOT = existsSync(
@@ -30,8 +33,10 @@ describe("QCut original sticker lab inventory", () => {
 	it("ships 42 categories with at least 10 distinct stickers each", () => {
 		const manifestText = readFileSync(MANIFEST_PATH, "utf8");
 		const catalog = parseLocalStickerManifest({ jsonText: manifestText });
-		if (catalog.version !== 2) {
-			throw new Error("Expected the bundled sticker lab catalog to use v2");
+		if (!isRemoteStickerCatalog(catalog)) {
+			throw new Error(
+				"Expected the bundled sticker lab catalog to use v2 with provenance"
+			);
 		}
 
 		expect(catalog.catalogId).toBe("qcut-original-42x10-r2-2026-07-31");
@@ -79,8 +84,10 @@ describe("QCut original sticker lab inventory", () => {
 		const catalog = parseLocalStickerManifest({
 			jsonText: readFileSync(MANIFEST_PATH, "utf8"),
 		});
-		if (catalog.version !== 2) {
-			throw new Error("Expected the bundled sticker lab catalog to use v2");
+		if (!isRemoteStickerCatalog(catalog)) {
+			throw new Error(
+				"Expected the bundled sticker lab catalog to use v2 with provenance"
+			);
 		}
 
 		expect(catalog.provenance).toMatchObject({

--- a/qcut/apps/web/src/lib/stickers/local-sticker-manifest.ts
+++ b/qcut/apps/web/src/lib/stickers/local-sticker-manifest.ts
@@ -8,9 +8,12 @@ import {
 	ABSOLUTE_LOCAL_PATH_PATTERN,
 	GIT_OID_PATTERN,
 	hasDotPathSegment,
+	MAX_PRIVATE_REFERENCE_CATALOG_BYTES,
+	MAX_PRIVATE_REFERENCE_CATEGORY_BYTES,
 	MAX_REMOTE_ASSET_BYTES,
 	MAX_REMOTE_CATALOG_BYTES,
 	MAX_REMOTE_CATEGORY_BYTES,
+	PRIVATE_REFERENCE_OBJECT_KEY_PATTERN,
 	SHA256_PATTERN,
 	SOURCE_ASSET_ID_PATTERN,
 	STICKER_ID_PATTERN,
@@ -205,6 +208,47 @@ const remoteStickerReferenceSchema = z
 		}
 	});
 
+/**
+ * Reference item in the allow-list-only harvested catalogue. Unlike the public
+ * catalogue there is no repo source asset to point at — the artwork was
+ * captured from a third-party app for internal parity study, so only the
+ * remote object and its integrity data exist.
+ */
+const privateStickerReferenceSchema = z
+	.object({
+		...commonStickerReferenceShape,
+		mimeType: z.enum(["image/png", "image/gif"]),
+		asset: z
+			.object({
+				kind: z.literal("supabase-storage"),
+				objectKey: z.string().regex(PRIVATE_REFERENCE_OBJECT_KEY_PATTERN),
+				byteSize: z.number().int().positive().max(MAX_REMOTE_ASSET_BYTES),
+				checksumSha256: z.string().regex(SHA256_PATTERN),
+			})
+			.strict(),
+	})
+	.strict()
+	.superRefine((reference, context) => {
+		validateReferencePlayback({ context, reference });
+
+		const expectedExtension =
+			reference.mimeType === "image/gif" ? ".gif" : ".png";
+		if (!reference.asset.objectKey.endsWith(expectedExtension)) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["asset", "objectKey"],
+				message: `${reference.mimeType} assets require ${expectedExtension} object keys`,
+			});
+		}
+		if (!reference.fileName.toLocaleLowerCase().endsWith(expectedExtension)) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["fileName"],
+				message: `${reference.mimeType} assets require ${expectedExtension} file names`,
+			});
+		}
+	});
+
 const commonCategoryShape = {
 	id: z.string().trim().regex(STICKER_ID_PATTERN),
 	label: z.string().trim().min(1).max(80),
@@ -330,6 +374,84 @@ const stickerLabManifestV2Schema = z
 		}
 	});
 
+const privateStickerCategorySchema = z
+	.object({
+		...commonCategoryShape,
+		items: z.array(privateStickerReferenceSchema).min(1).max(100),
+	})
+	.strict();
+
+/**
+ * The harvested reference catalogue: version 2 without provenance. The public
+ * v2 schema demands provenance, repo source assets, and tight byte budgets —
+ * none of which exist for captured third-party artwork. Everything here is
+ * still integrity-checked, but the object keys live under the jianying/
+ * prefix that the license server only signs for allow-listed users.
+ */
+const privateStickerCatalogSchema = z
+	.object({
+		version: z.literal(2),
+		catalogId: z
+			.string()
+			.trim()
+			.regex(STICKER_ID_PATTERN)
+			.refine((catalogId) => catalogId.startsWith("jianying-"), {
+				message: "Private reference catalogs must use the jianying- prefix",
+			}),
+		categories: z.array(privateStickerCategorySchema).min(1).max(100),
+	})
+	.strict()
+	.superRefine((manifest, context) => {
+		validateUniqueManifestEntries({
+			categories: manifest.categories,
+			context,
+		});
+		// catalogId "jianying-2026-07-31" owns the "jianying/2026-07-31/assets/"
+		// namespace in the bucket.
+		const catalogObjectPrefix = `${manifest.catalogId.replace(
+			/^jianying-/,
+			"jianying/"
+		)}/assets/`;
+		let catalogBytes = 0;
+		for (const [categoryIndex, category] of manifest.categories.entries()) {
+			const categoryBytes = category.items.reduce(
+				(totalBytes, item) => totalBytes + item.asset.byteSize,
+				0
+			);
+			catalogBytes += categoryBytes;
+			if (categoryBytes > MAX_PRIVATE_REFERENCE_CATEGORY_BYTES) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["categories", categoryIndex, "items"],
+					message: `Category assets exceed ${MAX_PRIVATE_REFERENCE_CATEGORY_BYTES} bytes`,
+				});
+			}
+			for (const [itemIndex, item] of category.items.entries()) {
+				if (!item.asset.objectKey.startsWith(catalogObjectPrefix)) {
+					context.addIssue({
+						code: z.ZodIssueCode.custom,
+						path: [
+							"categories",
+							categoryIndex,
+							"items",
+							itemIndex,
+							"asset",
+							"objectKey",
+						],
+						message: `Object key must belong to catalog ${manifest.catalogId}`,
+					});
+				}
+			}
+		}
+		if (catalogBytes > MAX_PRIVATE_REFERENCE_CATALOG_BYTES) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["categories"],
+				message: `Catalog assets exceed ${MAX_PRIVATE_REFERENCE_CATALOG_BYTES} bytes`,
+			});
+		}
+	});
+
 export type LocalStickerSourceKind = z.infer<
 	typeof localStickerSourceKindSchema
 >;
@@ -343,14 +465,37 @@ export type RemoteStickerReference = z.infer<
 export type RemoteStickerProvenance = z.infer<
 	typeof remoteStickerProvenanceSchema
 >;
+export type PrivateStickerReference = z.infer<
+	typeof privateStickerReferenceSchema
+>;
 export type StickerLabReference =
 	| LocalStickerReference
-	| RemoteStickerReference;
+	| RemoteStickerReference
+	| PrivateStickerReference;
 export type LocalStickerCategory = z.infer<typeof localStickerCategorySchema>;
 export type RemoteStickerCategory = z.infer<typeof remoteStickerCategorySchema>;
+export type PrivateStickerCategory = z.infer<
+	typeof privateStickerCategorySchema
+>;
 export type LocalStickerCatalog = z.infer<typeof localStickerManifestV1Schema>;
 export type RemoteStickerCatalog = z.infer<typeof stickerLabManifestV2Schema>;
-export type StickerLabCatalog = LocalStickerCatalog | RemoteStickerCatalog;
+export type PrivateStickerCatalog = z.infer<typeof privateStickerCatalogSchema>;
+export type StickerLabCatalog =
+	| LocalStickerCatalog
+	| RemoteStickerCatalog
+	| PrivateStickerCatalog;
+
+export function isPrivateStickerCatalog(
+	catalog: StickerLabCatalog
+): catalog is PrivateStickerCatalog {
+	return catalog.version === 2 && !("provenance" in catalog);
+}
+
+export function isRemoteStickerCatalog(
+	catalog: StickerLabCatalog
+): catalog is RemoteStickerCatalog {
+	return catalog.version === 2 && "provenance" in catalog;
+}
 
 function formatManifestIssues({ error }: { error: z.ZodError }): string {
 	return error.issues
@@ -372,8 +517,16 @@ function parseManifestCandidate({
 		"version" in candidate
 			? candidate.version
 			: undefined;
+	// Version 2 covers two shapes: the public catalogue carries provenance,
+	// the allow-list-only harvested reference catalogue does not.
 	const schema =
-		version === 2 ? stickerLabManifestV2Schema : localStickerManifestV1Schema;
+		version === 2
+			? typeof candidate === "object" &&
+				candidate !== null &&
+				"provenance" in candidate
+				? stickerLabManifestV2Schema
+				: privateStickerCatalogSchema
+			: localStickerManifestV1Schema;
 	const result = schema.safeParse(candidate);
 	if (!result.success) {
 		throw new Error(
@@ -428,15 +581,15 @@ export async function loadLocalStickerManifest({
 	return parseLocalStickerManifest({ jsonText });
 }
 
-export async function loadRemoteStickerManifest({
-	fetchImpl = fetch,
+async function fetchStickerManifest({
+	fetchImpl,
 	manifestUrl,
 	signal,
 }: {
-	fetchImpl?: typeof fetch;
+	fetchImpl: typeof fetch;
 	manifestUrl: string;
 	signal?: AbortSignal;
-}): Promise<RemoteStickerCatalog> {
+}): Promise<StickerLabCatalog> {
 	const response = await fetchImpl(manifestUrl, { signal });
 	if (!response.ok) {
 		throw new Error(
@@ -457,9 +610,49 @@ export async function loadRemoteStickerManifest({
 	} catch {
 		throw new Error("Invalid sticker lab manifest: expected UTF-8 JSON");
 	}
-	const catalog = parseLocalStickerManifest({ jsonText });
-	if (catalog.version !== 2) {
-		throw new Error("Remote sticker lab manifests must use version 2");
+	return parseLocalStickerManifest({ jsonText });
+}
+
+export async function loadRemoteStickerManifest({
+	fetchImpl = fetch,
+	manifestUrl,
+	signal,
+}: {
+	fetchImpl?: typeof fetch;
+	manifestUrl: string;
+	signal?: AbortSignal;
+}): Promise<RemoteStickerCatalog> {
+	const catalog = await fetchStickerManifest({
+		fetchImpl,
+		manifestUrl,
+		signal,
+	});
+	if (catalog.version !== 2 || !("provenance" in catalog)) {
+		throw new Error(
+			"Remote sticker lab manifests must use version 2 with provenance"
+		);
+	}
+	return catalog;
+}
+
+export async function loadPrivateStickerManifest({
+	fetchImpl = fetch,
+	manifestUrl,
+	signal,
+}: {
+	fetchImpl?: typeof fetch;
+	manifestUrl: string;
+	signal?: AbortSignal;
+}): Promise<PrivateStickerCatalog> {
+	const catalog = await fetchStickerManifest({
+		fetchImpl,
+		manifestUrl,
+		signal,
+	});
+	if (!isPrivateStickerCatalog(catalog)) {
+		throw new Error(
+			"Private sticker reference manifests must use version 2 without provenance"
+		);
 	}
 	return catalog;
 }

--- a/qcut/apps/web/src/lib/stickers/local-sticker-reference.ts
+++ b/qcut/apps/web/src/lib/stickers/local-sticker-reference.ts
@@ -16,6 +16,7 @@ import {
 } from "./local-sticker-file-reader";
 import type {
 	LocalStickerReference,
+	PrivateStickerReference,
 	RemoteStickerProvenance,
 	RemoteStickerReference,
 	StickerLabReference,
@@ -23,10 +24,35 @@ import type {
 
 export type {
 	LocalStickerReference,
+	PrivateStickerReference,
 	RemoteStickerProvenance,
 	RemoteStickerReference,
 	StickerLabReference,
 } from "./local-sticker-manifest";
+
+/** Any reference whose artwork lives in the private Supabase bucket. */
+export type RemoteCatalogStickerReference =
+	| RemoteStickerReference
+	| PrivateStickerReference;
+
+/**
+ * License metadata attached to cached copies of the harvested reference
+ * catalogue. Deliberately honest: the artwork is third-party and restricted,
+ * it exists purely so allow-listed internal accounts can study parity.
+ */
+export const PRIVATE_REFERENCE_PROVENANCE: RemoteStickerProvenance = {
+	creator: "Jianying (harvested reference)",
+	license: {
+		name: "Third-party reference — internal use only",
+		commercialUse: "restricted",
+		attributionRequired: false,
+		licenseFile: "docs/task/sticker-lab-private-reference/README.md",
+	},
+	sourceCollections: ["jianying-reference"],
+	sourceTreeGitOid: "0000000000000000000000000000000000000000",
+	transformation:
+		"Captured Jianying sticker previews for allow-listed internal parity reference",
+};
 
 type SessionTokenReader = () => Promise<string>;
 
@@ -93,6 +119,20 @@ export function stickerLabThumbnailUrl({
 	)}`;
 }
 
+/**
+ * Manifest of the harvested reference catalogue. The license server only
+ * serves it to allow-listed users, so a 403 here simply means the viewer
+ * gets the public catalogue alone.
+ */
+export function stickerLabPrivateManifestUrl({
+	licenseServerUrl = LICENSE_SERVER_URL,
+}: {
+	licenseServerUrl?: string;
+} = {}): string {
+	const serverUrl = licenseServerUrl.replace(/\/+$/, "");
+	return `${serverUrl}/api/sticker-lab/private-manifest`;
+}
+
 export function buildStickerLabAssetEntry({
 	licenseServerUrl = LICENSE_SERVER_URL,
 	provenance,
@@ -100,7 +140,7 @@ export function buildStickerLabAssetEntry({
 }: {
 	licenseServerUrl?: string;
 	provenance: RemoteStickerProvenance;
-	reference: RemoteStickerReference;
+	reference: RemoteCatalogStickerReference;
 }): AssetManifestEntry {
 	return {
 		schemaVersion: ASSET_MANIFEST_SCHEMA_VERSION,
@@ -133,7 +173,10 @@ export function buildStickerLabAssetEntry({
 			objectKey: reference.asset.objectKey,
 			playback: reference.playback,
 			provenance,
-			sourceAsset: reference.sourceAsset,
+			// Harvested references have no repo source asset to record.
+			...("sourceAsset" in reference
+				? { sourceAsset: reference.sourceAsset }
+				: {}),
 			sourceKind: reference.sourceKind,
 		},
 	};
@@ -197,7 +240,7 @@ function remoteResourceBlob({
 	reference,
 	resources,
 }: {
-	reference: RemoteStickerReference;
+	reference: RemoteCatalogStickerReference;
 	resources: ResolvedAssetResource[];
 }): Blob {
 	const source = resources.find((resource) => resource.role === "source");
@@ -228,7 +271,7 @@ export async function loadRemoteStickerReferenceFile({
 	getToken?: SessionTokenReader;
 	licenseServerUrl?: string;
 	provenance: RemoteStickerProvenance;
-	reference: RemoteStickerReference;
+	reference: RemoteCatalogStickerReference;
 	signal?: AbortSignal;
 }): Promise<File> {
 	const asset = buildStickerLabAssetEntry({
@@ -265,7 +308,7 @@ export async function loadStickerLabThumbnail({
 	fetchImpl?: typeof fetch;
 	getToken?: SessionTokenReader;
 	licenseServerUrl?: string;
-	reference: RemoteStickerReference;
+	reference: RemoteCatalogStickerReference;
 	signal?: AbortSignal;
 }): Promise<Blob> {
 	const authorizedFetch = createStickerLabAssetFetch({

--- a/qcut/apps/web/src/lib/stickers/sticker-manifest-validation.ts
+++ b/qcut/apps/web/src/lib/stickers/sticker-manifest-validation.ts
@@ -6,11 +6,18 @@ export const SOURCE_ASSET_ID_PATTERN =
 export const ABSOLUTE_LOCAL_PATH_PATTERN = /^(?:\/|[a-zA-Z]:[\\/]|\\\\)/;
 export const SUPABASE_OBJECT_KEY_PATTERN =
 	/^catalogs\/[a-z0-9]+(?:-[a-z0-9]+)*\/assets\/[a-z0-9]+(?:-[a-z0-9]+)*\.(gif|png)$/;
+export const PRIVATE_REFERENCE_OBJECT_KEY_PATTERN =
+	/^jianying\/[0-9]{4}-[0-9]{2}-[0-9]{2}\/assets\/[0-9]+\.(gif|png)$/;
 export const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 export const GIT_OID_PATTERN = /^[a-f0-9]{40}$/;
 export const MAX_REMOTE_ASSET_BYTES = 25 * 1024 * 1024;
 export const MAX_REMOTE_CATEGORY_BYTES = 1024 * 1024;
 export const MAX_REMOTE_CATALOG_BYTES = 25 * 1024 * 1024;
+// The harvested reference catalogue is animated GIFs, not optimized PNGs, so
+// its budgets are far above the public catalogue's. It is never bundled and
+// only allow-listed users can even fetch its manifest.
+export const MAX_PRIVATE_REFERENCE_CATEGORY_BYTES = 128 * 1024 * 1024;
+export const MAX_PRIVATE_REFERENCE_CATALOG_BYTES = 512 * 1024 * 1024;
 
 export function hasDotPathSegment({ filePath }: { filePath: string }): boolean {
 	return filePath

--- a/qcut/apps/web/src/lib/timeline/__tests__/adjustment-layer.test.ts
+++ b/qcut/apps/web/src/lib/timeline/__tests__/adjustment-layer.test.ts
@@ -1,29 +1,63 @@
 import { describe, expect, it, vi } from "vitest";
-import type { TimelineStore } from "@/stores/timeline/types";
-import { addAdjustmentLayer } from "../adjustment-layer";
+import type { TimelineTrack } from "@/types/timeline";
+import {
+	addAdjustmentLayer,
+	adjustmentTrackInsertionIndex,
+} from "../adjustment-layer";
+
+function track(type: TimelineTrack["type"]): Pick<TimelineTrack, "type"> {
+	return { type };
+}
 
 function timeline({
 	totalDuration,
 	elementId = "adjustment-element",
+	tracks = [track("media")],
 }: {
 	totalDuration: number;
 	elementId?: string | null;
+	tracks?: Pick<TimelineTrack, "type">[];
 }) {
 	return {
-		addTrack: vi.fn(() => "adjustment-track"),
+		tracks: tracks as TimelineTrack[],
+		insertTrackAt: vi.fn(() => "adjustment-track"),
 		addElementToTrack: vi.fn(() => elementId),
 		getTotalDuration: vi.fn(() => totalDuration),
 	};
 }
 
+describe("adjustmentTrackInsertionIndex", () => {
+	it("targets the slot directly above the topmost media track", () => {
+		// Adjustment layers only grade tracks below them, so they must sit
+		// above the media stack — but below text/sticker overlays.
+		const index = adjustmentTrackInsertionIndex({
+			tracks: [
+				track("text"),
+				track("sticker"),
+				track("media"),
+				track("media"),
+				track("audio"),
+			],
+		});
+
+		expect(index).toBe(2);
+	});
+
+	it("appends when the timeline has no media track", () => {
+		expect(
+			adjustmentTrackInsertionIndex({
+				tracks: [track("text"), track("audio")],
+			})
+		).toBe(2);
+		expect(adjustmentTrackInsertionIndex({ tracks: [] })).toBe(0);
+	});
+});
+
 describe("addAdjustmentLayer", () => {
 	it("creates an adjustment layer from the playhead to the project end", () => {
 		const timelineApi = timeline({ totalDuration: 20 });
 		const created = addAdjustmentLayer({
-			timeline: timelineApi as Pick<
-				TimelineStore,
-				"addTrack" | "addElementToTrack" | "getTotalDuration"
-			>,
+			timeline: timelineApi,
 			currentTime: 8,
 		});
 
@@ -31,7 +65,7 @@ describe("addAdjustmentLayer", () => {
 			trackId: "adjustment-track",
 			elementId: "adjustment-element",
 		});
-		expect(timelineApi.addTrack).toHaveBeenCalledWith("adjustment");
+		expect(timelineApi.insertTrackAt).toHaveBeenCalledWith("adjustment", 0);
 		expect(timelineApi.addElementToTrack).toHaveBeenCalledWith(
 			"adjustment-track",
 			expect.objectContaining({
@@ -44,13 +78,23 @@ describe("addAdjustmentLayer", () => {
 		);
 	});
 
+	it("inserts the new track above the topmost media track, not at the bottom", () => {
+		// Regression: addTrack used to append at the bottom of the timeline,
+		// where the layer wraps nothing and grades nothing.
+		const timelineApi = timeline({
+			totalDuration: 20,
+			tracks: [track("sticker"), track("media"), track("audio")],
+		});
+
+		addAdjustmentLayer({ timeline: timelineApi, currentTime: 0 });
+
+		expect(timelineApi.insertTrackAt).toHaveBeenCalledWith("adjustment", 1);
+	});
+
 	it("uses the minimum duration when the playhead is past the project end", () => {
 		const timelineApi = timeline({ totalDuration: 4 });
 		addAdjustmentLayer({
-			timeline: timelineApi as Pick<
-				TimelineStore,
-				"addTrack" | "addElementToTrack" | "getTotalDuration"
-			>,
+			timeline: timelineApi,
 			currentTime: 10,
 			name: "自定义调节",
 		});

--- a/qcut/apps/web/src/lib/timeline/adjustment-layer.ts
+++ b/qcut/apps/web/src/lib/timeline/adjustment-layer.ts
@@ -1,15 +1,32 @@
+import type { TimelineTrack } from "@/types/timeline";
 import type { TimelineStore } from "@/stores/timeline/types";
 
 export const DEFAULT_ADJUSTMENT_LAYER_DURATION = 5;
 
 type AdjustmentLayerTimeline = Pick<
 	TimelineStore,
-	"addTrack" | "addElementToTrack" | "getTotalDuration"
+	"tracks" | "insertTrackAt" | "addElementToTrack" | "getTotalDuration"
 >;
 
 export interface CreatedAdjustmentLayer {
 	trackId: string;
 	elementId: string | null;
+}
+
+/**
+ * An adjustment layer only grades the tracks rendered below it, so a track
+ * appended at the bottom of the timeline would grade nothing. Insert directly
+ * above the topmost media track instead — covering every media/audio track
+ * while leaving text and sticker overlays above it untouched, matching the
+ * legacy type-priority order (adjustment between sticker and media).
+ */
+export function adjustmentTrackInsertionIndex({
+	tracks,
+}: {
+	tracks: readonly Pick<TimelineTrack, "type">[];
+}): number {
+	const topmostMediaIndex = tracks.findIndex((track) => track.type === "media");
+	return topmostMediaIndex === -1 ? tracks.length : topmostMediaIndex;
 }
 
 export function addAdjustmentLayer({
@@ -21,7 +38,10 @@ export function addAdjustmentLayer({
 	currentTime: number;
 	name?: string;
 }): CreatedAdjustmentLayer {
-	const trackId = timeline.addTrack("adjustment");
+	const trackId = timeline.insertTrackAt(
+		"adjustment",
+		adjustmentTrackInsertionIndex({ tracks: timeline.tracks })
+	);
 	const projectEnd = timeline.getTotalDuration();
 	const duration = Math.max(
 		DEFAULT_ADJUSTMENT_LAYER_DURATION,

--- a/qcut/docs/task/sticker-lab-private-reference/README.md
+++ b/qcut/docs/task/sticker-lab-private-reference/README.md
@@ -1,0 +1,28 @@
+# Sticker Lab — 私有剪映参照目录
+
+贴纸实验室有两个目录:
+
+| 目录 | manifest | 存储前缀 | 可见性 |
+|---|---|---|---|
+| QCut 原创(公开) | 随包分发 `sticker-lab/qcut-original-*.json` | `catalogs/qcut-original-*/assets/` | 预览:所有登录用户;原图:白名单 |
+| 剪映参照(私有) | 仅服务端 `jianying/<date>/manifest.json` | `jianying/<date>/assets/` | manifest / 预览 / 原图全部仅白名单 |
+
+私有目录是 2026-07-31 从剪映专业版贴纸面板采集的 42 分类 / 168 个预览
+GIF(PR #371 开发期的 harvested catalog,commit `ef470377` 将其从公开目录
+中移除)。素材属于字节跳动及其合作 IP,**只作为内部对标参照使用**:
+
+- manifest 不进 Git、不进安装包 —— 只存在于私有 Supabase bucket,经
+  license server 的 `/api/sticker-lab/private-manifest` 下发;
+- 三层(manifest、缩略图、原图)全部要求
+  `STICKER_LAB_ALLOWED_USER_IDS` 白名单,fail-closed;
+- 客户端在缓存条目上标注 `commercialUse: "restricted"`
+  (见 `PRIVATE_REFERENCE_PROVENANCE`),这些素材不得出现在任何
+  发行物、宣传物或公开导出中;
+- 普通用户(含全部发行版用户)对该目录完全不可见:请求 manifest 得到
+  403,面板不渲染切换入口。
+
+恢复/重采集 manifest 的方法:
+`git show 28d2521d6:qcut/apps/web/public/sticker-lab/jianying-2026-07-31.json`,
+上传到 bucket 的 `jianying/<date>/manifest.json`,并同步
+`packages/license-server/src/routes/sticker-lab.ts` 里的
+`PRIVATE_REFERENCE_MANIFEST_OBJECT_KEY`。

--- a/qcut/packages/db/supabase/migrations/20260731210000_sticker_lab_manifest_mime.sql
+++ b/qcut/packages/db/supabase/migrations/20260731210000_sticker_lab_manifest_mime.sql
@@ -1,0 +1,6 @@
+-- The private reference manifest (jianying/<date>/manifest.json) lives in the
+-- same bucket as the artwork it describes, so the bucket must accept JSON in
+-- addition to the two image formats.
+update storage.buckets
+set allowed_mime_types = array['image/gif', 'image/png', 'application/json']
+where id = 'sticker-lab';

--- a/qcut/packages/license-server/src/routes/sticker-lab.test.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.test.ts
@@ -329,6 +329,39 @@ describe("sticker lab private reference tier", () => {
 		expect(storageMocks.from).not.toHaveBeenCalled();
 	});
 
+	it("forbids private originals outside the allowlist", async () => {
+		// The allow-list check must come before key parsing, so this holds even
+		// if the key branches are ever reordered.
+		const response = await buildApp().request(
+			buildAssetUrl({ objectKey: privateObjectKey })
+		);
+
+		expect(response.status).toBe(403);
+		expect(storageMocks.from).not.toHaveBeenCalled();
+	});
+
+	it("rejects traversal attempts against private thumbnail keys", async () => {
+		allowMockUser();
+		const traversalKeys = [
+			"jianying/2026-07-31/assets/../7437023238108105995.gif",
+			"jianying/../2026-07-31/assets/7437023238108105995.gif",
+		];
+
+		const responses = await Promise.all(
+			traversalKeys.flatMap((objectKey) => [
+				buildApp().request(buildThumbnailUrl({ objectKey })),
+				buildApp().request(
+					`/api/sticker-lab/thumbnail?objectKey=${encodeURIComponent(objectKey)}`
+				),
+			])
+		);
+
+		for (const response of responses) {
+			expect(response.status).toBe(400);
+		}
+		expect(storageMocks.from).not.toHaveBeenCalled();
+	});
+
 	it("signs private thumbnails without a transform for allow-listed users", async () => {
 		allowMockUser();
 		storageMocks.createSignedUrl.mockResolvedValue({
@@ -408,15 +441,32 @@ describe("sticker lab private reference tier", () => {
 		expect(storageMocks.download).not.toHaveBeenCalled();
 	});
 
-	it("returns 404 when the private manifest object is missing", async () => {
+	it("returns a sanitized 404 when the private manifest object is missing", async () => {
 		allowMockUser();
 		storageMocks.download.mockResolvedValue({
 			data: null,
-			error: { message: "Object not found" },
+			error: { message: "SUPABASE_SERVICE_KEY=do-not-leak" },
 		});
 
 		const response = await buildApp().request(manifestUrl);
+		const responseText = await response.text();
 
 		expect(response.status).toBe(404);
+		expect(responseText).toBe('{"error":"Private manifest unavailable"}');
+		expect(responseText).not.toContain("do-not-leak");
+	});
+
+	it("sanitizes exceptions raised while downloading the private manifest", async () => {
+		allowMockUser();
+		storageMocks.download.mockRejectedValue(
+			new Error("service-role secret leaked by upstream")
+		);
+
+		const response = await buildApp().request(manifestUrl);
+		const responseText = await response.text();
+
+		expect(response.status).toBe(502);
+		expect(responseText).toBe('{"error":"Private manifest unavailable"}');
+		expect(responseText).not.toContain("service-role");
 	});
 });

--- a/qcut/packages/license-server/src/routes/sticker-lab.test.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const storageMocks = vi.hoisted(() => ({
 	createSignedUrl: vi.fn(),
+	download: vi.fn(),
 	from: vi.fn(),
 }));
 
@@ -37,6 +38,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	storageMocks.from.mockReturnValue({
 		createSignedUrl: storageMocks.createSignedUrl,
+		download: storageMocks.download,
 	});
 });
 
@@ -289,5 +291,132 @@ describe("sticker lab preview tier", () => {
 
 		expect(preview.status).toBe(302);
 		expect(original.status).toBe(403);
+	});
+});
+
+describe("sticker lab private reference tier", () => {
+	const privateObjectKey = "jianying/2026-07-31/assets/7437023238108105995.gif";
+	const manifestUrl = "/api/sticker-lab/private-manifest";
+
+	it("signs private reference originals for allow-listed users", async () => {
+		allowMockUser();
+		const signedUrl = "https://storage.example/private.gif?token=signed";
+		storageMocks.createSignedUrl.mockResolvedValue({
+			data: { signedUrl },
+			error: null,
+		});
+
+		const response = await buildApp().request(
+			buildAssetUrl({ objectKey: privateObjectKey })
+		);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get("Location")).toBe(signedUrl);
+		expect(storageMocks.createSignedUrl).toHaveBeenCalledWith(
+			privateObjectKey,
+			600
+		);
+	});
+
+	it("forbids private thumbnails outside the allowlist", async () => {
+		// Unlike the public catalogue there is no browse-only tier: harvested
+		// third-party artwork must never be visible to ordinary users.
+		const response = await buildApp().request(
+			buildThumbnailUrl({ objectKey: privateObjectKey })
+		);
+
+		expect(response.status).toBe(403);
+		expect(storageMocks.from).not.toHaveBeenCalled();
+	});
+
+	it("signs private thumbnails without a transform for allow-listed users", async () => {
+		allowMockUser();
+		storageMocks.createSignedUrl.mockResolvedValue({
+			data: { signedUrl: "https://storage.example/private.gif" },
+			error: null,
+		});
+
+		const response = await buildApp().request(
+			buildThumbnailUrl({ objectKey: privateObjectKey })
+		);
+
+		expect(response.status).toBe(302);
+		expect(storageMocks.createSignedUrl).toHaveBeenCalledWith(
+			privateObjectKey,
+			600
+		);
+	});
+
+	it("rejects malformed private object keys", async () => {
+		allowMockUser();
+		const invalidKeys = [
+			"jianying/2026-07-31/assets/sticker-abc.gif",
+			"jianying/2026-07-31/assets/../123.gif",
+			"jianying/2026-7-31/assets/123.gif",
+			"jianying/2026-07-31/123.gif",
+			"jianying/2026-07-31/assets/123.jpg",
+		];
+
+		const responses = await Promise.all(
+			invalidKeys.map((objectKey) =>
+				buildApp().request(buildAssetUrl({ objectKey }))
+			)
+		);
+
+		for (const response of responses) {
+			expect(response.status).toBe(400);
+		}
+		expect(storageMocks.from).not.toHaveBeenCalled();
+	});
+
+	it("serves the private manifest to allow-listed users", async () => {
+		allowMockUser();
+		const manifestJson = JSON.stringify({
+			version: 2,
+			catalogId: "jianying-2026-07-31",
+			categories: [],
+		});
+		storageMocks.download.mockResolvedValue({
+			data: new Blob([manifestJson], { type: "application/json" }),
+			error: null,
+		});
+
+		const response = await buildApp().request(manifestUrl);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+		await expect(response.text()).resolves.toBe(manifestJson);
+		expect(storageMocks.download).toHaveBeenCalledWith(
+			"jianying/2026-07-31/manifest.json"
+		);
+	});
+
+	it("forbids the private manifest outside the allowlist", async () => {
+		const response = await buildApp().request(manifestUrl);
+
+		expect(response.status).toBe(403);
+		expect(storageMocks.download).not.toHaveBeenCalled();
+	});
+
+	it("requires authentication for the private manifest", async () => {
+		vi.stubEnv("MOCK_MODE", "false");
+
+		const response = await buildApp().request(manifestUrl);
+
+		expect(response.status).toBe(401);
+		expect(storageMocks.download).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 when the private manifest object is missing", async () => {
+		allowMockUser();
+		storageMocks.download.mockResolvedValue({
+			data: null,
+			error: { message: "Object not found" },
+		});
+
+		const response = await buildApp().request(manifestUrl);
+
+		expect(response.status).toBe(404);
 	});
 });

--- a/qcut/packages/license-server/src/routes/sticker-lab.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.ts
@@ -14,6 +14,15 @@ const STICKER_THUMBNAIL_EDGE_PIXELS = 192;
 const STICKER_THUMBNAIL_QUALITY = 60;
 const STICKER_OBJECT_KEY_PATTERN =
 	/^catalogs\/qcut-original(?:-[a-z0-9]+)+\/assets\/[a-z0-9]+(?:-[a-z0-9]+)*\.(gif|png)$/;
+/**
+ * Harvested third-party reference catalogue. Unlike the public catalogue,
+ * every tier of it — manifest, previews, originals — is restricted to the
+ * allow list; it must never be browsable by ordinary signed-in users.
+ */
+const PRIVATE_REFERENCE_OBJECT_KEY_PATTERN =
+	/^jianying\/[0-9]{4}-[0-9]{2}-[0-9]{2}\/assets\/[0-9]+\.(gif|png)$/;
+const PRIVATE_REFERENCE_MANIFEST_OBJECT_KEY =
+	"jianying/2026-07-31/manifest.json";
 
 function isStickerLabUserAllowed({
 	userId,
@@ -34,6 +43,14 @@ function isStickerLabUserAllowed({
 const stickerLabRoutes = new Hono();
 stickerLabRoutes.use("/*", authMiddleware);
 
+function isPrivateReferenceObjectKey({
+	objectKey,
+}: {
+	objectKey: string;
+}): boolean {
+	return PRIVATE_REFERENCE_OBJECT_KEY_PATTERN.test(objectKey);
+}
+
 stickerLabRoutes.get("/assets", async (c) => {
 	const userId = c.get("userId") as string | undefined;
 	if (!isStickerLabUserAllowed({ userId })) {
@@ -41,7 +58,11 @@ stickerLabRoutes.get("/assets", async (c) => {
 	}
 
 	const objectKey = c.req.query("objectKey");
-	if (!objectKey || !STICKER_OBJECT_KEY_PATTERN.test(objectKey)) {
+	if (
+		!objectKey ||
+		(!STICKER_OBJECT_KEY_PATTERN.test(objectKey) &&
+			!isPrivateReferenceObjectKey({ objectKey }))
+	) {
 		return c.json({ error: "Invalid sticker object key" }, 400);
 	}
 
@@ -49,10 +70,21 @@ stickerLabRoutes.get("/assets", async (c) => {
 });
 
 stickerLabRoutes.get("/thumbnail", async (c) => {
+	const objectKey = c.req.query("objectKey");
+	if (objectKey && isPrivateReferenceObjectKey({ objectKey })) {
+		// The harvested reference catalogue has no public preview tier: even
+		// thumbnails require the allow list. Skip the transform — these are
+		// animated GIFs and the viewer is entitled to the original anyway.
+		const userId = c.get("userId") as string | undefined;
+		if (!isStickerLabUserAllowed({ userId })) {
+			return c.json({ error: "Forbidden" }, 403);
+		}
+		return signStickerObject({ c, objectKey });
+	}
+
 	// Deliberately no allow-list check: previews are what makes the lab
 	// browsable for everyone. The transform is applied server-side, so the
 	// signed URL cannot be edited into a full-resolution download.
-	const objectKey = c.req.query("objectKey");
 	if (!objectKey || !STICKER_OBJECT_KEY_PATTERN.test(objectKey)) {
 		return c.json({ error: "Invalid sticker object key" }, 400);
 	}
@@ -67,6 +99,30 @@ stickerLabRoutes.get("/thumbnail", async (c) => {
 			resize: "contain",
 		},
 	});
+});
+
+stickerLabRoutes.get("/private-manifest", async (c) => {
+	const userId = c.get("userId") as string | undefined;
+	if (!isStickerLabUserAllowed({ userId })) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	try {
+		const { data, error } = await getSupabase()
+			.storage.from(STICKER_BUCKET)
+			.download(PRIVATE_REFERENCE_MANIFEST_OBJECT_KEY);
+		if (error || !data) {
+			return c.json({ error: "Private manifest unavailable" }, 404);
+		}
+		return new Response(await data.arrayBuffer(), {
+			headers: {
+				"Content-Type": "application/json",
+				"Cache-Control": "no-store",
+			},
+		});
+	} catch {
+		return c.json({ error: "Private manifest unavailable" }, 502);
+	}
 });
 
 async function signStickerObject({


### PR DESCRIPTION
## Summary

- restore access to the harvested Jianying reference catalogue (42 categories / 168 preview GIFs, removed from the public lab in `ef470377`) — for allow-listed accounts only
- license server: `/api/sticker-lab/private-manifest` route (allow-list gated, proxies `jianying/2026-07-31/manifest.json` from the private bucket), `jianying/<date>/assets/<id>.gif|png` object keys accepted on `/assets`, and — unlike the public catalogue — **thumbnails of private keys also require the allow list**; previews sign the original without a transform (they are animated GIFs)
- client: a version-2-without-provenance manifest schema with its own byte budgets (animated GIFs, not optimized PNGs), a runtime-gated catalogue switcher in the sticker lab (renders only when the private manifest request succeeds; 403/offline/signed-out stay silent), and private previews go through the IndexedDB-cached original loader so category switches do not re-download megabytes
- cached copies carry honest license metadata: `creator: Jianying (harvested reference)`, `commercialUse: restricted`
- Supabase migration widens the `sticker-lab` bucket mime allow list to accept the manifest JSON (already applied to prod; manifest uploaded; worker deployed as `bfc3c621`)

## Why

The harvest was done for parity study and its 168 objects were already sitting in the private bucket; PR #371 removed it from the *shipped* catalogue for licensing reasons but that also made it unreachable for the two internal allow-listed accounts it was collected for. Every tier (manifest, preview, original) is fail-closed behind `STICKER_LAB_ALLOWED_USER_IDS`; ordinary signed-in users and all release-build users see exactly what they saw before.

## Verification

- `packages/license-server`: 24 route tests (403-before-key-parse ordering, private-key traversal incl. percent-encoding, manifest 404/502 sanitization)
- `apps/web`: manifest schema tests incl. the recovered real manifest budgets; hook tests for entitled/denied; panel tests for the switcher, error isolation, and cached private previews (202 sticker tests green)
- adversarial review workflow (18 agents): no reachable path for non-allow-listed users, regex bypass matrix (traversal/encoding/homoglyphs/anchors) all rejected
- live end-to-end on the production worker: private tab renders the harvested catalogue (红圈 圈重点 etc.), placing one onto the timeline works; non-authenticated requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a private sticker catalog with allow-listed access.
  * Added tabs for switching between public and private sticker catalogs.
  * Added support for private sticker previews, thumbnails, and manifest loading.
  * Adjustment layers are now inserted above media tracks.

* **Bug Fixes**
  * Public catalog errors no longer prevent available private stickers from loading.
  * Improved validation and access controls for private sticker assets.

* **Documentation**
  * Documented private catalog structure, access rules, and asset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also included

- **fix(timeline): insert new adjustment tracks above the topmost media track** — `addTrack` appended adjustment tracks at the bottom of the timeline, where the compositor (which applies an adjustment layer only to tracks below it) wraps nothing and grades nothing. New adjustment tracks now insert directly above the topmost media track, below text/sticker overlays, matching the legacy type-priority order and the Jianying convention. Covered by 5 unit tests plus updated AdjustmentsView tests.