### PR TITLE
fix(sticker-lab): drop the fetch cache option workerd rejects

### DIFF
--- a/qcut/packages/license-server/src/routes/sticker-lab.test.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.test.ts
@@ -527,10 +527,11 @@ describe("sticker lab private reference tier", () => {
 		expect(response.headers.get("Content-Type")).toBe("application/json");
 		expect(response.headers.get("Cache-Control")).toBe("no-store");
 		await expect(response.text()).resolves.toBe(manifestJson);
+		// Only the path: storage-js spreads any third argument into the fetch
+		// RequestInit, and workerd rejects a `cache` field outright. Asserting
+		// the extra arguments is what let the production 404 ship green.
 		expect(storageMocks.download).toHaveBeenCalledWith(
-			defaultCatalog.manifestObjectKey,
-			{},
-			{ cache: "no-store" }
+			defaultCatalog.manifestObjectKey
 		);
 	});
 
@@ -557,11 +558,7 @@ describe("sticker lab private reference tier", () => {
 
 		expect(response.status).toBe(200);
 		await expect(response.text()).resolves.toBe(manifestJson);
-		expect(storageMocks.download).toHaveBeenCalledWith(
-			manifestObjectKey,
-			{},
-			{ cache: "no-store" }
-		);
+		expect(storageMocks.download).toHaveBeenCalledWith(manifestObjectKey);
 	});
 
 	it("rejects an oversized private manifest before reading its bytes", async () => {

--- a/qcut/packages/license-server/src/routes/sticker-lab.ts
+++ b/qcut/packages/license-server/src/routes/sticker-lab.ts
@@ -125,9 +125,15 @@ stickerLabRoutes.get("/private-manifest", async (c) => {
 	}
 
 	try {
+		// The third argument is spread straight into the fetch RequestInit, and
+		// workerd rejects a `cache` field ("not implemented") at this Worker's
+		// compatibility date. The throw surfaces as a download error, which this
+		// route reports as a missing manifest, so every catalogue 404s in
+		// production while passing under Bun. Freshness is already guaranteed by
+		// the no-store response header above.
 		const { data, error } = await getSupabase()
 			.storage.from(STICKER_BUCKET)
-			.download(catalog.manifestObjectKey, {}, { cache: "no-store" });
+			.download(catalog.manifestObjectKey);
 		if (error || !data) {
 			return c.json({ error: "Private manifest unavailable" }, 404);
 		}


### PR DESCRIPTION
## Symptom

Deploying the multi-catalogue license server made the Sticker Lab worse, not better: all three private reference catalogues returned `404 {"error":"Private manifest unavailable"}`, taking the panel from 168 stickers to 0. Rolled back within minutes.

## Root cause

`/private-manifest` called storage-js like this:

```ts
.download(catalog.manifestObjectKey, {}, { cache: "no-store" })
```

storage-js spreads its third argument straight into the fetch `RequestInit`:

```js
// @supabase/storage-js _getRequestParams
return _objectSpread2(_objectSpread2({}, params), parameters);
```

workerd rejects that field at this Worker's `compatibility_date = "2024-09-23"`:

> The 'cache' field on 'RequestInitializerDict' is not implemented.

The throw arrives at storage-js as a download error, and the route reports a download error as a missing manifest — a 404 for every catalogue, including the one that had been serving fine for days.

## Why the tests did not catch it

Two assertions pinned the three-argument call:

```ts
expect(storageMocks.download).toHaveBeenCalledWith(objectKey, {}, { cache: "no-store" });
```

Under Bun the `cache` field is supported, so the call shape that only fails in workerd was locked in as the expected behaviour. Both assertions now check the path alone.

## Verified

In workerd, at this Worker's compatibility date, against the real bucket:

```
before → ERROR: The 'cache' field on 'RequestInitializerDict' is not implemented.
after  → OK 129611B
```

`bun run test` in `packages/license-server`: 213 passed. Biome clean.

**Deployed and confirmed in production:**

| catalogId | HTTP | sha256 | declares | stickers |
|---|---|---|---|---|
| `jianying-2026-07-31` | 200 | `64515a618303` | `jianying-2026-07-31` | 168 |
| `jianying-2026-08-01-batch-2` | 200 | `8a01fd6b2877` | `jianying-2026-08-01-batch-2` | 168 |
| `jianying-2026-08-01-batch-3` | 200 | `8070b4eb7fb6` | `jianying-2026-08-01-batch-3` | 168 |
| `totally-bogus-catalog` | **400** | — | — | — |

Three distinct manifests, each declaring its own id: **504 stickers, up from 168**. Production is running this commit's code (version `0d225aa2-3efd-4279-b3bf-941b402788b3`), so merging brings master in line with what is live.

## Note on the response header

`Cache-Control: no-store` on the route's own reply is untouched — that is what keeps clients from caching the manifest. The removed argument only affected the Worker's upstream fetch to Supabase, which the pre-multi-catalogue code never set either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private manifest downloads by ensuring storage requests use the correct parameters.
  * Preserved response freshness controls and existing error handling for reliable downloads.
  * Added test coverage to validate the updated download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->