### PR TITLE
fix(security): stop echoing auth middleware exceptions to clients

### DIFF
--- a/qcut/packages/license-server/src/middleware/auth.test.ts
+++ b/qcut/packages/license-server/src/middleware/auth.test.ts
@@ -1,0 +1,79 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+	select: vi.fn(),
+}));
+
+vi.mock("../db/drizzle", () => ({
+	db: {
+		select: dbMocks.select,
+	},
+}));
+
+const { authMiddleware } = await import("./auth");
+
+function buildApp(): Hono {
+	const app = new Hono();
+	app.use("/*", authMiddleware);
+	app.get("/test", (c) => c.json({ ok: true }));
+	return app;
+}
+
+beforeEach(() => {
+	vi.stubEnv("MOCK_MODE", "false");
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+describe("authMiddleware error sanitization", () => {
+	it("never echoes upstream exception text to the client", async () => {
+		// Driver errors can contain hostnames, credentials, or SQL fragments.
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		dbMocks.select.mockImplementation(() => {
+			throw new Error(
+				"connect ECONNREFUSED db-internal.example.com:5432 SUPABASE_SERVICE_KEY=do-not-leak"
+			);
+		});
+
+		const response = await buildApp().request("/test", {
+			headers: { Authorization: "Bearer some-session-token" },
+		});
+		const responseText = await response.text();
+
+		expect(response.status).toBe(500);
+		expect(responseText).toBe('{"error":"Authentication failed"}');
+		expect(responseText).not.toContain("db-internal.example.com");
+		expect(responseText).not.toContain("do-not-leak");
+		// The detail still reaches the server-side log for debugging.
+		expect(consoleError).toHaveBeenCalledWith(
+			"[auth] middleware failed:",
+			expect.objectContaining({
+				message: expect.stringContaining("db-internal.example.com"),
+			})
+		);
+	});
+
+	it("sanitizes non-Error throwables the same way", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		dbMocks.select.mockImplementation(() => {
+			// Some drivers reject with plain objects rather than Error instances.
+			throw { code: "XX000", detail: "internal partition table secret" };
+		});
+
+		const response = await buildApp().request("/test", {
+			headers: { Authorization: "Bearer some-session-token" },
+		});
+		const responseText = await response.text();
+
+		expect(response.status).toBe(500);
+		expect(responseText).toBe('{"error":"Authentication failed"}');
+		expect(responseText).not.toContain("partition table");
+	});
+});

--- a/qcut/packages/license-server/src/middleware/auth.ts
+++ b/qcut/packages/license-server/src/middleware/auth.ts
@@ -60,14 +60,9 @@ export async function authMiddleware(c: Context, next: Next) {
 
 		return c.json({ error: "Invalid token" }, 401);
 	} catch (error) {
-		return c.json(
-			{
-				error:
-					error instanceof Error
-						? `Auth middleware failed: ${error.message}`
-						: "Auth middleware failed",
-			},
-			500
-		);
+		// Driver/connection exceptions can carry hostnames or SQL fragments;
+		// log them server-side but never echo them to the client.
+		console.error("[auth] middleware failed:", error);
+		return c.json({ error: "Authentication failed" }, 500);
 	}
 }


### PR DESCRIPTION
## Summary

- `authMiddleware`'s catch branch returned `Auth middleware failed: ${error.message}` in the 500 body — the DB session query runs inside the try, so driver/connection exception text (hostnames, SQL fragments, potentially credentials embedded in connection errors) could reach any client on any route mounted behind it (sticker-lab, AI proxy, payments, …)
- the response body is now the generic `{"error":"Authentication failed"}`; the original error is logged server-side with `console.error` (visible in `wrangler tail` / Workers logs)
- regression tests mirror the sanitization tests in `sticker-lab.test.ts`: upstream text must not appear in the body, for both `Error` instances and plain-object throwables, while still asserting the detail reaches the server-side log

Found and confirmed pre-existing during the adversarial review of the sticker-lab private reference work (PR #376) on 2026-07-31.

## Verification

- new `packages/license-server/src/middleware/auth.test.ts` (2 tests)
- full license-server suite: 172 passed; Biome and `bun check-types` clean

Note: the production Worker needs a redeploy to pick this up — best done from master once this and #376 are both merged, since the currently deployed Worker (`bfc3c621`) already carries #376's routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)