### PR TITLE
fix(sticker-lab): serve every reference catalogue, and say so when one does not load

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/local-sticker-reference-panel.test.tsx
@@ -659,4 +659,48 @@ describe("LocalStickerReferencePanel", () => {
 			})
 		);
 	});
+	it("names the catalogues that failed while others still load", () => {
+		render(
+			<LocalStickerReferencePanel
+				catalog={createRemoteStickerCatalog()}
+				error={null}
+				isLoading={false}
+				onSelect={async () => {}}
+				privateCatalogs={[createPrivateStickerCatalog()]}
+				unavailablePrivateCatalogIds={["jianying-2026-08-01-batch-2"]}
+			/>
+		);
+
+		const warning = screen.getByTestId("sticker-lab-private-catalog-warning");
+		expect(warning).toHaveTextContent("1 个参照素材包未能载入");
+		expect(warning).toHaveTextContent("只显示部分贴纸");
+		expect(warning).toHaveTextContent("jianying-2026-08-01-batch-2");
+	});
+
+	it("still reports the failure when every catalogue is unavailable", () => {
+		// The worst case, and the one a deployment regression actually produces:
+		// no private catalogue loads, so the private tab never renders. A warning
+		// gated on that tab would leave the shortfall as silent as before.
+		render(
+			<LocalStickerReferencePanel
+				catalog={createRemoteStickerCatalog()}
+				error={null}
+				isLoading={false}
+				onSelect={async () => {}}
+				privateCatalogs={[]}
+				unavailablePrivateCatalogIds={[
+					"jianying-2026-07-31",
+					"jianying-2026-08-01-batch-2",
+					"jianying-2026-08-01-batch-3",
+				]}
+			/>
+		);
+
+		expect(
+			screen.queryByTestId("sticker-lab-catalog-private")
+		).not.toBeInTheDocument();
+		const warning = screen.getByTestId("sticker-lab-private-catalog-warning");
+		expect(warning).toHaveTextContent("3 个参照素材包未能载入");
+		expect(warning).toHaveTextContent("暂时无法显示");
+	});
 });

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/use-local-sticker-catalog.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/__tests__/use-local-sticker-catalog.test.tsx
@@ -67,6 +67,7 @@ describe("useLocalStickerCatalog", () => {
 			isAvailable: false,
 			isLoading: false,
 			privateCatalogs: [],
+			unavailablePrivateCatalogIds: [],
 		});
 		expect(catalogMocks.loadPrivateManifest).not.toHaveBeenCalled();
 		expect(catalogMocks.loadManifest).not.toHaveBeenCalled();
@@ -146,6 +147,9 @@ describe("useLocalStickerCatalog", () => {
 			isAvailable: true,
 			isLoading: false,
 			privateCatalogs: [],
+			// Nothing mocks the private manifests here, so all three legitimately
+			// fail — and the panel now says so instead of showing a short list.
+			unavailablePrivateCatalogIds: [...PRIVATE_STICKER_CATALOG_IDS],
 		});
 	});
 

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
@@ -134,6 +134,18 @@ export function LocalStickerReferencePanel({
 				<p className="mt-0.5 text-[10px] leading-4 text-muted-foreground">
 					实验素材按需载入，不随 QCut 安装包分发
 				</p>
+				{missingCatalogCount > 0 ? (
+					<div
+						className="mt-1 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] leading-snug text-amber-200/90"
+						data-testid="sticker-lab-private-catalog-warning"
+					>
+						{missingCatalogCount} 个参照素材包未能载入
+						{hasPrivateCatalog
+							? "，当前只显示部分贴纸（"
+							: "，剪映参照贴纸暂时无法显示（"}
+						{unavailablePrivateCatalogIds.join("、")}）
+					</div>
+				) : null}
 				{hasPrivateCatalog ? (
 					<StickerCatalogTabs
 						activeCatalogKey={activeCatalogKey}
@@ -244,15 +256,6 @@ export function LocalStickerReferencePanel({
 									{selectedCategory.items.length} 个贴纸
 								</span>
 							</div>
-							{isPrivateCatalogActive && missingCatalogCount > 0 ? (
-								<div
-									className="mx-3 mb-1 shrink-0 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] leading-snug text-amber-200/90"
-									data-testid="sticker-lab-private-catalog-warning"
-								>
-									{missingCatalogCount} 个参照素材包未能载入,当前只显示部分贴纸(
-									{unavailablePrivateCatalogIds.join("、")})
-								</div>
-							) : null}
 							<div className="min-h-0 flex-1 overflow-y-auto p-2">
 								<div
 									className="grid grid-cols-3 gap-2"

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/components/local-sticker-reference-panel.tsx
@@ -22,6 +22,7 @@ import {
 	StickerCatalogTabs,
 } from "./sticker-catalog-tabs";
 
+const EMPTY_UNAVAILABLE_CATALOG_IDS: readonly string[] = [];
 const EMPTY_PRIVATE_CATALOGS: readonly PrivateStickerCatalog[] = [];
 
 export function LocalStickerReferencePanel({
@@ -30,12 +31,14 @@ export function LocalStickerReferencePanel({
 	isLoading,
 	onSelect,
 	privateCatalogs = EMPTY_PRIVATE_CATALOGS,
+	unavailablePrivateCatalogIds = EMPTY_UNAVAILABLE_CATALOG_IDS,
 }: {
 	catalog: StickerLabCatalog | null;
 	error: string | null;
 	isLoading: boolean;
 	onSelect: ({ file }: { file: File }) => Promise<void>;
 	privateCatalogs?: readonly PrivateStickerCatalog[];
+	unavailablePrivateCatalogIds?: readonly string[];
 }) {
 	const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
 		null
@@ -49,6 +52,9 @@ export function LocalStickerReferencePanel({
 		[privateCatalogs]
 	);
 	const hasPrivateCatalog = privateCatalogs.length > 0;
+	// A reference catalogue that failed to load takes its slice of the stickers
+	// with it. Without this the panel is indistinguishable from a small one.
+	const missingCatalogCount = unavailablePrivateCatalogIds.length;
 	const isPrivateCatalogActive =
 		activeCatalogKey === "private" && hasPrivateCatalog;
 	const categories = isPrivateCatalogActive
@@ -238,6 +244,15 @@ export function LocalStickerReferencePanel({
 									{selectedCategory.items.length} 个贴纸
 								</span>
 							</div>
+							{isPrivateCatalogActive && missingCatalogCount > 0 ? (
+								<div
+									className="mx-3 mb-1 shrink-0 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] leading-snug text-amber-200/90"
+									data-testid="sticker-lab-private-catalog-warning"
+								>
+									{missingCatalogCount} 个参照素材包未能载入,当前只显示部分贴纸(
+									{unavailablePrivateCatalogIds.join("、")})
+								</div>
+							) : null}
 							<div className="min-h-0 flex-1 overflow-y-auto p-2">
 								<div
 									className="grid grid-cols-3 gap-2"

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/hooks/use-local-sticker-catalog.ts
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/hooks/use-local-sticker-catalog.ts
@@ -26,6 +26,12 @@ export interface LocalStickerCatalogState {
 	 * Everyone else gets an empty list and sees only the public catalogue.
 	 */
 	privateCatalogs: PrivateStickerCatalog[];
+	/**
+	 * Reference catalogues that failed to load. Surfaced rather than swallowed:
+	 * every failure hides a slice of the catalogue, and dropping them silently
+	 * makes a partially-loaded lab indistinguishable from a small one.
+	 */
+	unavailablePrivateCatalogIds: string[];
 }
 
 function initialCatalogState({
@@ -39,6 +45,7 @@ function initialCatalogState({
 		isAvailable: hasSource,
 		isLoading: hasSource,
 		privateCatalogs: [],
+		unavailablePrivateCatalogIds: [],
 	};
 }
 
@@ -126,14 +133,18 @@ export function useLocalStickerCatalog(): LocalStickerCatalogState {
 			if (disposed) return;
 
 			const availableCatalogs: PrivateStickerCatalog[] = [];
+			const unavailableCatalogIds: string[] = [];
 			for (const [index, result] of results.entries()) {
 				const catalogId = PRIVATE_STICKER_CATALOG_IDS[index];
 				if (result.status === "fulfilled") {
 					availableCatalogs.push(result.value);
 					continue;
 				}
-				// Expected during rolling deploys, for users outside the allow list,
-				// signed-out sessions, and offline runs.
+				// Happens during rolling deploys, for users outside the allow list,
+				// signed-out sessions, and offline runs — but also when the server
+				// serves one catalogue for every id, which looks identical from here.
+				// Record it so the panel can say a slice is missing.
+				unavailableCatalogIds.push(catalogId);
 				debugError(
 					`[StickerLab] Private reference catalog unavailable: ${catalogId}`,
 					result.reason
@@ -144,13 +155,21 @@ export function useLocalStickerCatalog(): LocalStickerCatalogState {
 				const privateCatalogs = validatePrivateStickerCatalogSet({
 					catalogs: availableCatalogs,
 				});
-				setState((previous) => ({ ...previous, privateCatalogs }));
+				setState((previous) => ({
+					...previous,
+					privateCatalogs,
+					unavailablePrivateCatalogIds: unavailableCatalogIds,
+				}));
 			} catch (error) {
 				debugError(
 					"[StickerLab] Private reference catalog set rejected",
 					error
 				);
-				setState((previous) => ({ ...previous, privateCatalogs: [] }));
+				setState((previous) => ({
+					...previous,
+					privateCatalogs: [],
+					unavailablePrivateCatalogIds: [...PRIVATE_STICKER_CATALOG_IDS],
+				}));
 			}
 		};
 

--- a/qcut/apps/web/src/components/editor/media-panel/views/stickers/stickers-view.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/stickers/stickers-view.tsx
@@ -218,6 +218,9 @@ export function StickersView() {
 							isLoading={localStickerCatalog.isLoading}
 							onSelect={handleLocalReferenceSelect}
 							privateCatalogs={localStickerCatalog.privateCatalogs}
+							unavailablePrivateCatalogIds={
+								localStickerCatalog.unavailablePrivateCatalogIds
+							}
 						/>
 					) : (
 						<div className="flex h-full min-h-0 flex-col">

--- a/qcut/packages/license-server/src/routes/sticker-lab.test.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.test.ts
@@ -527,10 +527,11 @@ describe("sticker lab private reference tier", () => {
 		expect(response.headers.get("Content-Type")).toBe("application/json");
 		expect(response.headers.get("Cache-Control")).toBe("no-store");
 		await expect(response.text()).resolves.toBe(manifestJson);
+		// Only the path: storage-js spreads any third argument into the fetch
+		// RequestInit, and workerd rejects a `cache` field outright. Asserting
+		// the extra arguments is what let the production 404 ship green.
 		expect(storageMocks.download).toHaveBeenCalledWith(
-			defaultCatalog.manifestObjectKey,
-			{},
-			{ cache: "no-store" }
+			defaultCatalog.manifestObjectKey
 		);
 	});
 
@@ -557,11 +558,7 @@ describe("sticker lab private reference tier", () => {
 
 		expect(response.status).toBe(200);
 		await expect(response.text()).resolves.toBe(manifestJson);
-		expect(storageMocks.download).toHaveBeenCalledWith(
-			manifestObjectKey,
-			{},
-			{ cache: "no-store" }
-		);
+		expect(storageMocks.download).toHaveBeenCalledWith(manifestObjectKey);
 	});
 
 	it("rejects an oversized private manifest before reading its bytes", async () => {

--- a/qcut/packages/license-server/src/routes/sticker-lab.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.ts
@@ -125,9 +125,15 @@ stickerLabRoutes.get("/private-manifest", async (c) => {
 	}
 
 	try {
+		// The third argument is spread straight into the fetch RequestInit, and
+		// workerd rejects a `cache` field ("not implemented") at this Worker's
+		// compatibility date. The throw surfaces as a download error, which this
+		// route reports as a missing manifest, so every catalogue 404s in
+		// production while passing under Bun. Freshness is already guaranteed by
+		// the no-store response header above.
 		const { data, error } = await getSupabase()
 			.storage.from(STICKER_BUCKET)
-			.download(catalog.manifestObjectKey, {}, { cache: "no-store" });
+			.download(catalog.manifestObjectKey);
 		if (error || !data) {
 			return c.json({ error: "Private manifest unavailable" }, 404);
 		}


### PR DESCRIPTION
Combines what was PR #398 into this one — the two halves of the same defect.

## What you saw

The Sticker Lab's 剪映参照 tab showed **4 stickers per category**. It should show 12. The shortfall was silent.

## Two causes, both fixed here

### 1. The deployed license server ignored `catalogId` (was #398)

`packages/license-server/src/routes/sticker-lab.ts` resolves a distinct `manifestObjectKey` per catalogue and was correct — but deploying it made things *worse*, not better: every catalogue returned `404 Private manifest unavailable`, taking the panel from 168 stickers to 0. Rolled back within minutes.

The route called storage-js like this:

```ts
.download(catalog.manifestObjectKey, {}, { cache: "no-store" })
```

storage-js spreads its third argument straight into the fetch `RequestInit`:

```js
// @supabase/storage-js _getRequestParams
return _objectSpread2(_objectSpread2({}, params), parameters);
```

and workerd rejects that field at this Worker's `compatibility_date = "2024-09-23"`:

> The 'cache' field on 'RequestInitializerDict' is not implemented.

The throw reaches storage-js as a download error, and the route reports a download error as a missing manifest. Under Bun the field is supported, so tests and local runs stayed green — and two assertions pinned the three-argument call, making the defect the expected behaviour. Both now assert the path alone.

`Cache-Control: no-store` on the route's own reply is untouched; that is what keeps clients from caching the manifest. The removed argument only affected the Worker's upstream fetch, which the pre-multi-catalogue code never set either.

### 2. The panel hid its own failures

`use-local-sticker-catalog.ts` dropped failed catalogues through `debugError`, which does not surface in a production build. The panel now records which ones failed and names them.

The warning first lived inside the private tab — but that tab only renders when at least one private catalogue loaded, so a **total** failure still said nothing. That is not hypothetical: the bad deploy above produced exactly it. The warning now sits in the always-rendered header and distinguishes the two cases.

## Verified

**In workerd**, at this Worker's compatibility date, against the real bucket:

```
before → ERROR: The 'cache' field on 'RequestInitializerDict' is not implemented.
after  → OK 129611B
```

**Deployed and confirmed in production:**

| catalogId | HTTP | sha256 | declares | stickers |
|---|---|---|---|---|
| `jianying-2026-07-31` | 200 | `64515a618303` | `jianying-2026-07-31` | 168 |
| `jianying-2026-08-01-batch-2` | 200 | `8a01fd6b2877` | `jianying-2026-08-01-batch-2` | 168 |
| `jianying-2026-08-01-batch-3` | 200 | `8070b4eb7fb6` | `jianying-2026-08-01-batch-3` | 168 |
| `totally-bogus-catalog` | **400** | — | — | — |

Three distinct manifests: **504 stickers, up from 168**. Production runs this branch's worker code (version `0d225aa2-3efd-4279-b3bf-941b402788b3`), so merging brings master in line with what is live.

**Tests:** 213 pass in `packages/license-server`; 44 pass under `.../views/stickers`, including two new cases — partial failure and total failure — for a warning that previously had no coverage at all. Biome clean.

## Note

The client half only takes effect in a build that carries all three catalogue ids. The `2026.8.103` release predates `149ef4c22` by three hours and knows only one, so it will keep showing 168 regardless of the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings identifying private sticker catalogs that could not be loaded.
  * Available sticker catalogs remain accessible when others fail.

* **Bug Fixes**
  * Improved handling of invalid or unavailable private sticker catalog manifests.
  * Fixed private manifest downloads by removing an unsupported request option while retaining no-cache behavior.

* **Tests**
  * Added coverage for partial and complete private catalog loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->