### PR TITLE
feat(skills): inspect Jianying filter cache packages

### DIFF
--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
@@ -48,6 +48,12 @@ order, cover image, or the `jianying-reference` one-card mtime probe. Never pick
 the first title match silently. If the package is absent, apply that one card in
 a disposable draft to force its download, then rerun the inspector.
 
+A file that cannot be read or parsed is reported in that package's `issues`
+array rather than aborting the run, so a half-downloaded asset never hides the
+packages that did resolve. Treat a non-empty `issues` list as an incomplete
+download: reopen the card in Jianying to finish it and rerun before concluding
+anything about `kind`.
+
 Read [cache-formats.md](references/cache-formats.md) before decoding or replaying
 a package. Cached assets are local interoperability evidence: do not copy LUTs,
 textures, shaders, Lua, or derived tables into the repo or product.

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
@@ -1,25 +1,58 @@
 ---
 name: jianying-filter-parity
-description: Clone a Jianying (剪映) filter look into QCut as a fitted FilterLutRecipe preset — capture references from the Jianying desktop UI, least-squares fit the recipe, register it in the filter catalog, and lock it with parity tests. Use for 剪映滤镜, 滤镜对标, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
+description: Trace a Jianying (剪映) filter from its local resource database to the downloaded package, classify its LUT/shader/segmentation implementation, then reproduce pure color grades in QCut with measured parity. Use for 剪映滤镜, 滤镜对标, 滤镜缓存, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
 argument-hint: <filter-name-or-family>
 ---
 
 # Jianying Filter Parity
 
 QCut filters ("System A", `apps/web/src/lib/filters/`) are procedurally
-generated 17³ LUTs: each preset is a `FilterLutRecipe` (exposure, contrast,
-saturation, temperature, tint, fade, gamma, blackLift, hueShift,
-shadow/highlight tint) fed through `transformFilterColor` in `filter-lut.ts`.
-That function is **pure**, so any external look can be cloned by numerically
-fitting the recipe against a reference before/after image pair. This produced
-PR #347 (8 summer/cinema looks) and PR #373 (30 jy-* presets); typical fit
-quality is 3–8 RMSE/255.
+generated 17³ LUTs: each preset is a `FilterLutRecipe` fed through the pure
+`transformFilterColor` function in `filter-lut.ts`. This model can closely fit
+some global color grades, but it cannot express every Jianying filter. A card
+may instead use a higher-resolution 3D LUT, per-hue behavior, separate skin and
+background LUTs, segmentation, textures, or a multi-pass shader graph.
 
-For filters that are *effect packages* (shaders, textures) rather than pure
-color grades, harvest the package with the `jianying-reference` skill instead
-— this skill covers the LUT-fit path only.
+**Inspect the downloaded package before fitting screenshots.** Package evidence
+defines what the filter actually is; captures verify that the package mapping
+and replay are correct. Only then decide whether a `FilterLutRecipe` is an
+appropriate implementation target.
 
-## Step 0 — Build a calibration chart (do this instead of a photo)
+## Step 0 — Map the card to its local package
+
+Jianying stores UI metadata and packages separately:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+~/Movies/JianyingPro/User Data/Cache/artistEffect/<resource-id>/<md5>/
+~/Movies/JianyingPro/User Data/Cache/effect/<resource-id>/<md5>/
+```
+
+Run the read-only inspector with the exact visible card title:
+
+```bash
+bun .agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts "静谧暗调"
+```
+
+The tool preserves 64-bit IDs as strings, searches both resource databases,
+maps `title → resource ID + md5`, locates packages in both mixed cache roots,
+and classifies common implementations:
+
+- `3d-lut`: a `VF_V` float32 cube plus a sampler3D shader;
+- `skin-segmented-dual-lut`: separate background/skin LUT images and a skin mask;
+- `shader-or-effect-package`: inspect readable shaders, Lua, config, and graph;
+- `unknown`: gather more UI/cache evidence before fitting.
+
+An exact title can return multiple resources. Disambiguate with the UI card
+order, cover image, or the `jianying-reference` one-card mtime probe. Never pick
+the first title match silently. If the package is absent, apply that one card in
+a disposable draft to force its download, then rerun the inspector.
+
+Read [cache-formats.md](references/cache-formats.md) before decoding or replaying
+a package. Cached assets are local interoperability evidence: do not copy LUTs,
+textures, shaders, Lua, or derived tables into the repo or product.
+
+## Step 1 — Build a calibration chart (do this instead of a photo)
 
 Fitting against a photo wastes most samples on one narrow region of color
 space. Generate a **576-patch chart** at the project resolution instead:
@@ -40,7 +73,7 @@ interior ×2, cube edges ×0.5, saturated hues ×0.35. Report a separate
 "natural" RMSE over grays/skin/interior only — that number, not the raw
 fit, is what decides whether a preset ships.
 
-## Step 1 — Capture references from Jianying desktop (macOS)
+## Step 2 — Capture references from Jianying desktop (macOS)
 
 1. Add the filter as a **track segment** via the hover "+" button on the
    filter card. This is the only trustworthy path: segment intensity is
@@ -61,7 +94,7 @@ fit, is what decides whether a preset ships.
 - Both captures go through the same display transform, so it cancels in the
   fit; captured pairs differ from true video frames by only ~2–3/255.
 
-## Step 2 — Fit the recipe
+## Step 3 — Fit the recipe
 
 Build a one-off bun harness (they have always been ad-hoc; keep it out of
 the repo):
@@ -72,7 +105,7 @@ the repo):
 2. Load both captures, sample a few thousand pixel-aligned (original,
    filtered) pairs.
 3. Optimize the recipe parameters with random-restart + coordinate descent
-   minimizing RGB RMSE. Accept at ≤8 RMSE/255; the best fits land near 3.
+   minimizing RGB RMSE. Report both weighted and natural-color RMSE.
 4. **Do not hand-"fix" fitted values afterwards.** Outliers like
    `contrast: 2.82` or `gamma: 2.26` are legitimate fit results;
    `buildFilterCube` output is verified bounded by the catalog test.
@@ -84,8 +117,16 @@ the repo):
    keeps the catalogue honest. Rules of thumb: ≤12 natural RMSE is a close
    clone, 12–20 is a recognizable interpretation, >25 means the look needs
    machinery QCut does not have — drop it rather than shipping a stand-in.
+6. Compare the fit against the **package replay**, not only the screenshot.
+   A package replay that differs from the Jianying capture by >8 natural RMSE
+   usually means the resource mapping, sampler coordinates, intensity, or
+   segmented path is wrong. Fix that evidence chain before judging QCut.
 
-## Step 3 — Register the preset
+For skin-segmented dual-LUT packages, a calibration chart validates only the
+background path. Capture a common face clip to measure the skin path. Do not
+claim full parity from a chart-only fit.
+
+## Step 4 — Register the preset
 
 Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
 
@@ -102,7 +143,7 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   `EXPECTED_LOCALIZED_NAMES` order and per-family counts are a deliberate
   catalog snapshot — extend them, don't loosen them.
 
-## Step 4 — Thumbnails and verification
+## Step 5 — Thumbnails and verification
 
 - Generate the `/images/filter-previews/jy-*.webp` thumbnail with the
   existing generator. It needs the `packages/nexusai-website` showcase assets
@@ -115,13 +156,19 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   presets but needs a real ffmpeg at
   `electron/resources/ffmpeg/darwin-arm64/ffmpeg` (not in git — symlink in
   worktrees, remove before committing).
-- Frame-verify at least one preset visually against the Jianying reference
-  (side-by-side crop) before opening the PR.
+- Frame-verify every new preset against the same input at 100% intensity.
+  Produce a labeled side-by-side image with Jianying/package replay on the left
+  and QCut on the right, and record package-replay, natural, and all-chart RMSE.
+- Keep raw cache assets and captured frames in a scratch directory outside the
+  worktree. Comparison screenshots are acceptable evidence; proprietary package
+  contents are not.
 
 ## Related
 
 - `jianying-reference` — package harvesting + stepped-frame capture for
   non-LUT effects (text animations, transitions, shader filters, stickers).
+- `scripts/inspect-filter-cache.ts` — exact-title database mapping and safe
+  package classification without copying package contents.
 - PR #373 shows the salvage pattern: presets carry fitted recipes as pure
   data, so they can be lifted from an abandoned branch with zero mechanism
   changes.

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
@@ -1,0 +1,120 @@
+# Jianying Filter Cache Formats
+
+Use package contents as implementation evidence and UI captures as visual
+ground truth. A title match alone does not prove that the package belongs to
+the selected card because Jianying can expose multiple resources with the same
+display name.
+
+## Resource database mapping
+
+The resource databases live under:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+```
+
+Recent versions keep filter cards in JSON responses inside `http_cache` as well
+as normalized rows in `effect`. Important fields are:
+
+- `common_attr.title`: visible card name;
+- `common_attr.id` / `effect_id`: primary package directory candidate;
+- `common_attr.third_resource_id_str`: alternate engine resource ID;
+- `common_attr.md5`: package version directory;
+- `common_attr.requirements` and `sdk_model`: runtime dependencies;
+- `common_attr.publish_source`: useful when duplicate titles exist.
+
+Keep all resource IDs as strings. Values routinely exceed JavaScript's safe
+integer range.
+
+## Package roots
+
+Both roots are mixed containers and must be checked:
+
+```text
+Cache/artistEffect/<id>/<md5>/
+Cache/effect/<id>/<md5>/
+```
+
+Try the primary ID, effect ID, and third resource ID. Prefer an exact
+`<id>/<md5>` match. If the exact version is missing, do not silently inspect a
+different hash; apply one card in the UI and repeat the mapping.
+
+## VF_V 3D LUT
+
+Common pure color grades contain:
+
+```text
+AmazingFeature/texture/filter.cube.vf
+AmazingFeature/shaders/.../*.frag
+AmazingFeature/lua/SeekModeScript.lua
+```
+
+`filter.cube.vf` has a 10-byte little-endian header:
+
+| Offset | Bytes | Meaning |
+|---:|---:|---|
+| 0 | 4 | ASCII `VF_V` |
+| 4 | 2 | width |
+| 6 | 2 | height |
+| 8 | 2 | depth |
+
+The payload is `width × height × depth × 3` little-endian float32 values. The
+observed ordering is red/X fastest, then green/Y, then blue/Z. Validate the
+payload length before reading values. Dimensions such as 17³ and 32³ are both
+used.
+
+Read the compiled fragment shader to confirm semantics. A typical pure grade
+samples `sampler3D` with the source RGB and mixes the result with the original
+using the intensity uniform. In those packages, `SeekModeScript.lua` merely
+forwards the intensity event and contains no color math.
+
+When replaying a sampler3D shader on CPU, reproduce normalized texture sampling
+and edge clamping. Compare that replay with the captured Jianying chart. A low
+replay-to-capture error validates the package mapping and decoder before QCut is
+evaluated.
+
+## Skin-segmented dual LUT
+
+Signals include:
+
+```text
+SkinFilter/image/filter_bg.png
+SkinFilter/image/filter_skin.png
+SkinFilter/algorithmConfig.json
+SkinFilter/shaders/.../*.frag
+requirements: skin_seg
+sdk_model: tt_skin_seg
+```
+
+The observed LUT images are 512×512 atlases containing a 64³ cube as 8×8 blue
+slices. The shader samples background and skin LUTs separately, then mixes them
+with the alpha channel of the segmentation mask. Read the shader for exact tile
+coordinates, slice interpolation, mask orientation, and intensity behavior.
+
+A color chart has no skin region, so it verifies only the background LUT. Use a
+common face clip for parity claims. A single global QCut LUT cannot reproduce
+this architecture on both skin and background.
+
+## Shader or effect package
+
+If there is no recognized LUT but the package contains shaders, textures,
+passes, models, or algorithm nodes, switch to the `jianying-reference` workflow.
+Inspect readable compiled shaders and Lua, capture stepped visual evidence, and
+identify the missing QCut runtime capability before implementing an
+approximation.
+
+## Evidence and ownership
+
+Record outside the worktree:
+
+- exact card title and category;
+- resource ID, md5, database row timestamp, and package path;
+- why duplicate-title candidates were rejected;
+- package classification and runtime dependencies;
+- package replay vs Jianying screenshot RMSE;
+- QCut vs package replay RMSE for natural colors and the full chart;
+- labeled left/right comparison images.
+
+Do not commit cached LUT values, textures, Lua, compiled shaders, package dumps,
+or derived lookup tables. Transcribe behavior into QCut-owned math and prose;
+comparison screenshots may be retained as review evidence only when needed.

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
@@ -100,6 +100,48 @@ describe("inspect-filter-cache", () => {
 		}
 	});
 
+	test("reports malformed assets as issues instead of aborting the scan", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-partial-")
+		);
+		try {
+			mkdirSync(path.join(temporaryRoot, "Partial/texture"), {
+				recursive: true,
+			});
+			mkdirSync(path.join(temporaryRoot, "Partial/image"), { recursive: true });
+			// A download interrupted mid-write: valid header, truncated payload.
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/truncated.cube.vf"),
+				createVfCube({ size: 17 }).subarray(0, 100)
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/image/filter_bg.png"),
+				Buffer.alloc(24)
+			);
+
+			const inspected = inspectPackage({ packageRoot: temporaryRoot });
+
+			// The intact cube is still classified and returned.
+			expect(inspected.kind).toBe("3d-lut");
+			expect(inspected.cubes).toHaveLength(1);
+			expect(inspected.cubes[0]?.path).toBe("Partial/texture/filter.cube.vf");
+			// Both bad files are surfaced as evidence, keyed by relative path.
+			expect(inspected.issues).toHaveLength(2);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/texture/truncated.cube.vf: Invalid VF payload length"
+			);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/image/filter_bg.png: Unsupported PNG texture"
+			);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
 	test("maps exact HTTP-cache titles without losing 64-bit resource IDs", () => {
 		const temporaryRoot = mkdtempSync(
 			path.join(os.tmpdir(), "qcut-filter-db-")

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
@@ -1,11 +1,6 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import {
-	mkdtempSync,
-	mkdirSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -49,15 +44,21 @@ describe("inspect-filter-cache", () => {
 
 	test("parses PNG LUT dimensions", () => {
 		expect(
-			parsePngDimensions({ buffer: createPngHeader({ width: 512, height: 512 }) })
+			parsePngDimensions({
+				buffer: createPngHeader({ width: 512, height: 512 }),
+			})
 		).toEqual({ width: 512, height: 512 });
 	});
 
 	test("classifies float cube and skin-segmented dual-LUT packages", () => {
-		const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "qcut-filter-cache-"));
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-cache-")
+		);
 		try {
 			const cubeRoot = path.join(temporaryRoot, "cube");
-			mkdirSync(path.join(cubeRoot, "AmazingFeature/texture"), { recursive: true });
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/texture"), {
+				recursive: true,
+			});
 			mkdirSync(path.join(cubeRoot, "AmazingFeature/lua"), { recursive: true });
 			writeFileSync(
 				path.join(cubeRoot, "AmazingFeature/texture/filter.cube.vf"),
@@ -100,7 +101,9 @@ describe("inspect-filter-cache", () => {
 	});
 
 	test("maps exact HTTP-cache titles without losing 64-bit resource IDs", () => {
-		const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "qcut-filter-db-"));
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-db-")
+		);
 		try {
 			const databasePath = path.join(temporaryRoot, "rp.db");
 			const database = new Database(databasePath);
@@ -128,7 +131,9 @@ describe("inspect-filter-cache", () => {
 				},
 			});
 			database
-				.query("INSERT INTO http_cache (response_body, timestamp) VALUES (?, ?)")
+				.query(
+					"INSERT INTO http_cache (response_body, timestamp) VALUES (?, ?)"
+				)
 				.run(responseBody, "2026-08-01 12:00:00");
 			database.close();
 

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
@@ -1,0 +1,149 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import {
+	mkdtempSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	findFilterRecords,
+	inspectPackage,
+	parsePngDimensions,
+	parseVfHeader,
+} from "./inspect-filter-cache";
+
+function createVfCube({ size }: { size: number }) {
+	const buffer = Buffer.alloc(10 + size ** 3 * 3 * 4);
+	buffer.write("VF_V", 0, "ascii");
+	buffer.writeUInt16LE(size, 4);
+	buffer.writeUInt16LE(size, 6);
+	buffer.writeUInt16LE(size, 8);
+	return buffer;
+}
+
+function createPngHeader({ width, height }: { width: number; height: number }) {
+	const buffer = Buffer.alloc(24);
+	Buffer.from("89504e470d0a1a0a", "hex").copy(buffer, 0);
+	buffer.write("IHDR", 12, "ascii");
+	buffer.writeUInt32BE(width, 16);
+	buffer.writeUInt32BE(height, 20);
+	return buffer;
+}
+
+describe("inspect-filter-cache", () => {
+	test("parses VF_V float cube dimensions and validates payload length", () => {
+		expect(parseVfHeader({ buffer: createVfCube({ size: 17 }) })).toEqual({
+			width: 17,
+			height: 17,
+			depth: 17,
+			channels: 3,
+			valueType: "float32-le",
+		});
+		expect(() =>
+			parseVfHeader({ buffer: createVfCube({ size: 17 }).subarray(0, 100) })
+		).toThrow("Invalid VF payload length");
+	});
+
+	test("parses PNG LUT dimensions", () => {
+		expect(
+			parsePngDimensions({ buffer: createPngHeader({ width: 512, height: 512 }) })
+		).toEqual({ width: 512, height: 512 });
+	});
+
+	test("classifies float cube and skin-segmented dual-LUT packages", () => {
+		const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "qcut-filter-cache-"));
+		try {
+			const cubeRoot = path.join(temporaryRoot, "cube");
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/texture"), { recursive: true });
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/lua"), { recursive: true });
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/texture/filter.cube.vf"),
+				createVfCube({ size: 32 })
+			);
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/lua/SeekModeScript.lua"),
+				"return {}"
+			);
+			const cubePackage = inspectPackage({ packageRoot: cubeRoot });
+			expect(cubePackage.kind).toBe("3d-lut");
+			expect(cubePackage.cubes[0]).toMatchObject({
+				width: 32,
+				height: 32,
+				depth: 32,
+			});
+			expect(cubePackage.luaFiles).toEqual([
+				"AmazingFeature/lua/SeekModeScript.lua",
+			]);
+
+			const skinRoot = path.join(temporaryRoot, "skin");
+			mkdirSync(path.join(skinRoot, "SkinFilter/image"), { recursive: true });
+			mkdirSync(path.join(skinRoot, "SkinFilter/texture"), { recursive: true });
+			for (const name of ["filter_bg.png", "filter_skin.png"]) {
+				writeFileSync(
+					path.join(skinRoot, "SkinFilter/image", name),
+					createPngHeader({ width: 512, height: 512 })
+				);
+			}
+			writeFileSync(
+				path.join(skinRoot, "SkinFilter/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			const skinPackage = inspectPackage({ packageRoot: skinRoot });
+			expect(skinPackage.kind).toBe("skin-segmented-dual-lut");
+			expect(skinPackage.imageLuts).toHaveLength(2);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("maps exact HTTP-cache titles without losing 64-bit resource IDs", () => {
+		const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "qcut-filter-db-"));
+		try {
+			const databasePath = path.join(temporaryRoot, "rp.db");
+			const database = new Database(databasePath);
+			database.exec(`
+				CREATE TABLE http_cache (
+					id INTEGER PRIMARY KEY,
+					response_body TEXT NOT NULL,
+					timestamp TEXT
+				)
+			`);
+			const responseBody = JSON.stringify({
+				data: {
+					effect_item_list: [
+						{
+							common_attr: {
+								title: "静谧暗调",
+								id: "7630501558370733321",
+								effect_id: "7630501558370733321",
+								md5: "32893a4130581511f99ca8d1db4b258a",
+								publish_source: "user_post",
+								requirements: ["blit"],
+							},
+						},
+					],
+				},
+			});
+			database
+				.query("INSERT INTO http_cache (response_body, timestamp) VALUES (?, ?)")
+				.run(responseBody, "2026-08-01 12:00:00");
+			database.close();
+
+			const records = findFilterRecords({
+				databasePaths: [databasePath],
+				title: "静谧暗调",
+			});
+			expect(records).toHaveLength(1);
+			expect(records[0]).toMatchObject({
+				title: "静谧暗调",
+				id: "7630501558370733321",
+				md5: "32893a4130581511f99ca8d1db4b258a",
+			});
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
@@ -54,6 +54,12 @@ interface InspectedPackage {
 	luaFiles: string[];
 	shaderFiles: string[];
 	configFiles: string[];
+	/**
+	 * Per-file read/parse failures. A partially downloaded package is the exact
+	 * state this tool exists to diagnose, so a malformed asset is reported as
+	 * evidence rather than aborting the scan.
+	 */
+	issues: string[];
 }
 
 const DEFAULT_CACHE_ROOT = path.join(
@@ -277,6 +283,16 @@ function listPackageFiles({ packageRoot }: { packageRoot: string }): string[] {
 	return relativeFiles.sort();
 }
 
+function describeIssue({
+	relativePath,
+	error,
+}: {
+	relativePath: string;
+	error: unknown;
+}): string {
+	return `${relativePath}: ${error instanceof Error ? error.message : String(error)}`;
+}
+
 export function inspectPackage({
 	packageRoot,
 }: {
@@ -288,30 +304,39 @@ export function inspectPackage({
 	const luaFiles: string[] = [];
 	const shaderFiles: string[] = [];
 	const configFiles: string[] = [];
+	const issues: string[] = [];
 
 	for (const relativePath of relativeFiles) {
 		const absolutePath = path.join(packageRoot, relativePath);
 		const lowerPath = relativePath.toLowerCase();
 		if (lowerPath.endsWith(".cube.vf")) {
-			cubes.push({
-				path: relativePath,
-				...parseVfHeader({
-					buffer: readFileSync(absolutePath),
-					filePath: absolutePath,
-				}),
-			});
+			try {
+				cubes.push({
+					path: relativePath,
+					...parseVfHeader({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
 		}
 		if (
 			lowerPath.endsWith("filter_bg.png") ||
 			lowerPath.endsWith("filter_skin.png")
 		) {
-			imageLuts.push({
-				path: relativePath,
-				...parsePngDimensions({
-					buffer: readFileSync(absolutePath),
-					filePath: absolutePath,
-				}),
-			});
+			try {
+				imageLuts.push({
+					path: relativePath,
+					...parsePngDimensions({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
 		}
 		if (lowerPath.endsWith(".lua")) luaFiles.push(relativePath);
 		if (
@@ -351,6 +376,7 @@ export function inspectPackage({
 		luaFiles,
 		shaderFiles,
 		configFiles,
+		issues,
 	};
 }
 
@@ -459,6 +485,13 @@ function runCli() {
 					...(matches.some(({ packages }) => packages.length === 0)
 						? [
 								"At least one matching resource is not downloaded in artistEffect/effect.",
+							]
+						: []),
+					...(matches.some(({ packages }) =>
+						packages.some(({ issues }) => issues.length > 0)
+					)
+						? [
+								"At least one package asset could not be read or parsed; see package issues. A partial download is the usual cause — reopen the card in Jianying to finish it, then rerun.",
 							]
 						: []),
 				],

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
@@ -1,0 +1,466 @@
+#!/usr/bin/env bun
+
+import { Database } from "bun:sqlite";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+interface FilterCacheRecord {
+	title: string;
+	id: string;
+	effectId: string;
+	thirdResourceId: string;
+	md5: string;
+	publishSource: string;
+	requirements: string;
+	sdkModel: string;
+	databasePath: string;
+	timestamp: string;
+}
+
+interface RawFilterCacheRecord {
+	title: string | null;
+	id: string | null;
+	effectId: string | null;
+	thirdResourceId: string | null;
+	md5: string | null;
+	publishSource: string | null;
+	requirements: string | null;
+	sdkModel: string | null;
+	timestamp: string | null;
+}
+
+interface InspectedPackage {
+	packageRoot: string;
+	kind:
+		| "3d-lut"
+		| "skin-segmented-dual-lut"
+		| "shader-or-effect-package"
+		| "unknown";
+	cubes: Array<{
+		path: string;
+		width: number;
+		height: number;
+		depth: number;
+		channels: number;
+		valueType: "float32-le";
+	}>;
+	imageLuts: Array<{
+		path: string;
+		width: number;
+		height: number;
+	}>;
+	luaFiles: string[];
+	shaderFiles: string[];
+	configFiles: string[];
+}
+
+const DEFAULT_CACHE_ROOT = path.join(
+	os.homedir(),
+	"Movies/JianyingPro/User Data/Cache"
+);
+
+function normalizeRecord({
+	record,
+	databasePath,
+}: {
+	record: RawFilterCacheRecord;
+	databasePath: string;
+}): FilterCacheRecord | null {
+	if (!(record.title && record.id && record.md5)) return null;
+	return {
+		title: record.title,
+		id: record.id,
+		effectId: record.effectId ?? "",
+		thirdResourceId: record.thirdResourceId ?? "",
+		md5: record.md5,
+		publishSource: record.publishSource ?? "",
+		requirements: record.requirements ?? "",
+		sdkModel: record.sdkModel ?? "",
+		databasePath,
+		timestamp: record.timestamp ?? "",
+	};
+}
+
+function tableExists({ database, table }: { database: Database; table: string }) {
+	const result = database
+		.query<{ present: number }, [string]>(
+			"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?) AS present"
+		)
+		.get(table);
+	return result?.present === 1;
+}
+
+function queryHttpCache({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "http_cache" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string]>(`
+			SELECT
+				CAST(json_extract(item.value, '$.common_attr.title') AS TEXT) AS title,
+				CAST(json_extract(item.value, '$.common_attr.id') AS TEXT) AS id,
+				CAST(json_extract(item.value, '$.common_attr.effect_id') AS TEXT) AS effectId,
+				COALESCE(
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id_str') AS TEXT),
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id') AS TEXT)
+				) AS thirdResourceId,
+				CAST(json_extract(item.value, '$.common_attr.md5') AS TEXT) AS md5,
+				CAST(json_extract(item.value, '$.common_attr.publish_source') AS TEXT) AS publishSource,
+				CAST(json_extract(item.value, '$.common_attr.requirements') AS TEXT) AS requirements,
+				CAST(json_extract(item.value, '$.common_attr.sdk_model') AS TEXT) AS sdkModel,
+				CAST(cache.timestamp AS TEXT) AS timestamp
+			FROM http_cache AS cache,
+				json_each(
+					CASE WHEN json_valid(cache.response_body) THEN cache.response_body ELSE '{}' END,
+					'$.data.effect_item_list'
+				) AS item
+			WHERE json_extract(item.value, '$.common_attr.title') = ?
+		`)
+		.all(title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function queryEffectTable({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "effect" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string, string]>(`
+			SELECT
+				CAST(COALESCE(title, name) AS TEXT) AS title,
+				CAST(id AS TEXT) AS id,
+				CAST(effect_id AS TEXT) AS effectId,
+				CAST(third_resource_id AS TEXT) AS thirdResourceId,
+				CAST(md5 AS TEXT) AS md5,
+				CAST(publish_source AS TEXT) AS publishSource,
+				CAST(requirements AS TEXT) AS requirements,
+				CAST(sdk_model AS TEXT) AS sdkModel,
+				CAST(_request_time AS TEXT) AS timestamp
+			FROM effect
+			WHERE title = ? OR name = ?
+		`)
+		.all(title, title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function deduplicateRecords({
+	records,
+}: {
+	records: FilterCacheRecord[];
+}): FilterCacheRecord[] {
+	const byResource = new Map<string, FilterCacheRecord>();
+	for (const record of records) {
+		const key = `${record.id}:${record.md5}`;
+		const current = byResource.get(key);
+		if (!current || record.timestamp > current.timestamp) {
+			byResource.set(key, record);
+		}
+	}
+	return [...byResource.values()].sort((left, right) =>
+		left.id.localeCompare(right.id)
+	);
+}
+
+export function findFilterRecords({
+	databasePaths,
+	title,
+}: {
+	databasePaths: string[];
+	title: string;
+}): FilterCacheRecord[] {
+	const records: FilterCacheRecord[] = [];
+	for (const databasePath of databasePaths) {
+		const database = new Database(databasePath, { readonly: true });
+		try {
+			records.push(
+				...queryHttpCache({ database, databasePath, title }),
+				...queryEffectTable({ database, databasePath, title })
+			);
+		} finally {
+			database.close();
+		}
+	}
+	return deduplicateRecords({ records });
+}
+
+export function parseVfHeader({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	if (buffer.length < 10 || buffer.toString("ascii", 0, 4) !== "VF_V") {
+		throw new Error(`Unsupported VF texture: ${filePath}`);
+	}
+	const width = buffer.readUInt16LE(4);
+	const height = buffer.readUInt16LE(6);
+	const depth = buffer.readUInt16LE(8);
+	const channels = 3;
+	const expectedBytes = 10 + width * height * depth * channels * 4;
+	if (buffer.length !== expectedBytes) {
+		throw new Error(
+			`Invalid VF payload length for ${filePath}: expected ${expectedBytes}, got ${buffer.length}`
+		);
+	}
+	return { width, height, depth, channels, valueType: "float32-le" as const };
+}
+
+export function parsePngDimensions({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	const signature = "89504e470d0a1a0a";
+	if (
+		buffer.length < 24 ||
+		buffer.subarray(0, 8).toString("hex") !== signature ||
+		buffer.subarray(12, 16).toString("ascii") !== "IHDR"
+	) {
+		throw new Error(`Unsupported PNG texture: ${filePath}`);
+	}
+	return {
+		width: buffer.readUInt32BE(16),
+		height: buffer.readUInt32BE(20),
+	};
+}
+
+function listPackageFiles({ packageRoot }: { packageRoot: string }): string[] {
+	const relativeFiles: string[] = [];
+	const pending = [packageRoot];
+	while (pending.length > 0) {
+		const current = pending.pop();
+		if (!current) continue;
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const absolutePath = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				pending.push(absolutePath);
+				continue;
+			}
+			if (entry.isFile()) {
+				relativeFiles.push(path.relative(packageRoot, absolutePath));
+			}
+		}
+	}
+	return relativeFiles.sort();
+}
+
+export function inspectPackage({
+	packageRoot,
+}: {
+	packageRoot: string;
+}): InspectedPackage {
+	const relativeFiles = listPackageFiles({ packageRoot });
+	const cubes: InspectedPackage["cubes"] = [];
+	const imageLuts: InspectedPackage["imageLuts"] = [];
+	const luaFiles: string[] = [];
+	const shaderFiles: string[] = [];
+	const configFiles: string[] = [];
+
+	for (const relativePath of relativeFiles) {
+		const absolutePath = path.join(packageRoot, relativePath);
+		const lowerPath = relativePath.toLowerCase();
+		if (lowerPath.endsWith(".cube.vf")) {
+			cubes.push({
+				path: relativePath,
+				...parseVfHeader({
+					buffer: readFileSync(absolutePath),
+					filePath: absolutePath,
+				}),
+			});
+		}
+		if (
+			lowerPath.endsWith("filter_bg.png") ||
+			lowerPath.endsWith("filter_skin.png")
+		) {
+			imageLuts.push({
+				path: relativePath,
+				...parsePngDimensions({
+					buffer: readFileSync(absolutePath),
+					filePath: absolutePath,
+				}),
+			});
+		}
+		if (lowerPath.endsWith(".lua")) luaFiles.push(relativePath);
+		if (
+			lowerPath.endsWith(".frag") ||
+			lowerPath.endsWith(".vert") ||
+			lowerPath.endsWith(".xshader")
+		) {
+			shaderFiles.push(relativePath);
+		}
+		if (
+			lowerPath.endsWith("config.json") ||
+			lowerPath.endsWith("content.json") ||
+			lowerPath.endsWith(".material")
+		) {
+			configFiles.push(relativePath);
+		}
+	}
+
+	const hasBackgroundLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_bg.png")
+	);
+	const hasSkinLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_skin.png")
+	);
+	let kind: InspectedPackage["kind"] = "unknown";
+	if (cubes.length > 0) kind = "3d-lut";
+	if (hasBackgroundLut && hasSkinLut) kind = "skin-segmented-dual-lut";
+	if (kind === "unknown" && shaderFiles.length > 0) {
+		kind = "shader-or-effect-package";
+	}
+
+	return {
+		packageRoot,
+		kind,
+		cubes,
+		imageLuts,
+		luaFiles,
+		shaderFiles,
+		configFiles,
+	};
+}
+
+function findDatabasePaths({ cacheRoot }: { cacheRoot: string }): string[] {
+	const databaseRoot = path.join(cacheRoot, "ressdk_db");
+	if (!existsSync(databaseRoot)) return [];
+	const databasePaths: string[] = [];
+	for (const entry of readdirSync(databaseRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const databasePath = path.join(databaseRoot, entry.name, "rp.db");
+		if (existsSync(databasePath) && statSync(databasePath).isFile()) {
+			databasePaths.push(databasePath);
+		}
+	}
+	return databasePaths.sort();
+}
+
+function findPackageRoots({
+	cacheRoot,
+	record,
+}: {
+	cacheRoot: string;
+	record: FilterCacheRecord;
+}): string[] {
+	const identifiers = new Set(
+		[record.id, record.effectId, record.thirdResourceId].filter(Boolean)
+	);
+	const packageRoots: string[] = [];
+	for (const containerName of ["artistEffect", "effect"]) {
+		for (const identifier of identifiers) {
+			const exactPath = path.join(
+				cacheRoot,
+				containerName,
+				identifier,
+				record.md5
+			);
+			if (existsSync(exactPath) && statSync(exactPath).isDirectory()) {
+				packageRoots.push(exactPath);
+			}
+		}
+	}
+	return [...new Set(packageRoots)].sort();
+}
+
+function printUsage() {
+	console.log(`Usage:
+  bun inspect-filter-cache.ts [--cache-root <path>] <exact-filter-title>
+
+Examples:
+  bun inspect-filter-cache.ts 静谧暗调
+  bun inspect-filter-cache.ts --cache-root "$HOME/Movies/JianyingPro/User Data/Cache" 黑金`);
+}
+
+function runCli() {
+	const { values, positionals } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			"cache-root": { type: "string" },
+			help: { type: "boolean", short: "h" },
+		},
+		allowPositionals: true,
+		strict: true,
+	});
+	if (values.help) {
+		printUsage();
+		return;
+	}
+	const title = positionals.join(" ").trim();
+	if (!title) {
+		printUsage();
+		throw new Error("An exact Jianying filter title is required");
+	}
+	const cacheRoot = path.resolve(values["cache-root"] ?? DEFAULT_CACHE_ROOT);
+	const databasePaths = findDatabasePaths({ cacheRoot });
+	if (databasePaths.length === 0) {
+		throw new Error(`No ressdk_db/*/rp.db files found under ${cacheRoot}`);
+	}
+	const records = findFilterRecords({ databasePaths, title });
+	const matches = records.map((record) => {
+		const packageRoots = findPackageRoots({ cacheRoot, record });
+		return {
+			...record,
+			packages: packageRoots.map((packageRoot) =>
+				inspectPackage({ packageRoot })
+			),
+		};
+	});
+	console.log(
+		JSON.stringify(
+			{
+				title,
+				cacheRoot,
+				databasePaths,
+				matches,
+				warnings: [
+					...(matches.length === 0
+						? ["No exact title match was found in the local resource databases."]
+						: []),
+					...(matches.length > 1
+						? ["Multiple resources share this title; disambiguate with UI order or an mtime probe."]
+						: []),
+					...(matches.some(({ packages }) => packages.length === 0)
+						? ["At least one matching resource is not downloaded in artistEffect/effect."]
+						: []),
+				],
+			},
+			null,
+			2
+		)
+	);
+	if (matches.length === 0) process.exitCode = 2;
+}
+
+if (import.meta.main) runCli();

--- a/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
+++ b/qcut/.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
@@ -1,12 +1,7 @@
 #!/usr/bin/env bun
 
 import { Database } from "bun:sqlite";
-import {
-	existsSync,
-	readdirSync,
-	readFileSync,
-	statSync,
-} from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
@@ -88,7 +83,13 @@ function normalizeRecord({
 	};
 }
 
-function tableExists({ database, table }: { database: Database; table: string }) {
+function tableExists({
+	database,
+	table,
+}: {
+	database: Database;
+	table: string;
+}) {
 	const result = database
 		.query<{ present: number }, [string]>(
 			"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?) AS present"
@@ -446,13 +447,19 @@ function runCli() {
 				matches,
 				warnings: [
 					...(matches.length === 0
-						? ["No exact title match was found in the local resource databases."]
+						? [
+								"No exact title match was found in the local resource databases.",
+							]
 						: []),
 					...(matches.length > 1
-						? ["Multiple resources share this title; disambiguate with UI order or an mtime probe."]
+						? [
+								"Multiple resources share this title; disambiguate with UI order or an mtime probe.",
+							]
 						: []),
 					...(matches.some(({ packages }) => packages.length === 0)
-						? ["At least one matching resource is not downloaded in artistEffect/effect."]
+						? [
+								"At least one matching resource is not downloaded in artistEffect/effect.",
+							]
 						: []),
 				],
 			},

--- a/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
+++ b/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/SKILL.md
@@ -1,25 +1,64 @@
 ---
 name: jianying-filter-parity
-description: Clone a Jianying (剪映) filter look into QCut as a fitted FilterLutRecipe preset — capture references from the Jianying desktop UI, least-squares fit the recipe, register it in the filter catalog, and lock it with parity tests. Use for 剪映滤镜, 滤镜对标, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
+description: Trace a Jianying (剪映) filter from its local resource database to the downloaded package, classify its LUT/shader/segmentation implementation, then reproduce pure color grades in QCut with measured parity. Use for 剪映滤镜, 滤镜对标, 滤镜缓存, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
 argument-hint: <filter-name-or-family>
 ---
 
 # Jianying Filter Parity
 
 QCut filters ("System A", `apps/web/src/lib/filters/`) are procedurally
-generated 17³ LUTs: each preset is a `FilterLutRecipe` (exposure, contrast,
-saturation, temperature, tint, fade, gamma, blackLift, hueShift,
-shadow/highlight tint) fed through `transformFilterColor` in `filter-lut.ts`.
-That function is **pure**, so any external look can be cloned by numerically
-fitting the recipe against a reference before/after image pair. This produced
-PR #347 (8 summer/cinema looks) and PR #373 (30 jy-* presets); typical fit
-quality is 3–8 RMSE/255.
+generated 17³ LUTs: each preset is a `FilterLutRecipe` fed through the pure
+`transformFilterColor` function in `filter-lut.ts`. This model can closely fit
+some global color grades, but it cannot express every Jianying filter. A card
+may instead use a higher-resolution 3D LUT, per-hue behavior, separate skin and
+background LUTs, segmentation, textures, or a multi-pass shader graph.
 
-For filters that are *effect packages* (shaders, textures) rather than pure
-color grades, harvest the package with the `jianying-reference` skill instead
-— this skill covers the LUT-fit path only.
+**Inspect the downloaded package before fitting screenshots.** Package evidence
+defines what the filter actually is; captures verify that the package mapping
+and replay are correct. Only then decide whether a `FilterLutRecipe` is an
+appropriate implementation target.
 
-## Step 0 — Build a calibration chart (do this instead of a photo)
+## Step 0 — Map the card to its local package
+
+Jianying stores UI metadata and packages separately:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+~/Movies/JianyingPro/User Data/Cache/artistEffect/<resource-id>/<md5>/
+~/Movies/JianyingPro/User Data/Cache/effect/<resource-id>/<md5>/
+```
+
+Run the read-only inspector with the exact visible card title:
+
+```bash
+bun .agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts "静谧暗调"
+```
+
+The tool preserves 64-bit IDs as strings, searches both resource databases,
+maps `title → resource ID + md5`, locates packages in both mixed cache roots,
+and classifies common implementations:
+
+- `3d-lut`: a `VF_V` float32 cube plus a sampler3D shader;
+- `skin-segmented-dual-lut`: separate background/skin LUT images and a skin mask;
+- `shader-or-effect-package`: inspect readable shaders, Lua, config, and graph;
+- `unknown`: gather more UI/cache evidence before fitting.
+
+An exact title can return multiple resources. Disambiguate with the UI card
+order, cover image, or the `jianying-reference` one-card mtime probe. Never pick
+the first title match silently. If the package is absent, apply that one card in
+a disposable draft to force its download, then rerun the inspector.
+
+A file that cannot be read or parsed is reported in that package's `issues`
+array rather than aborting the run, so a half-downloaded asset never hides the
+packages that did resolve. Treat a non-empty `issues` list as an incomplete
+download: reopen the card in Jianying to finish it and rerun before concluding
+anything about `kind`.
+
+Read [cache-formats.md](references/cache-formats.md) before decoding or replaying
+a package. Cached assets are local interoperability evidence: do not copy LUTs,
+textures, shaders, Lua, or derived tables into the repo or product.
+
+## Step 1 — Build a calibration chart (do this instead of a photo)
 
 Fitting against a photo wastes most samples on one narrow region of color
 space. Generate a **576-patch chart** at the project resolution instead:
@@ -40,7 +79,7 @@ interior ×2, cube edges ×0.5, saturated hues ×0.35. Report a separate
 "natural" RMSE over grays/skin/interior only — that number, not the raw
 fit, is what decides whether a preset ships.
 
-## Step 1 — Capture references from Jianying desktop (macOS)
+## Step 2 — Capture references from Jianying desktop (macOS)
 
 1. Add the filter as a **track segment** via the hover "+" button on the
    filter card. This is the only trustworthy path: segment intensity is
@@ -61,7 +100,7 @@ fit, is what decides whether a preset ships.
 - Both captures go through the same display transform, so it cancels in the
   fit; captured pairs differ from true video frames by only ~2–3/255.
 
-## Step 2 — Fit the recipe
+## Step 3 — Fit the recipe
 
 Build a one-off bun harness (they have always been ad-hoc; keep it out of
 the repo):
@@ -72,7 +111,7 @@ the repo):
 2. Load both captures, sample a few thousand pixel-aligned (original,
    filtered) pairs.
 3. Optimize the recipe parameters with random-restart + coordinate descent
-   minimizing RGB RMSE. Accept at ≤8 RMSE/255; the best fits land near 3.
+   minimizing RGB RMSE. Report both weighted and natural-color RMSE.
 4. **Do not hand-"fix" fitted values afterwards.** Outliers like
    `contrast: 2.82` or `gamma: 2.26` are legitimate fit results;
    `buildFilterCube` output is verified bounded by the catalog test.
@@ -84,8 +123,16 @@ the repo):
    keeps the catalogue honest. Rules of thumb: ≤12 natural RMSE is a close
    clone, 12–20 is a recognizable interpretation, >25 means the look needs
    machinery QCut does not have — drop it rather than shipping a stand-in.
+6. Compare the fit against the **package replay**, not only the screenshot.
+   A package replay that differs from the Jianying capture by >8 natural RMSE
+   usually means the resource mapping, sampler coordinates, intensity, or
+   segmented path is wrong. Fix that evidence chain before judging QCut.
 
-## Step 3 — Register the preset
+For skin-segmented dual-LUT packages, a calibration chart validates only the
+background path. Capture a common face clip to measure the skin path. Do not
+claim full parity from a chart-only fit.
+
+## Step 4 — Register the preset
 
 Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
 
@@ -102,7 +149,7 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   `EXPECTED_LOCALIZED_NAMES` order and per-family counts are a deliberate
   catalog snapshot — extend them, don't loosen them.
 
-## Step 4 — Thumbnails and verification
+## Step 5 — Thumbnails and verification
 
 - Generate the `/images/filter-previews/jy-*.webp` thumbnail with the
   existing generator. It needs the `packages/nexusai-website` showcase assets
@@ -115,13 +162,19 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   presets but needs a real ffmpeg at
   `electron/resources/ffmpeg/darwin-arm64/ffmpeg` (not in git — symlink in
   worktrees, remove before committing).
-- Frame-verify at least one preset visually against the Jianying reference
-  (side-by-side crop) before opening the PR.
+- Frame-verify every new preset against the same input at 100% intensity.
+  Produce a labeled side-by-side image with Jianying/package replay on the left
+  and QCut on the right, and record package-replay, natural, and all-chart RMSE.
+- Keep raw cache assets and captured frames in a scratch directory outside the
+  worktree. Comparison screenshots are acceptable evidence; proprietary package
+  contents are not.
 
 ## Related
 
 - `jianying-reference` — package harvesting + stepped-frame capture for
   non-LUT effects (text animations, transitions, shader filters, stickers).
+- `scripts/inspect-filter-cache.ts` — exact-title database mapping and safe
+  package classification without copying package contents.
 - PR #373 shows the salvage pattern: presets carry fitted recipes as pure
   data, so they can be lifted from an abandoned branch with zero mechanism
   changes.

--- a/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
+++ b/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
@@ -1,0 +1,120 @@
+# Jianying Filter Cache Formats
+
+Use package contents as implementation evidence and UI captures as visual
+ground truth. A title match alone does not prove that the package belongs to
+the selected card because Jianying can expose multiple resources with the same
+display name.
+
+## Resource database mapping
+
+The resource databases live under:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+```
+
+Recent versions keep filter cards in JSON responses inside `http_cache` as well
+as normalized rows in `effect`. Important fields are:
+
+- `common_attr.title`: visible card name;
+- `common_attr.id` / `effect_id`: primary package directory candidate;
+- `common_attr.third_resource_id_str`: alternate engine resource ID;
+- `common_attr.md5`: package version directory;
+- `common_attr.requirements` and `sdk_model`: runtime dependencies;
+- `common_attr.publish_source`: useful when duplicate titles exist.
+
+Keep all resource IDs as strings. Values routinely exceed JavaScript's safe
+integer range.
+
+## Package roots
+
+Both roots are mixed containers and must be checked:
+
+```text
+Cache/artistEffect/<id>/<md5>/
+Cache/effect/<id>/<md5>/
+```
+
+Try the primary ID, effect ID, and third resource ID. Prefer an exact
+`<id>/<md5>` match. If the exact version is missing, do not silently inspect a
+different hash; apply one card in the UI and repeat the mapping.
+
+## VF_V 3D LUT
+
+Common pure color grades contain:
+
+```text
+AmazingFeature/texture/filter.cube.vf
+AmazingFeature/shaders/.../*.frag
+AmazingFeature/lua/SeekModeScript.lua
+```
+
+`filter.cube.vf` has a 10-byte little-endian header:
+
+| Offset | Bytes | Meaning |
+|---:|---:|---|
+| 0 | 4 | ASCII `VF_V` |
+| 4 | 2 | width |
+| 6 | 2 | height |
+| 8 | 2 | depth |
+
+The payload is `width × height × depth × 3` little-endian float32 values. The
+observed ordering is red/X fastest, then green/Y, then blue/Z. Validate the
+payload length before reading values. Dimensions such as 17³ and 32³ are both
+used.
+
+Read the compiled fragment shader to confirm semantics. A typical pure grade
+samples `sampler3D` with the source RGB and mixes the result with the original
+using the intensity uniform. In those packages, `SeekModeScript.lua` merely
+forwards the intensity event and contains no color math.
+
+When replaying a sampler3D shader on CPU, reproduce normalized texture sampling
+and edge clamping. Compare that replay with the captured Jianying chart. A low
+replay-to-capture error validates the package mapping and decoder before QCut is
+evaluated.
+
+## Skin-segmented dual LUT
+
+Signals include:
+
+```text
+SkinFilter/image/filter_bg.png
+SkinFilter/image/filter_skin.png
+SkinFilter/algorithmConfig.json
+SkinFilter/shaders/.../*.frag
+requirements: skin_seg
+sdk_model: tt_skin_seg
+```
+
+The observed LUT images are 512×512 atlases containing a 64³ cube as 8×8 blue
+slices. The shader samples background and skin LUTs separately, then mixes them
+with the alpha channel of the segmentation mask. Read the shader for exact tile
+coordinates, slice interpolation, mask orientation, and intensity behavior.
+
+A color chart has no skin region, so it verifies only the background LUT. Use a
+common face clip for parity claims. A single global QCut LUT cannot reproduce
+this architecture on both skin and background.
+
+## Shader or effect package
+
+If there is no recognized LUT but the package contains shaders, textures,
+passes, models, or algorithm nodes, switch to the `jianying-reference` workflow.
+Inspect readable compiled shaders and Lua, capture stepped visual evidence, and
+identify the missing QCut runtime capability before implementing an
+approximation.
+
+## Evidence and ownership
+
+Record outside the worktree:
+
+- exact card title and category;
+- resource ID, md5, database row timestamp, and package path;
+- why duplicate-title candidates were rejected;
+- package classification and runtime dependencies;
+- package replay vs Jianying screenshot RMSE;
+- QCut vs package replay RMSE for natural colors and the full chart;
+- labeled left/right comparison images.
+
+Do not commit cached LUT values, textures, Lua, compiled shaders, package dumps,
+or derived lookup tables. Transcribe behavior into QCut-owned math and prose;
+comparison screenshots may be retained as review evidence only when needed.

--- a/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
+++ b/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
@@ -1,0 +1,196 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	findFilterRecords,
+	inspectPackage,
+	parsePngDimensions,
+	parseVfHeader,
+} from "./inspect-filter-cache";
+
+function createVfCube({ size }: { size: number }) {
+	const buffer = Buffer.alloc(10 + size ** 3 * 3 * 4);
+	buffer.write("VF_V", 0, "ascii");
+	buffer.writeUInt16LE(size, 4);
+	buffer.writeUInt16LE(size, 6);
+	buffer.writeUInt16LE(size, 8);
+	return buffer;
+}
+
+function createPngHeader({ width, height }: { width: number; height: number }) {
+	const buffer = Buffer.alloc(24);
+	Buffer.from("89504e470d0a1a0a", "hex").copy(buffer, 0);
+	buffer.write("IHDR", 12, "ascii");
+	buffer.writeUInt32BE(width, 16);
+	buffer.writeUInt32BE(height, 20);
+	return buffer;
+}
+
+describe("inspect-filter-cache", () => {
+	test("parses VF_V float cube dimensions and validates payload length", () => {
+		expect(parseVfHeader({ buffer: createVfCube({ size: 17 }) })).toEqual({
+			width: 17,
+			height: 17,
+			depth: 17,
+			channels: 3,
+			valueType: "float32-le",
+		});
+		expect(() =>
+			parseVfHeader({ buffer: createVfCube({ size: 17 }).subarray(0, 100) })
+		).toThrow("Invalid VF payload length");
+	});
+
+	test("parses PNG LUT dimensions", () => {
+		expect(
+			parsePngDimensions({
+				buffer: createPngHeader({ width: 512, height: 512 }),
+			})
+		).toEqual({ width: 512, height: 512 });
+	});
+
+	test("classifies float cube and skin-segmented dual-LUT packages", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-cache-")
+		);
+		try {
+			const cubeRoot = path.join(temporaryRoot, "cube");
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/texture"), {
+				recursive: true,
+			});
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/lua"), { recursive: true });
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/texture/filter.cube.vf"),
+				createVfCube({ size: 32 })
+			);
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/lua/SeekModeScript.lua"),
+				"return {}"
+			);
+			const cubePackage = inspectPackage({ packageRoot: cubeRoot });
+			expect(cubePackage.kind).toBe("3d-lut");
+			expect(cubePackage.cubes[0]).toMatchObject({
+				width: 32,
+				height: 32,
+				depth: 32,
+			});
+			expect(cubePackage.luaFiles).toEqual([
+				"AmazingFeature/lua/SeekModeScript.lua",
+			]);
+
+			const skinRoot = path.join(temporaryRoot, "skin");
+			mkdirSync(path.join(skinRoot, "SkinFilter/image"), { recursive: true });
+			mkdirSync(path.join(skinRoot, "SkinFilter/texture"), { recursive: true });
+			for (const name of ["filter_bg.png", "filter_skin.png"]) {
+				writeFileSync(
+					path.join(skinRoot, "SkinFilter/image", name),
+					createPngHeader({ width: 512, height: 512 })
+				);
+			}
+			writeFileSync(
+				path.join(skinRoot, "SkinFilter/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			const skinPackage = inspectPackage({ packageRoot: skinRoot });
+			expect(skinPackage.kind).toBe("skin-segmented-dual-lut");
+			expect(skinPackage.imageLuts).toHaveLength(2);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("reports malformed assets as issues instead of aborting the scan", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-partial-")
+		);
+		try {
+			mkdirSync(path.join(temporaryRoot, "Partial/texture"), {
+				recursive: true,
+			});
+			mkdirSync(path.join(temporaryRoot, "Partial/image"), { recursive: true });
+			// A download interrupted mid-write: valid header, truncated payload.
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/truncated.cube.vf"),
+				createVfCube({ size: 17 }).subarray(0, 100)
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/image/filter_bg.png"),
+				Buffer.alloc(24)
+			);
+
+			const inspected = inspectPackage({ packageRoot: temporaryRoot });
+
+			// The intact cube is still classified and returned.
+			expect(inspected.kind).toBe("3d-lut");
+			expect(inspected.cubes).toHaveLength(1);
+			expect(inspected.cubes[0]?.path).toBe("Partial/texture/filter.cube.vf");
+			// Both bad files are surfaced as evidence, keyed by relative path.
+			expect(inspected.issues).toHaveLength(2);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/texture/truncated.cube.vf: Invalid VF payload length"
+			);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/image/filter_bg.png: Unsupported PNG texture"
+			);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("maps exact HTTP-cache titles without losing 64-bit resource IDs", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-db-")
+		);
+		try {
+			const databasePath = path.join(temporaryRoot, "rp.db");
+			const database = new Database(databasePath);
+			database.exec(`
+				CREATE TABLE http_cache (
+					id INTEGER PRIMARY KEY,
+					response_body TEXT NOT NULL,
+					timestamp TEXT
+				)
+			`);
+			const responseBody = JSON.stringify({
+				data: {
+					effect_item_list: [
+						{
+							common_attr: {
+								title: "静谧暗调",
+								id: "7630501558370733321",
+								effect_id: "7630501558370733321",
+								md5: "32893a4130581511f99ca8d1db4b258a",
+								publish_source: "user_post",
+								requirements: ["blit"],
+							},
+						},
+					],
+				},
+			});
+			database
+				.query(
+					"INSERT INTO http_cache (response_body, timestamp) VALUES (?, ?)"
+				)
+				.run(responseBody, "2026-08-01 12:00:00");
+			database.close();
+
+			const records = findFilterRecords({
+				databasePaths: [databasePath],
+				title: "静谧暗调",
+			});
+			expect(records).toHaveLength(1);
+			expect(records[0]).toMatchObject({
+				title: "静谧暗调",
+				id: "7630501558370733321",
+				md5: "32893a4130581511f99ca8d1db4b258a",
+			});
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
+++ b/qcut/.claude/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
@@ -1,0 +1,506 @@
+#!/usr/bin/env bun
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+interface FilterCacheRecord {
+	title: string;
+	id: string;
+	effectId: string;
+	thirdResourceId: string;
+	md5: string;
+	publishSource: string;
+	requirements: string;
+	sdkModel: string;
+	databasePath: string;
+	timestamp: string;
+}
+
+interface RawFilterCacheRecord {
+	title: string | null;
+	id: string | null;
+	effectId: string | null;
+	thirdResourceId: string | null;
+	md5: string | null;
+	publishSource: string | null;
+	requirements: string | null;
+	sdkModel: string | null;
+	timestamp: string | null;
+}
+
+interface InspectedPackage {
+	packageRoot: string;
+	kind:
+		| "3d-lut"
+		| "skin-segmented-dual-lut"
+		| "shader-or-effect-package"
+		| "unknown";
+	cubes: Array<{
+		path: string;
+		width: number;
+		height: number;
+		depth: number;
+		channels: number;
+		valueType: "float32-le";
+	}>;
+	imageLuts: Array<{
+		path: string;
+		width: number;
+		height: number;
+	}>;
+	luaFiles: string[];
+	shaderFiles: string[];
+	configFiles: string[];
+	/**
+	 * Per-file read/parse failures. A partially downloaded package is the exact
+	 * state this tool exists to diagnose, so a malformed asset is reported as
+	 * evidence rather than aborting the scan.
+	 */
+	issues: string[];
+}
+
+const DEFAULT_CACHE_ROOT = path.join(
+	os.homedir(),
+	"Movies/JianyingPro/User Data/Cache"
+);
+
+function normalizeRecord({
+	record,
+	databasePath,
+}: {
+	record: RawFilterCacheRecord;
+	databasePath: string;
+}): FilterCacheRecord | null {
+	if (!(record.title && record.id && record.md5)) return null;
+	return {
+		title: record.title,
+		id: record.id,
+		effectId: record.effectId ?? "",
+		thirdResourceId: record.thirdResourceId ?? "",
+		md5: record.md5,
+		publishSource: record.publishSource ?? "",
+		requirements: record.requirements ?? "",
+		sdkModel: record.sdkModel ?? "",
+		databasePath,
+		timestamp: record.timestamp ?? "",
+	};
+}
+
+function tableExists({
+	database,
+	table,
+}: {
+	database: Database;
+	table: string;
+}) {
+	const result = database
+		.query<{ present: number }, [string]>(
+			"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?) AS present"
+		)
+		.get(table);
+	return result?.present === 1;
+}
+
+function queryHttpCache({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "http_cache" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string]>(`
+			SELECT
+				CAST(json_extract(item.value, '$.common_attr.title') AS TEXT) AS title,
+				CAST(json_extract(item.value, '$.common_attr.id') AS TEXT) AS id,
+				CAST(json_extract(item.value, '$.common_attr.effect_id') AS TEXT) AS effectId,
+				COALESCE(
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id_str') AS TEXT),
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id') AS TEXT)
+				) AS thirdResourceId,
+				CAST(json_extract(item.value, '$.common_attr.md5') AS TEXT) AS md5,
+				CAST(json_extract(item.value, '$.common_attr.publish_source') AS TEXT) AS publishSource,
+				CAST(json_extract(item.value, '$.common_attr.requirements') AS TEXT) AS requirements,
+				CAST(json_extract(item.value, '$.common_attr.sdk_model') AS TEXT) AS sdkModel,
+				CAST(cache.timestamp AS TEXT) AS timestamp
+			FROM http_cache AS cache,
+				json_each(
+					CASE WHEN json_valid(cache.response_body) THEN cache.response_body ELSE '{}' END,
+					'$.data.effect_item_list'
+				) AS item
+			WHERE json_extract(item.value, '$.common_attr.title') = ?
+		`)
+		.all(title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function queryEffectTable({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "effect" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string, string]>(`
+			SELECT
+				CAST(COALESCE(title, name) AS TEXT) AS title,
+				CAST(id AS TEXT) AS id,
+				CAST(effect_id AS TEXT) AS effectId,
+				CAST(third_resource_id AS TEXT) AS thirdResourceId,
+				CAST(md5 AS TEXT) AS md5,
+				CAST(publish_source AS TEXT) AS publishSource,
+				CAST(requirements AS TEXT) AS requirements,
+				CAST(sdk_model AS TEXT) AS sdkModel,
+				CAST(_request_time AS TEXT) AS timestamp
+			FROM effect
+			WHERE title = ? OR name = ?
+		`)
+		.all(title, title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function deduplicateRecords({
+	records,
+}: {
+	records: FilterCacheRecord[];
+}): FilterCacheRecord[] {
+	const byResource = new Map<string, FilterCacheRecord>();
+	for (const record of records) {
+		const key = `${record.id}:${record.md5}`;
+		const current = byResource.get(key);
+		if (!current || record.timestamp > current.timestamp) {
+			byResource.set(key, record);
+		}
+	}
+	return [...byResource.values()].sort((left, right) =>
+		left.id.localeCompare(right.id)
+	);
+}
+
+export function findFilterRecords({
+	databasePaths,
+	title,
+}: {
+	databasePaths: string[];
+	title: string;
+}): FilterCacheRecord[] {
+	const records: FilterCacheRecord[] = [];
+	for (const databasePath of databasePaths) {
+		const database = new Database(databasePath, { readonly: true });
+		try {
+			records.push(
+				...queryHttpCache({ database, databasePath, title }),
+				...queryEffectTable({ database, databasePath, title })
+			);
+		} finally {
+			database.close();
+		}
+	}
+	return deduplicateRecords({ records });
+}
+
+export function parseVfHeader({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	if (buffer.length < 10 || buffer.toString("ascii", 0, 4) !== "VF_V") {
+		throw new Error(`Unsupported VF texture: ${filePath}`);
+	}
+	const width = buffer.readUInt16LE(4);
+	const height = buffer.readUInt16LE(6);
+	const depth = buffer.readUInt16LE(8);
+	const channels = 3;
+	const expectedBytes = 10 + width * height * depth * channels * 4;
+	if (buffer.length !== expectedBytes) {
+		throw new Error(
+			`Invalid VF payload length for ${filePath}: expected ${expectedBytes}, got ${buffer.length}`
+		);
+	}
+	return { width, height, depth, channels, valueType: "float32-le" as const };
+}
+
+export function parsePngDimensions({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	const signature = "89504e470d0a1a0a";
+	if (
+		buffer.length < 24 ||
+		buffer.subarray(0, 8).toString("hex") !== signature ||
+		buffer.subarray(12, 16).toString("ascii") !== "IHDR"
+	) {
+		throw new Error(`Unsupported PNG texture: ${filePath}`);
+	}
+	return {
+		width: buffer.readUInt32BE(16),
+		height: buffer.readUInt32BE(20),
+	};
+}
+
+function listPackageFiles({ packageRoot }: { packageRoot: string }): string[] {
+	const relativeFiles: string[] = [];
+	const pending = [packageRoot];
+	while (pending.length > 0) {
+		const current = pending.pop();
+		if (!current) continue;
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const absolutePath = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				pending.push(absolutePath);
+				continue;
+			}
+			if (entry.isFile()) {
+				relativeFiles.push(path.relative(packageRoot, absolutePath));
+			}
+		}
+	}
+	return relativeFiles.sort();
+}
+
+function describeIssue({
+	relativePath,
+	error,
+}: {
+	relativePath: string;
+	error: unknown;
+}): string {
+	return `${relativePath}: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+export function inspectPackage({
+	packageRoot,
+}: {
+	packageRoot: string;
+}): InspectedPackage {
+	const relativeFiles = listPackageFiles({ packageRoot });
+	const cubes: InspectedPackage["cubes"] = [];
+	const imageLuts: InspectedPackage["imageLuts"] = [];
+	const luaFiles: string[] = [];
+	const shaderFiles: string[] = [];
+	const configFiles: string[] = [];
+	const issues: string[] = [];
+
+	for (const relativePath of relativeFiles) {
+		const absolutePath = path.join(packageRoot, relativePath);
+		const lowerPath = relativePath.toLowerCase();
+		if (lowerPath.endsWith(".cube.vf")) {
+			try {
+				cubes.push({
+					path: relativePath,
+					...parseVfHeader({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
+		}
+		if (
+			lowerPath.endsWith("filter_bg.png") ||
+			lowerPath.endsWith("filter_skin.png")
+		) {
+			try {
+				imageLuts.push({
+					path: relativePath,
+					...parsePngDimensions({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
+		}
+		if (lowerPath.endsWith(".lua")) luaFiles.push(relativePath);
+		if (
+			lowerPath.endsWith(".frag") ||
+			lowerPath.endsWith(".vert") ||
+			lowerPath.endsWith(".xshader")
+		) {
+			shaderFiles.push(relativePath);
+		}
+		if (
+			lowerPath.endsWith("config.json") ||
+			lowerPath.endsWith("content.json") ||
+			lowerPath.endsWith(".material")
+		) {
+			configFiles.push(relativePath);
+		}
+	}
+
+	const hasBackgroundLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_bg.png")
+	);
+	const hasSkinLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_skin.png")
+	);
+	let kind: InspectedPackage["kind"] = "unknown";
+	if (cubes.length > 0) kind = "3d-lut";
+	if (hasBackgroundLut && hasSkinLut) kind = "skin-segmented-dual-lut";
+	if (kind === "unknown" && shaderFiles.length > 0) {
+		kind = "shader-or-effect-package";
+	}
+
+	return {
+		packageRoot,
+		kind,
+		cubes,
+		imageLuts,
+		luaFiles,
+		shaderFiles,
+		configFiles,
+		issues,
+	};
+}
+
+function findDatabasePaths({ cacheRoot }: { cacheRoot: string }): string[] {
+	const databaseRoot = path.join(cacheRoot, "ressdk_db");
+	if (!existsSync(databaseRoot)) return [];
+	const databasePaths: string[] = [];
+	for (const entry of readdirSync(databaseRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const databasePath = path.join(databaseRoot, entry.name, "rp.db");
+		if (existsSync(databasePath) && statSync(databasePath).isFile()) {
+			databasePaths.push(databasePath);
+		}
+	}
+	return databasePaths.sort();
+}
+
+function findPackageRoots({
+	cacheRoot,
+	record,
+}: {
+	cacheRoot: string;
+	record: FilterCacheRecord;
+}): string[] {
+	const identifiers = new Set(
+		[record.id, record.effectId, record.thirdResourceId].filter(Boolean)
+	);
+	const packageRoots: string[] = [];
+	for (const containerName of ["artistEffect", "effect"]) {
+		for (const identifier of identifiers) {
+			const exactPath = path.join(
+				cacheRoot,
+				containerName,
+				identifier,
+				record.md5
+			);
+			if (existsSync(exactPath) && statSync(exactPath).isDirectory()) {
+				packageRoots.push(exactPath);
+			}
+		}
+	}
+	return [...new Set(packageRoots)].sort();
+}
+
+function printUsage() {
+	console.log(`Usage:
+  bun inspect-filter-cache.ts [--cache-root <path>] <exact-filter-title>
+
+Examples:
+  bun inspect-filter-cache.ts 静谧暗调
+  bun inspect-filter-cache.ts --cache-root "$HOME/Movies/JianyingPro/User Data/Cache" 黑金`);
+}
+
+function runCli() {
+	const { values, positionals } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			"cache-root": { type: "string" },
+			help: { type: "boolean", short: "h" },
+		},
+		allowPositionals: true,
+		strict: true,
+	});
+	if (values.help) {
+		printUsage();
+		return;
+	}
+	const title = positionals.join(" ").trim();
+	if (!title) {
+		printUsage();
+		throw new Error("An exact Jianying filter title is required");
+	}
+	const cacheRoot = path.resolve(values["cache-root"] ?? DEFAULT_CACHE_ROOT);
+	const databasePaths = findDatabasePaths({ cacheRoot });
+	if (databasePaths.length === 0) {
+		throw new Error(`No ressdk_db/*/rp.db files found under ${cacheRoot}`);
+	}
+	const records = findFilterRecords({ databasePaths, title });
+	const matches = records.map((record) => {
+		const packageRoots = findPackageRoots({ cacheRoot, record });
+		return {
+			...record,
+			packages: packageRoots.map((packageRoot) =>
+				inspectPackage({ packageRoot })
+			),
+		};
+	});
+	console.log(
+		JSON.stringify(
+			{
+				title,
+				cacheRoot,
+				databasePaths,
+				matches,
+				warnings: [
+					...(matches.length === 0
+						? [
+								"No exact title match was found in the local resource databases.",
+							]
+						: []),
+					...(matches.length > 1
+						? [
+								"Multiple resources share this title; disambiguate with UI order or an mtime probe.",
+							]
+						: []),
+					...(matches.some(({ packages }) => packages.length === 0)
+						? [
+								"At least one matching resource is not downloaded in artistEffect/effect.",
+							]
+						: []),
+					...(matches.some(({ packages }) =>
+						packages.some(({ issues }) => issues.length > 0)
+					)
+						? [
+								"At least one package asset could not be read or parsed; see package issues. A partial download is the usual cause — reopen the card in Jianying to finish it, then rerun.",
+							]
+						: []),
+				],
+			},
+			null,
+			2
+		)
+	);
+	if (matches.length === 0) process.exitCode = 2;
+}
+
+if (import.meta.main) runCli();

--- a/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/SKILL.md
+++ b/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/SKILL.md
@@ -1,25 +1,64 @@
 ---
 name: jianying-filter-parity
-description: Clone a Jianying (剪映) filter look into QCut as a fitted FilterLutRecipe preset — capture references from the Jianying desktop UI, least-squares fit the recipe, register it in the filter catalog, and lock it with parity tests. Use for 剪映滤镜, 滤镜对标, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
+description: Trace a Jianying (剪映) filter from its local resource database to the downloaded package, classify its LUT/shader/segmentation implementation, then reproduce pure color grades in QCut with measured parity. Use for 剪映滤镜, 滤镜对标, 滤镜缓存, 拟合滤镜, 复刻滤镜, adding jy-* filter presets, or matching a reference color grade.
 argument-hint: <filter-name-or-family>
 ---
 
 # Jianying Filter Parity
 
 QCut filters ("System A", `apps/web/src/lib/filters/`) are procedurally
-generated 17³ LUTs: each preset is a `FilterLutRecipe` (exposure, contrast,
-saturation, temperature, tint, fade, gamma, blackLift, hueShift,
-shadow/highlight tint) fed through `transformFilterColor` in `filter-lut.ts`.
-That function is **pure**, so any external look can be cloned by numerically
-fitting the recipe against a reference before/after image pair. This produced
-PR #347 (8 summer/cinema looks) and PR #373 (30 jy-* presets); typical fit
-quality is 3–8 RMSE/255.
+generated 17³ LUTs: each preset is a `FilterLutRecipe` fed through the pure
+`transformFilterColor` function in `filter-lut.ts`. This model can closely fit
+some global color grades, but it cannot express every Jianying filter. A card
+may instead use a higher-resolution 3D LUT, per-hue behavior, separate skin and
+background LUTs, segmentation, textures, or a multi-pass shader graph.
 
-For filters that are *effect packages* (shaders, textures) rather than pure
-color grades, harvest the package with the `jianying-reference` skill instead
-— this skill covers the LUT-fit path only.
+**Inspect the downloaded package before fitting screenshots.** Package evidence
+defines what the filter actually is; captures verify that the package mapping
+and replay are correct. Only then decide whether a `FilterLutRecipe` is an
+appropriate implementation target.
 
-## Step 0 — Build a calibration chart (do this instead of a photo)
+## Step 0 — Map the card to its local package
+
+Jianying stores UI metadata and packages separately:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+~/Movies/JianyingPro/User Data/Cache/artistEffect/<resource-id>/<md5>/
+~/Movies/JianyingPro/User Data/Cache/effect/<resource-id>/<md5>/
+```
+
+Run the read-only inspector with the exact visible card title:
+
+```bash
+bun .agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts "静谧暗调"
+```
+
+The tool preserves 64-bit IDs as strings, searches both resource databases,
+maps `title → resource ID + md5`, locates packages in both mixed cache roots,
+and classifies common implementations:
+
+- `3d-lut`: a `VF_V` float32 cube plus a sampler3D shader;
+- `skin-segmented-dual-lut`: separate background/skin LUT images and a skin mask;
+- `shader-or-effect-package`: inspect readable shaders, Lua, config, and graph;
+- `unknown`: gather more UI/cache evidence before fitting.
+
+An exact title can return multiple resources. Disambiguate with the UI card
+order, cover image, or the `jianying-reference` one-card mtime probe. Never pick
+the first title match silently. If the package is absent, apply that one card in
+a disposable draft to force its download, then rerun the inspector.
+
+A file that cannot be read or parsed is reported in that package's `issues`
+array rather than aborting the run, so a half-downloaded asset never hides the
+packages that did resolve. Treat a non-empty `issues` list as an incomplete
+download: reopen the card in Jianying to finish it and rerun before concluding
+anything about `kind`.
+
+Read [cache-formats.md](references/cache-formats.md) before decoding or replaying
+a package. Cached assets are local interoperability evidence: do not copy LUTs,
+textures, shaders, Lua, or derived tables into the repo or product.
+
+## Step 1 — Build a calibration chart (do this instead of a photo)
 
 Fitting against a photo wastes most samples on one narrow region of color
 space. Generate a **576-patch chart** at the project resolution instead:
@@ -40,7 +79,7 @@ interior ×2, cube edges ×0.5, saturated hues ×0.35. Report a separate
 "natural" RMSE over grays/skin/interior only — that number, not the raw
 fit, is what decides whether a preset ships.
 
-## Step 1 — Capture references from Jianying desktop (macOS)
+## Step 2 — Capture references from Jianying desktop (macOS)
 
 1. Add the filter as a **track segment** via the hover "+" button on the
    filter card. This is the only trustworthy path: segment intensity is
@@ -61,7 +100,7 @@ fit, is what decides whether a preset ships.
 - Both captures go through the same display transform, so it cancels in the
   fit; captured pairs differ from true video frames by only ~2–3/255.
 
-## Step 2 — Fit the recipe
+## Step 3 — Fit the recipe
 
 Build a one-off bun harness (they have always been ad-hoc; keep it out of
 the repo):
@@ -72,7 +111,7 @@ the repo):
 2. Load both captures, sample a few thousand pixel-aligned (original,
    filtered) pairs.
 3. Optimize the recipe parameters with random-restart + coordinate descent
-   minimizing RGB RMSE. Accept at ≤8 RMSE/255; the best fits land near 3.
+   minimizing RGB RMSE. Report both weighted and natural-color RMSE.
 4. **Do not hand-"fix" fitted values afterwards.** Outliers like
    `contrast: 2.82` or `gamma: 2.26` are legitimate fit results;
    `buildFilterCube` output is verified bounded by the catalog test.
@@ -84,8 +123,16 @@ the repo):
    keeps the catalogue honest. Rules of thumb: ≤12 natural RMSE is a close
    clone, 12–20 is a recognizable interpretation, >25 means the look needs
    machinery QCut does not have — drop it rather than shipping a stand-in.
+6. Compare the fit against the **package replay**, not only the screenshot.
+   A package replay that differs from the Jianying capture by >8 natural RMSE
+   usually means the resource mapping, sampler coordinates, intensity, or
+   segmented path is wrong. Fix that evidence chain before judging QCut.
 
-## Step 3 — Register the preset
+For skin-segmented dual-LUT packages, a calibration chart validates only the
+background path. Capture a common face clip to measure the skin path. Do not
+claim full parity from a chart-only fit.
+
+## Step 4 — Register the preset
 
 Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
 
@@ -102,7 +149,7 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   `EXPECTED_LOCALIZED_NAMES` order and per-family counts are a deliberate
   catalog snapshot — extend them, don't loosen them.
 
-## Step 4 — Thumbnails and verification
+## Step 5 — Thumbnails and verification
 
 - Generate the `/images/filter-previews/jy-*.webp` thumbnail with the
   existing generator. It needs the `packages/nexusai-website` showcase assets
@@ -115,13 +162,19 @@ Follow the PR #373 layout in `apps/web/src/lib/filters/jianying-parity/`:
   presets but needs a real ffmpeg at
   `electron/resources/ffmpeg/darwin-arm64/ffmpeg` (not in git — symlink in
   worktrees, remove before committing).
-- Frame-verify at least one preset visually against the Jianying reference
-  (side-by-side crop) before opening the PR.
+- Frame-verify every new preset against the same input at 100% intensity.
+  Produce a labeled side-by-side image with Jianying/package replay on the left
+  and QCut on the right, and record package-replay, natural, and all-chart RMSE.
+- Keep raw cache assets and captured frames in a scratch directory outside the
+  worktree. Comparison screenshots are acceptable evidence; proprietary package
+  contents are not.
 
 ## Related
 
 - `jianying-reference` — package harvesting + stepped-frame capture for
   non-LUT effects (text animations, transitions, shader filters, stickers).
+- `scripts/inspect-filter-cache.ts` — exact-title database mapping and safe
+  package classification without copying package contents.
 - PR #373 shows the salvage pattern: presets carry fitted recipes as pure
   data, so they can be lifted from an abandoned branch with zero mechanism
   changes.

--- a/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
+++ b/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/references/cache-formats.md
@@ -1,0 +1,120 @@
+# Jianying Filter Cache Formats
+
+Use package contents as implementation evidence and UI captures as visual
+ground truth. A title match alone does not prove that the package belongs to
+the selected card because Jianying can expose multiple resources with the same
+display name.
+
+## Resource database mapping
+
+The resource databases live under:
+
+```text
+~/Movies/JianyingPro/User Data/Cache/ressdk_db/*/rp.db
+```
+
+Recent versions keep filter cards in JSON responses inside `http_cache` as well
+as normalized rows in `effect`. Important fields are:
+
+- `common_attr.title`: visible card name;
+- `common_attr.id` / `effect_id`: primary package directory candidate;
+- `common_attr.third_resource_id_str`: alternate engine resource ID;
+- `common_attr.md5`: package version directory;
+- `common_attr.requirements` and `sdk_model`: runtime dependencies;
+- `common_attr.publish_source`: useful when duplicate titles exist.
+
+Keep all resource IDs as strings. Values routinely exceed JavaScript's safe
+integer range.
+
+## Package roots
+
+Both roots are mixed containers and must be checked:
+
+```text
+Cache/artistEffect/<id>/<md5>/
+Cache/effect/<id>/<md5>/
+```
+
+Try the primary ID, effect ID, and third resource ID. Prefer an exact
+`<id>/<md5>` match. If the exact version is missing, do not silently inspect a
+different hash; apply one card in the UI and repeat the mapping.
+
+## VF_V 3D LUT
+
+Common pure color grades contain:
+
+```text
+AmazingFeature/texture/filter.cube.vf
+AmazingFeature/shaders/.../*.frag
+AmazingFeature/lua/SeekModeScript.lua
+```
+
+`filter.cube.vf` has a 10-byte little-endian header:
+
+| Offset | Bytes | Meaning |
+|---:|---:|---|
+| 0 | 4 | ASCII `VF_V` |
+| 4 | 2 | width |
+| 6 | 2 | height |
+| 8 | 2 | depth |
+
+The payload is `width × height × depth × 3` little-endian float32 values. The
+observed ordering is red/X fastest, then green/Y, then blue/Z. Validate the
+payload length before reading values. Dimensions such as 17³ and 32³ are both
+used.
+
+Read the compiled fragment shader to confirm semantics. A typical pure grade
+samples `sampler3D` with the source RGB and mixes the result with the original
+using the intensity uniform. In those packages, `SeekModeScript.lua` merely
+forwards the intensity event and contains no color math.
+
+When replaying a sampler3D shader on CPU, reproduce normalized texture sampling
+and edge clamping. Compare that replay with the captured Jianying chart. A low
+replay-to-capture error validates the package mapping and decoder before QCut is
+evaluated.
+
+## Skin-segmented dual LUT
+
+Signals include:
+
+```text
+SkinFilter/image/filter_bg.png
+SkinFilter/image/filter_skin.png
+SkinFilter/algorithmConfig.json
+SkinFilter/shaders/.../*.frag
+requirements: skin_seg
+sdk_model: tt_skin_seg
+```
+
+The observed LUT images are 512×512 atlases containing a 64³ cube as 8×8 blue
+slices. The shader samples background and skin LUTs separately, then mixes them
+with the alpha channel of the segmentation mask. Read the shader for exact tile
+coordinates, slice interpolation, mask orientation, and intensity behavior.
+
+A color chart has no skin region, so it verifies only the background LUT. Use a
+common face clip for parity claims. A single global QCut LUT cannot reproduce
+this architecture on both skin and background.
+
+## Shader or effect package
+
+If there is no recognized LUT but the package contains shaders, textures,
+passes, models, or algorithm nodes, switch to the `jianying-reference` workflow.
+Inspect readable compiled shaders and Lua, capture stepped visual evidence, and
+identify the missing QCut runtime capability before implementing an
+approximation.
+
+## Evidence and ownership
+
+Record outside the worktree:
+
+- exact card title and category;
+- resource ID, md5, database row timestamp, and package path;
+- why duplicate-title candidates were rejected;
+- package classification and runtime dependencies;
+- package replay vs Jianying screenshot RMSE;
+- QCut vs package replay RMSE for natural colors and the full chart;
+- labeled left/right comparison images.
+
+Do not commit cached LUT values, textures, Lua, compiled shaders, package dumps,
+or derived lookup tables. Transcribe behavior into QCut-owned math and prose;
+comparison screenshots may be retained as review evidence only when needed.

--- a/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
+++ b/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts
@@ -1,0 +1,196 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	findFilterRecords,
+	inspectPackage,
+	parsePngDimensions,
+	parseVfHeader,
+} from "./inspect-filter-cache";
+
+function createVfCube({ size }: { size: number }) {
+	const buffer = Buffer.alloc(10 + size ** 3 * 3 * 4);
+	buffer.write("VF_V", 0, "ascii");
+	buffer.writeUInt16LE(size, 4);
+	buffer.writeUInt16LE(size, 6);
+	buffer.writeUInt16LE(size, 8);
+	return buffer;
+}
+
+function createPngHeader({ width, height }: { width: number; height: number }) {
+	const buffer = Buffer.alloc(24);
+	Buffer.from("89504e470d0a1a0a", "hex").copy(buffer, 0);
+	buffer.write("IHDR", 12, "ascii");
+	buffer.writeUInt32BE(width, 16);
+	buffer.writeUInt32BE(height, 20);
+	return buffer;
+}
+
+describe("inspect-filter-cache", () => {
+	test("parses VF_V float cube dimensions and validates payload length", () => {
+		expect(parseVfHeader({ buffer: createVfCube({ size: 17 }) })).toEqual({
+			width: 17,
+			height: 17,
+			depth: 17,
+			channels: 3,
+			valueType: "float32-le",
+		});
+		expect(() =>
+			parseVfHeader({ buffer: createVfCube({ size: 17 }).subarray(0, 100) })
+		).toThrow("Invalid VF payload length");
+	});
+
+	test("parses PNG LUT dimensions", () => {
+		expect(
+			parsePngDimensions({
+				buffer: createPngHeader({ width: 512, height: 512 }),
+			})
+		).toEqual({ width: 512, height: 512 });
+	});
+
+	test("classifies float cube and skin-segmented dual-LUT packages", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-cache-")
+		);
+		try {
+			const cubeRoot = path.join(temporaryRoot, "cube");
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/texture"), {
+				recursive: true,
+			});
+			mkdirSync(path.join(cubeRoot, "AmazingFeature/lua"), { recursive: true });
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/texture/filter.cube.vf"),
+				createVfCube({ size: 32 })
+			);
+			writeFileSync(
+				path.join(cubeRoot, "AmazingFeature/lua/SeekModeScript.lua"),
+				"return {}"
+			);
+			const cubePackage = inspectPackage({ packageRoot: cubeRoot });
+			expect(cubePackage.kind).toBe("3d-lut");
+			expect(cubePackage.cubes[0]).toMatchObject({
+				width: 32,
+				height: 32,
+				depth: 32,
+			});
+			expect(cubePackage.luaFiles).toEqual([
+				"AmazingFeature/lua/SeekModeScript.lua",
+			]);
+
+			const skinRoot = path.join(temporaryRoot, "skin");
+			mkdirSync(path.join(skinRoot, "SkinFilter/image"), { recursive: true });
+			mkdirSync(path.join(skinRoot, "SkinFilter/texture"), { recursive: true });
+			for (const name of ["filter_bg.png", "filter_skin.png"]) {
+				writeFileSync(
+					path.join(skinRoot, "SkinFilter/image", name),
+					createPngHeader({ width: 512, height: 512 })
+				);
+			}
+			writeFileSync(
+				path.join(skinRoot, "SkinFilter/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			const skinPackage = inspectPackage({ packageRoot: skinRoot });
+			expect(skinPackage.kind).toBe("skin-segmented-dual-lut");
+			expect(skinPackage.imageLuts).toHaveLength(2);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("reports malformed assets as issues instead of aborting the scan", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-partial-")
+		);
+		try {
+			mkdirSync(path.join(temporaryRoot, "Partial/texture"), {
+				recursive: true,
+			});
+			mkdirSync(path.join(temporaryRoot, "Partial/image"), { recursive: true });
+			// A download interrupted mid-write: valid header, truncated payload.
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/truncated.cube.vf"),
+				createVfCube({ size: 17 }).subarray(0, 100)
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/texture/filter.cube.vf"),
+				createVfCube({ size: 17 })
+			);
+			writeFileSync(
+				path.join(temporaryRoot, "Partial/image/filter_bg.png"),
+				Buffer.alloc(24)
+			);
+
+			const inspected = inspectPackage({ packageRoot: temporaryRoot });
+
+			// The intact cube is still classified and returned.
+			expect(inspected.kind).toBe("3d-lut");
+			expect(inspected.cubes).toHaveLength(1);
+			expect(inspected.cubes[0]?.path).toBe("Partial/texture/filter.cube.vf");
+			// Both bad files are surfaced as evidence, keyed by relative path.
+			expect(inspected.issues).toHaveLength(2);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/texture/truncated.cube.vf: Invalid VF payload length"
+			);
+			expect(inspected.issues.join("\n")).toContain(
+				"Partial/image/filter_bg.png: Unsupported PNG texture"
+			);
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("maps exact HTTP-cache titles without losing 64-bit resource IDs", () => {
+		const temporaryRoot = mkdtempSync(
+			path.join(os.tmpdir(), "qcut-filter-db-")
+		);
+		try {
+			const databasePath = path.join(temporaryRoot, "rp.db");
+			const database = new Database(databasePath);
+			database.exec(`
+				CREATE TABLE http_cache (
+					id INTEGER PRIMARY KEY,
+					response_body TEXT NOT NULL,
+					timestamp TEXT
+				)
+			`);
+			const responseBody = JSON.stringify({
+				data: {
+					effect_item_list: [
+						{
+							common_attr: {
+								title: "静谧暗调",
+								id: "7630501558370733321",
+								effect_id: "7630501558370733321",
+								md5: "32893a4130581511f99ca8d1db4b258a",
+								publish_source: "user_post",
+								requirements: ["blit"],
+							},
+						},
+					],
+				},
+			});
+			database
+				.query(
+					"INSERT INTO http_cache (response_body, timestamp) VALUES (?, ?)"
+				)
+				.run(responseBody, "2026-08-01 12:00:00");
+			database.close();
+
+			const records = findFilterRecords({
+				databasePaths: [databasePath],
+				title: "静谧暗调",
+			});
+			expect(records).toHaveLength(1);
+			expect(records[0]).toMatchObject({
+				title: "静谧暗调",
+				id: "7630501558370733321",
+				md5: "32893a4130581511f99ca8d1db4b258a",
+			});
+		} finally {
+			rmSync(temporaryRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
+++ b/qcut/resources/default-skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.ts
@@ -1,0 +1,506 @@
+#!/usr/bin/env bun
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+interface FilterCacheRecord {
+	title: string;
+	id: string;
+	effectId: string;
+	thirdResourceId: string;
+	md5: string;
+	publishSource: string;
+	requirements: string;
+	sdkModel: string;
+	databasePath: string;
+	timestamp: string;
+}
+
+interface RawFilterCacheRecord {
+	title: string | null;
+	id: string | null;
+	effectId: string | null;
+	thirdResourceId: string | null;
+	md5: string | null;
+	publishSource: string | null;
+	requirements: string | null;
+	sdkModel: string | null;
+	timestamp: string | null;
+}
+
+interface InspectedPackage {
+	packageRoot: string;
+	kind:
+		| "3d-lut"
+		| "skin-segmented-dual-lut"
+		| "shader-or-effect-package"
+		| "unknown";
+	cubes: Array<{
+		path: string;
+		width: number;
+		height: number;
+		depth: number;
+		channels: number;
+		valueType: "float32-le";
+	}>;
+	imageLuts: Array<{
+		path: string;
+		width: number;
+		height: number;
+	}>;
+	luaFiles: string[];
+	shaderFiles: string[];
+	configFiles: string[];
+	/**
+	 * Per-file read/parse failures. A partially downloaded package is the exact
+	 * state this tool exists to diagnose, so a malformed asset is reported as
+	 * evidence rather than aborting the scan.
+	 */
+	issues: string[];
+}
+
+const DEFAULT_CACHE_ROOT = path.join(
+	os.homedir(),
+	"Movies/JianyingPro/User Data/Cache"
+);
+
+function normalizeRecord({
+	record,
+	databasePath,
+}: {
+	record: RawFilterCacheRecord;
+	databasePath: string;
+}): FilterCacheRecord | null {
+	if (!(record.title && record.id && record.md5)) return null;
+	return {
+		title: record.title,
+		id: record.id,
+		effectId: record.effectId ?? "",
+		thirdResourceId: record.thirdResourceId ?? "",
+		md5: record.md5,
+		publishSource: record.publishSource ?? "",
+		requirements: record.requirements ?? "",
+		sdkModel: record.sdkModel ?? "",
+		databasePath,
+		timestamp: record.timestamp ?? "",
+	};
+}
+
+function tableExists({
+	database,
+	table,
+}: {
+	database: Database;
+	table: string;
+}) {
+	const result = database
+		.query<{ present: number }, [string]>(
+			"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?) AS present"
+		)
+		.get(table);
+	return result?.present === 1;
+}
+
+function queryHttpCache({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "http_cache" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string]>(`
+			SELECT
+				CAST(json_extract(item.value, '$.common_attr.title') AS TEXT) AS title,
+				CAST(json_extract(item.value, '$.common_attr.id') AS TEXT) AS id,
+				CAST(json_extract(item.value, '$.common_attr.effect_id') AS TEXT) AS effectId,
+				COALESCE(
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id_str') AS TEXT),
+					CAST(json_extract(item.value, '$.common_attr.third_resource_id') AS TEXT)
+				) AS thirdResourceId,
+				CAST(json_extract(item.value, '$.common_attr.md5') AS TEXT) AS md5,
+				CAST(json_extract(item.value, '$.common_attr.publish_source') AS TEXT) AS publishSource,
+				CAST(json_extract(item.value, '$.common_attr.requirements') AS TEXT) AS requirements,
+				CAST(json_extract(item.value, '$.common_attr.sdk_model') AS TEXT) AS sdkModel,
+				CAST(cache.timestamp AS TEXT) AS timestamp
+			FROM http_cache AS cache,
+				json_each(
+					CASE WHEN json_valid(cache.response_body) THEN cache.response_body ELSE '{}' END,
+					'$.data.effect_item_list'
+				) AS item
+			WHERE json_extract(item.value, '$.common_attr.title') = ?
+		`)
+		.all(title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function queryEffectTable({
+	database,
+	databasePath,
+	title,
+}: {
+	database: Database;
+	databasePath: string;
+	title: string;
+}): FilterCacheRecord[] {
+	if (!tableExists({ database, table: "effect" })) return [];
+	const rows = database
+		.query<RawFilterCacheRecord, [string, string]>(`
+			SELECT
+				CAST(COALESCE(title, name) AS TEXT) AS title,
+				CAST(id AS TEXT) AS id,
+				CAST(effect_id AS TEXT) AS effectId,
+				CAST(third_resource_id AS TEXT) AS thirdResourceId,
+				CAST(md5 AS TEXT) AS md5,
+				CAST(publish_source AS TEXT) AS publishSource,
+				CAST(requirements AS TEXT) AS requirements,
+				CAST(sdk_model AS TEXT) AS sdkModel,
+				CAST(_request_time AS TEXT) AS timestamp
+			FROM effect
+			WHERE title = ? OR name = ?
+		`)
+		.all(title, title);
+	const records: FilterCacheRecord[] = [];
+	for (const row of rows) {
+		const record = normalizeRecord({ record: row, databasePath });
+		if (record) records.push(record);
+	}
+	return records;
+}
+
+function deduplicateRecords({
+	records,
+}: {
+	records: FilterCacheRecord[];
+}): FilterCacheRecord[] {
+	const byResource = new Map<string, FilterCacheRecord>();
+	for (const record of records) {
+		const key = `${record.id}:${record.md5}`;
+		const current = byResource.get(key);
+		if (!current || record.timestamp > current.timestamp) {
+			byResource.set(key, record);
+		}
+	}
+	return [...byResource.values()].sort((left, right) =>
+		left.id.localeCompare(right.id)
+	);
+}
+
+export function findFilterRecords({
+	databasePaths,
+	title,
+}: {
+	databasePaths: string[];
+	title: string;
+}): FilterCacheRecord[] {
+	const records: FilterCacheRecord[] = [];
+	for (const databasePath of databasePaths) {
+		const database = new Database(databasePath, { readonly: true });
+		try {
+			records.push(
+				...queryHttpCache({ database, databasePath, title }),
+				...queryEffectTable({ database, databasePath, title })
+			);
+		} finally {
+			database.close();
+		}
+	}
+	return deduplicateRecords({ records });
+}
+
+export function parseVfHeader({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	if (buffer.length < 10 || buffer.toString("ascii", 0, 4) !== "VF_V") {
+		throw new Error(`Unsupported VF texture: ${filePath}`);
+	}
+	const width = buffer.readUInt16LE(4);
+	const height = buffer.readUInt16LE(6);
+	const depth = buffer.readUInt16LE(8);
+	const channels = 3;
+	const expectedBytes = 10 + width * height * depth * channels * 4;
+	if (buffer.length !== expectedBytes) {
+		throw new Error(
+			`Invalid VF payload length for ${filePath}: expected ${expectedBytes}, got ${buffer.length}`
+		);
+	}
+	return { width, height, depth, channels, valueType: "float32-le" as const };
+}
+
+export function parsePngDimensions({
+	buffer,
+	filePath = "<buffer>",
+}: {
+	buffer: Buffer;
+	filePath?: string;
+}) {
+	const signature = "89504e470d0a1a0a";
+	if (
+		buffer.length < 24 ||
+		buffer.subarray(0, 8).toString("hex") !== signature ||
+		buffer.subarray(12, 16).toString("ascii") !== "IHDR"
+	) {
+		throw new Error(`Unsupported PNG texture: ${filePath}`);
+	}
+	return {
+		width: buffer.readUInt32BE(16),
+		height: buffer.readUInt32BE(20),
+	};
+}
+
+function listPackageFiles({ packageRoot }: { packageRoot: string }): string[] {
+	const relativeFiles: string[] = [];
+	const pending = [packageRoot];
+	while (pending.length > 0) {
+		const current = pending.pop();
+		if (!current) continue;
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const absolutePath = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				pending.push(absolutePath);
+				continue;
+			}
+			if (entry.isFile()) {
+				relativeFiles.push(path.relative(packageRoot, absolutePath));
+			}
+		}
+	}
+	return relativeFiles.sort();
+}
+
+function describeIssue({
+	relativePath,
+	error,
+}: {
+	relativePath: string;
+	error: unknown;
+}): string {
+	return `${relativePath}: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+export function inspectPackage({
+	packageRoot,
+}: {
+	packageRoot: string;
+}): InspectedPackage {
+	const relativeFiles = listPackageFiles({ packageRoot });
+	const cubes: InspectedPackage["cubes"] = [];
+	const imageLuts: InspectedPackage["imageLuts"] = [];
+	const luaFiles: string[] = [];
+	const shaderFiles: string[] = [];
+	const configFiles: string[] = [];
+	const issues: string[] = [];
+
+	for (const relativePath of relativeFiles) {
+		const absolutePath = path.join(packageRoot, relativePath);
+		const lowerPath = relativePath.toLowerCase();
+		if (lowerPath.endsWith(".cube.vf")) {
+			try {
+				cubes.push({
+					path: relativePath,
+					...parseVfHeader({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
+		}
+		if (
+			lowerPath.endsWith("filter_bg.png") ||
+			lowerPath.endsWith("filter_skin.png")
+		) {
+			try {
+				imageLuts.push({
+					path: relativePath,
+					...parsePngDimensions({
+						buffer: readFileSync(absolutePath),
+						filePath: absolutePath,
+					}),
+				});
+			} catch (error) {
+				issues.push(describeIssue({ relativePath, error }));
+			}
+		}
+		if (lowerPath.endsWith(".lua")) luaFiles.push(relativePath);
+		if (
+			lowerPath.endsWith(".frag") ||
+			lowerPath.endsWith(".vert") ||
+			lowerPath.endsWith(".xshader")
+		) {
+			shaderFiles.push(relativePath);
+		}
+		if (
+			lowerPath.endsWith("config.json") ||
+			lowerPath.endsWith("content.json") ||
+			lowerPath.endsWith(".material")
+		) {
+			configFiles.push(relativePath);
+		}
+	}
+
+	const hasBackgroundLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_bg.png")
+	);
+	const hasSkinLut = imageLuts.some(({ path: imagePath }) =>
+		imagePath.toLowerCase().endsWith("filter_skin.png")
+	);
+	let kind: InspectedPackage["kind"] = "unknown";
+	if (cubes.length > 0) kind = "3d-lut";
+	if (hasBackgroundLut && hasSkinLut) kind = "skin-segmented-dual-lut";
+	if (kind === "unknown" && shaderFiles.length > 0) {
+		kind = "shader-or-effect-package";
+	}
+
+	return {
+		packageRoot,
+		kind,
+		cubes,
+		imageLuts,
+		luaFiles,
+		shaderFiles,
+		configFiles,
+		issues,
+	};
+}
+
+function findDatabasePaths({ cacheRoot }: { cacheRoot: string }): string[] {
+	const databaseRoot = path.join(cacheRoot, "ressdk_db");
+	if (!existsSync(databaseRoot)) return [];
+	const databasePaths: string[] = [];
+	for (const entry of readdirSync(databaseRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const databasePath = path.join(databaseRoot, entry.name, "rp.db");
+		if (existsSync(databasePath) && statSync(databasePath).isFile()) {
+			databasePaths.push(databasePath);
+		}
+	}
+	return databasePaths.sort();
+}
+
+function findPackageRoots({
+	cacheRoot,
+	record,
+}: {
+	cacheRoot: string;
+	record: FilterCacheRecord;
+}): string[] {
+	const identifiers = new Set(
+		[record.id, record.effectId, record.thirdResourceId].filter(Boolean)
+	);
+	const packageRoots: string[] = [];
+	for (const containerName of ["artistEffect", "effect"]) {
+		for (const identifier of identifiers) {
+			const exactPath = path.join(
+				cacheRoot,
+				containerName,
+				identifier,
+				record.md5
+			);
+			if (existsSync(exactPath) && statSync(exactPath).isDirectory()) {
+				packageRoots.push(exactPath);
+			}
+		}
+	}
+	return [...new Set(packageRoots)].sort();
+}
+
+function printUsage() {
+	console.log(`Usage:
+  bun inspect-filter-cache.ts [--cache-root <path>] <exact-filter-title>
+
+Examples:
+  bun inspect-filter-cache.ts 静谧暗调
+  bun inspect-filter-cache.ts --cache-root "$HOME/Movies/JianyingPro/User Data/Cache" 黑金`);
+}
+
+function runCli() {
+	const { values, positionals } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			"cache-root": { type: "string" },
+			help: { type: "boolean", short: "h" },
+		},
+		allowPositionals: true,
+		strict: true,
+	});
+	if (values.help) {
+		printUsage();
+		return;
+	}
+	const title = positionals.join(" ").trim();
+	if (!title) {
+		printUsage();
+		throw new Error("An exact Jianying filter title is required");
+	}
+	const cacheRoot = path.resolve(values["cache-root"] ?? DEFAULT_CACHE_ROOT);
+	const databasePaths = findDatabasePaths({ cacheRoot });
+	if (databasePaths.length === 0) {
+		throw new Error(`No ressdk_db/*/rp.db files found under ${cacheRoot}`);
+	}
+	const records = findFilterRecords({ databasePaths, title });
+	const matches = records.map((record) => {
+		const packageRoots = findPackageRoots({ cacheRoot, record });
+		return {
+			...record,
+			packages: packageRoots.map((packageRoot) =>
+				inspectPackage({ packageRoot })
+			),
+		};
+	});
+	console.log(
+		JSON.stringify(
+			{
+				title,
+				cacheRoot,
+				databasePaths,
+				matches,
+				warnings: [
+					...(matches.length === 0
+						? [
+								"No exact title match was found in the local resource databases.",
+							]
+						: []),
+					...(matches.length > 1
+						? [
+								"Multiple resources share this title; disambiguate with UI order or an mtime probe.",
+							]
+						: []),
+					...(matches.some(({ packages }) => packages.length === 0)
+						? [
+								"At least one matching resource is not downloaded in artistEffect/effect.",
+							]
+						: []),
+					...(matches.some(({ packages }) =>
+						packages.some(({ issues }) => issues.length > 0)
+					)
+						? [
+								"At least one package asset could not be read or parsed; see package issues. A partial download is the usual cause — reopen the card in Jianying to finish it, then rerun.",
+							]
+						: []),
+				],
+			},
+			null,
+			2
+		)
+	);
+	if (matches.length === 0) process.exitCode = 2;
+}
+
+if (import.meta.main) runCli();


### PR DESCRIPTION
## Summary

- add a read-only exact-title inspector for Jianying `ressdk_db` metadata and downloaded `artistEffect` / `effect` packages
- preserve 64-bit resource IDs, report duplicate-title ambiguity, and classify float 3D LUT, skin-segmented dual-LUT, and shader/effect packages
- make the filter parity Skill cache-first and document `VF_V`, dual-LUT, evidence, and ownership rules
- keep cached LUTs, shaders, Lua, textures, and captures outside the repository

## Validation

- `bun test ./.agents/skills/qcut-toolkit/jianying-filter-parity/scripts/inspect-filter-cache.test.ts`
- `bunx ultracite check .../inspect-filter-cache.ts .../inspect-filter-cache.test.ts`
- targeted TypeScript check with Bun types and `--skipLibCheck`
- real local cache probes: 静谧暗调, 墨色胶卷, 银蓝, 黑金, 水墨意境
  - four target packages classified as 3D LUTs
  - 银蓝 classified as skin-segmented dual LUT
  - 黑金 returned both same-title candidates and the expected ambiguity warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooling to inspect Jianying filter caches and identify LUT, shader, and segmented filter packages.
  * Added structured validation for filter resources, including LUT formats, package contents, and exact filter matches.
  * Added calibration and replay guidance for comparing Jianying filters with QCut results.

* **Documentation**
  * Documented cache formats, package lookup rules, validation requirements, and evidence standards.

* **Tests**
  * Added coverage for cache inspection, LUT parsing, package classification, and resource matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->