### PR TITLE
fix(updates): keep staged updates installable and visible

### DIFF
--- a/qcut/electron/__tests__/auto-update-controller.test.ts
+++ b/qcut/electron/__tests__/auto-update-controller.test.ts
@@ -24,6 +24,8 @@ class FakeUpdater extends EventEmitter implements AutoUpdaterLike {
 	downloadCount = 0;
 	installCount = 0;
 	info: UpdateInfoLike;
+	nextCheckError: Error | undefined;
+	nextCheckOutcome: "available" | "not-available" = "available";
 
 	constructor({ info }: { info: UpdateInfoLike }) {
 		super();
@@ -33,12 +35,30 @@ class FakeUpdater extends EventEmitter implements AutoUpdaterLike {
 	async checkForUpdates(): Promise<unknown> {
 		this.checkCount += 1;
 		this.emit("checking-for-update");
+		if (this.nextCheckError) {
+			const error = this.nextCheckError;
+			this.nextCheckError = undefined;
+			this.emit("error", error);
+			throw error;
+		}
+		if (this.nextCheckOutcome === "not-available") {
+			this.emit("update-not-available", this.info);
+			return { updateInfo: this.info };
+		}
 		this.emit("update-available", this.info);
 		return { updateInfo: this.info };
 	}
 
+	nextDownloadError: Error | undefined;
+
 	async downloadUpdate(): Promise<string[]> {
 		this.downloadCount += 1;
+		if (this.nextDownloadError) {
+			const error = this.nextDownloadError;
+			this.nextDownloadError = undefined;
+			this.emit("error", error);
+			throw error;
+		}
 		this.emit("download-progress", {
 			percent: 50,
 			transferred: 50,
@@ -168,6 +188,256 @@ describe("auto update controller", () => {
 		expect(controller.getState().phase).toBe("ready");
 		expect(updater.downloadCount).toBe(1);
 		controller.stop();
+	});
+
+	it("keeps a staged update installable when later checks fail", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const stagedVersions: string[] = [];
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			onUpdateStaged: ({ staged }) => stagedVersions.push(staged.version),
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		expect(stagedVersions).toEqual(["2026.07.12.1"]);
+		// Drain the initial check chain so the failing check below starts fresh
+		// instead of coalescing onto the still-settling first check.
+		await controller.checkForUpdates();
+
+		updater.nextCheckError = new Error("net::ERR_NAME_NOT_RESOLVED");
+		await controller.checkForUpdates();
+
+		const state = controller.getState();
+		expect(state.phase).toBe("ready");
+		expect(state.version).toBe("2026.07.12.1");
+		expect(state.staged?.version).toBe("2026.07.12.1");
+		expect(state.lastCheckError).toContain("ERR_NAME_NOT_RESOLVED");
+
+		// A later successful check clears the stale failure.
+		await controller.checkForUpdates();
+		expect(controller.getState().phase).toBe("ready");
+		expect(controller.getState().lastCheckError).toBeUndefined();
+
+		expect(controller.installUpdate().success).toBe(true);
+		controller.stop();
+	});
+
+	it("does not re-download a version that is already staged", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const stagedVersions: string[] = [];
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			onUpdateStaged: ({ staged }) => stagedVersions.push(staged.version),
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		expect(updater.downloadCount).toBe(1);
+		// Drain the initial check chain, then re-check twice for real.
+		await controller.checkForUpdates();
+
+		// The hourly re-check reports the same version again.
+		await controller.checkForUpdates();
+		await controller.checkForUpdates();
+
+		expect(updater.downloadCount).toBe(1);
+		expect(stagedVersions).toEqual(["2026.07.12.1"]);
+		expect(controller.getState().phase).toBe("ready");
+		controller.stop();
+	});
+
+	it("downloads a genuinely newer version over an older staged one", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const stagedVersions: string[] = [];
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			onUpdateStaged: ({ staged }) => stagedVersions.push(staged.version),
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		// Drain the initial check chain so the newer-version check runs fresh.
+		await controller.checkForUpdates();
+
+		updater.info = { version: "2026.7.1301", files: [{ size: 1_000 }] };
+		await controller.checkForUpdates();
+		await vi.waitFor(() =>
+			expect(controller.getState().version).toBe("2026.07.13.1")
+		);
+		expect(updater.downloadCount).toBe(2);
+		expect(controller.getState().phase).toBe("ready");
+		expect(controller.getState().staged?.version).toBe("2026.07.13.1");
+		// The staging hook must fire again for the second version — it drives
+		// the macOS dock badge and notification for long-running sessions.
+		expect(stagedVersions).toEqual(["2026.07.12.1", "2026.07.13.1"]);
+		controller.stop();
+	});
+
+	it("keeps a newer available offer through a failed check", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		// Drain the initial check chain so the next checks run fresh.
+		await controller.checkForUpdates();
+
+		// A newer, too-large build appears: phase "available", waiting for a
+		// manual download.
+		updater.info = {
+			version: "2026.7.1301",
+			files: [{ size: MAX_AUTOMATIC_UPDATE_BYTES + 1 }],
+		};
+		await controller.checkForUpdates();
+		expect(controller.getState().phase).toBe("available");
+		expect(controller.getState().version).toBe("2026.07.13.1");
+
+		// A failed background check must not rewind to the older staged build.
+		updater.nextCheckError = new Error("offline");
+		await controller.checkForUpdates();
+		expect(controller.getState().phase).toBe("available");
+		expect(controller.getState().version).toBe("2026.07.13.1");
+		expect(controller.getState().lastCheckError).toBe("offline");
+
+		// The manual download for the newer version still works immediately.
+		await controller.downloadUpdate();
+		expect(updater.downloadCount).toBe(2);
+		expect(controller.getState().phase).toBe("ready");
+		expect(controller.getState().staged?.version).toBe("2026.07.13.1");
+		expect(controller.getState().lastCheckError).toBeUndefined();
+		controller.stop();
+	});
+
+	it("falls back to the staged build when a newer download fails", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		await controller.checkForUpdates();
+
+		updater.info = { version: "2026.7.1301", files: [{ size: 1_000 }] };
+		updater.nextDownloadError = new Error("connection reset");
+		await controller.checkForUpdates();
+		await vi.waitFor(() =>
+			expect(controller.getState().lastCheckError).toBe("connection reset")
+		);
+
+		// The older staged build stays installable after the failed download.
+		expect(controller.getState().phase).toBe("ready");
+		expect(controller.getState().version).toBe("2026.07.12.1");
+		expect(controller.installUpdate().success).toBe(true);
+		controller.stop();
+	});
+
+	it("disarms close interception before quitAndInstall", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const order: string[] = [];
+		updater.quitAndInstall = () => {
+			order.push("quit-and-install");
+		};
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			onBeforeQuitAndInstall: () => order.push("disarm"),
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		expect(controller.installUpdate().success).toBe(true);
+		expect(order).toEqual(["disarm", "quit-and-install"]);
+		controller.stop();
+	});
+
+	it("keeps the staged build when the feed stops offering it", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			checkIntervalMs: 60_000,
+		});
+
+		controller.start();
+		await vi.waitFor(() => expect(controller.getState().phase).toBe("ready"));
+		// Drain the initial check chain so the not-available check runs fresh.
+		await controller.checkForUpdates();
+
+		updater.nextCheckOutcome = "not-available";
+		await controller.checkForUpdates();
+
+		expect(controller.getState().phase).toBe("ready");
+		expect(controller.getState().staged?.version).toBe("2026.07.12.1");
+		controller.stop();
+	});
+
+	it("still reports errors normally when nothing is staged", async () => {
+		const updater = new FakeUpdater({
+			info: { version: "2026.7.1201", files: [{ size: 1_000 }] },
+		});
+		updater.nextCheckError = new Error("offline");
+		const controller = createAutoUpdateController({
+			updater,
+			currentVersion: "2026.7.1101",
+			userDataPath: createUserDataPath(),
+			logger: createLogger(),
+			sendToRenderer: () => undefined,
+			checkIntervalMs: 60_000,
+		});
+
+		await controller.checkForUpdates();
+		expect(controller.getState().phase).toBe("error");
+		expect(controller.getState().error).toBe("offline");
 	});
 
 	it("selects the largest alternative artifact and handles unknown sizes", () => {

--- a/qcut/electron/__tests__/update-staged-visibility.test.ts
+++ b/qcut/electron/__tests__/update-staged-visibility.test.ts
@@ -42,6 +42,17 @@ describe("staged update visibility", () => {
 		expect(showNotification).toHaveBeenCalledTimes(2);
 	});
 
+	it("still notifies when the dock badge throws", () => {
+		const { visibility, setDockBadge, showNotification } = createHarness();
+		setDockBadge.mockImplementation(() => {
+			throw new Error("no dock");
+		});
+
+		visibility.onUpdateStaged({ staged: STAGED });
+
+		expect(showNotification).toHaveBeenCalledTimes(1);
+	});
+
 	it("skips the dock badge off macOS and never intercepts close there", () => {
 		const { visibility, setDockBadge } = createHarness({ platform: "win32" });
 

--- a/qcut/electron/__tests__/update-staged-visibility.test.ts
+++ b/qcut/electron/__tests__/update-staged-visibility.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StagedUpdateInfo } from "../auto-update-controller";
+import { createStagedUpdateVisibility } from "../update-staged-visibility";
+
+const STAGED: StagedUpdateInfo = {
+	version: "2026.07.12.1",
+	internalVersion: "2026.7.1201",
+};
+
+function createHarness({
+	platform = "darwin" as NodeJS.Platform,
+	choice = "close" as "install" | "close",
+} = {}) {
+	const setDockBadge = vi.fn();
+	const showNotification = vi.fn();
+	const promptQuitAndInstall = vi.fn().mockResolvedValue(choice);
+	const visibility = createStagedUpdateVisibility({
+		platform,
+		setDockBadge,
+		showNotification,
+		promptQuitAndInstall,
+		logger: { log: vi.fn(), warn: vi.fn() },
+	});
+	return { visibility, setDockBadge, showNotification, promptQuitAndInstall };
+}
+
+describe("staged update visibility", () => {
+	it("badges the dock and notifies once per staged version", () => {
+		const { visibility, setDockBadge, showNotification } = createHarness();
+
+		visibility.onUpdateStaged({ staged: STAGED });
+		visibility.onUpdateStaged({ staged: STAGED });
+
+		expect(setDockBadge).toHaveBeenCalledTimes(1);
+		expect(setDockBadge).toHaveBeenCalledWith({ text: "1" });
+		expect(showNotification).toHaveBeenCalledTimes(1);
+		expect(showNotification.mock.calls[0][0].body).toContain("2026.07.12.1");
+
+		visibility.onUpdateStaged({
+			staged: { version: "2026.07.13.1", internalVersion: "2026.7.1301" },
+		});
+		expect(showNotification).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips the dock badge off macOS and never intercepts close there", () => {
+		const { visibility, setDockBadge } = createHarness({ platform: "win32" });
+
+		visibility.onUpdateStaged({ staged: STAGED });
+		expect(setDockBadge).not.toHaveBeenCalled();
+		expect(visibility.shouldInterceptClose()).toBe(false);
+	});
+
+	it("prompts at most once per staged version on close", async () => {
+		const { visibility, promptQuitAndInstall } = createHarness();
+
+		expect(visibility.shouldInterceptClose()).toBe(false);
+		visibility.onUpdateStaged({ staged: STAGED });
+		expect(visibility.shouldInterceptClose()).toBe(true);
+
+		await expect(visibility.resolveClose()).resolves.toBe("close");
+		expect(promptQuitAndInstall).toHaveBeenCalledWith({
+			version: "2026.07.12.1",
+		});
+		// The user chose to keep running; closing again must not nag.
+		expect(visibility.shouldInterceptClose()).toBe(false);
+
+		// A newer staged version may prompt again.
+		visibility.onUpdateStaged({
+			staged: { version: "2026.07.13.1", internalVersion: "2026.7.1301" },
+		});
+		expect(visibility.shouldInterceptClose()).toBe(true);
+	});
+
+	it("returns the install choice and suppresses prompts while quitting", async () => {
+		const { visibility } = createHarness({ choice: "install" });
+
+		visibility.onUpdateStaged({ staged: STAGED });
+		expect(visibility.shouldInterceptClose()).toBe(true);
+		await expect(visibility.resolveClose()).resolves.toBe("install");
+
+		const { visibility: quitting } = createHarness();
+		quitting.onUpdateStaged({ staged: STAGED });
+		quitting.setQuitting();
+		expect(quitting.shouldInterceptClose()).toBe(false);
+	});
+
+	it("treats a failed prompt as a plain close", async () => {
+		const { visibility, promptQuitAndInstall } = createHarness();
+		promptQuitAndInstall.mockRejectedValueOnce(new Error("dialog failed"));
+
+		visibility.onUpdateStaged({ staged: STAGED });
+		await expect(visibility.resolveClose()).resolves.toBe("close");
+		// The version must count as prompted even when the dialog throws;
+		// otherwise main.ts's follow-up close() would be intercepted again,
+		// looping forever on a repeatedly-failing dialog.
+		expect(visibility.shouldInterceptClose()).toBe(false);
+	});
+});

--- a/qcut/electron/__tests__/update-version.test.ts
+++ b/qcut/electron/__tests__/update-version.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	compareReleaseVersions,
 	detectUpdateChannel,
 	normalizeReleaseNotesVersion,
 	parseReleaseVersion,
@@ -58,5 +59,44 @@ describe("update version mapping", () => {
 	it("detects stable and prerelease channels", () => {
 		expect(detectUpdateChannel({ version: "2026.7.1101" })).toBe("latest");
 		expect(detectUpdateChannel({ version: "2026.7.1101-beta.2" })).toBe("beta");
+	});
+
+	it("orders versions across package and release forms", () => {
+		expect(
+			compareReleaseVersions({ left: "2026.7.1201", right: "2026.07.12.1" })
+		).toBe(0);
+		expect(
+			compareReleaseVersions({ left: "2026.7.1201", right: "2026.7.1301" })
+		).toBeLessThan(0);
+		expect(
+			compareReleaseVersions({ left: "2026.08.05.2", right: "2026.08.05.1" })
+		).toBeGreaterThan(0);
+		expect(
+			compareReleaseVersions({ left: "2027.01.02.1", right: "2026.12.31.99" })
+		).toBeGreaterThan(0);
+	});
+
+	it("ranks stable above prereleases and orders channels", () => {
+		expect(
+			compareReleaseVersions({
+				left: "2026.7.1201",
+				right: "2026.7.1201-rc.1",
+			})
+		).toBeGreaterThan(0);
+		expect(
+			compareReleaseVersions({
+				left: "2026.7.1201-alpha.2",
+				right: "2026.7.1201-beta.1",
+			})
+		).toBeLessThan(0);
+		expect(
+			compareReleaseVersions({
+				left: "2026.7.1201-rc.1",
+				right: "2026.7.1201-rc.2",
+			})
+		).toBeLessThan(0);
+		expect(() =>
+			compareReleaseVersions({ left: "not-a-version", right: "2026.7.1201" })
+		).toThrow("Invalid QCut release version");
 	});
 });

--- a/qcut/electron/auto-update-controller.ts
+++ b/qcut/electron/auto-update-controller.ts
@@ -4,7 +4,11 @@ import {
 	type UpdatePreferences,
 	writeUpdatePreferences,
 } from "./update-preferences.js";
-import { detectUpdateChannel, toReleaseVersion } from "./update-version.js";
+import {
+	compareReleaseVersions,
+	detectUpdateChannel,
+	toReleaseVersion,
+} from "./update-version.js";
 
 export type UpdatePhase =
 	| "idle"
@@ -16,6 +20,15 @@ export type UpdatePhase =
 	| "error";
 
 export type AutomaticUpdateDecision = "automatic" | "disabled" | "too-large";
+
+/** A downloaded update sitting on disk, waiting for the app to restart. */
+export interface StagedUpdateInfo {
+	version: string;
+	internalVersion: string;
+	releaseNotes?: string;
+	releaseDate?: string;
+	downloadSize?: number;
+}
 
 export interface UpdateState {
 	phase: UpdatePhase;
@@ -32,6 +45,13 @@ export interface UpdateState {
 	decision?: AutomaticUpdateDecision;
 	message?: string;
 	error?: string;
+	/**
+	 * Survives later checks: a failed hourly check must never hide an update
+	 * that is already downloaded and installable.
+	 */
+	staged?: StagedUpdateInfo;
+	/** Most recent background check/download failure while an update is staged. */
+	lastCheckError?: string;
 }
 
 export interface UpdateInfoLike {
@@ -142,6 +162,8 @@ export function createAutoUpdateController({
 	userDataPath,
 	logger,
 	sendToRenderer,
+	onUpdateStaged,
+	onBeforeQuitAndInstall,
 	checkIntervalMs = CHECK_INTERVAL_MS,
 }: {
 	updater: AutoUpdaterLike;
@@ -155,6 +177,14 @@ export function createAutoUpdateController({
 		channel: string;
 		data: unknown;
 	}) => void;
+	/** Fired once each time a downloaded update becomes installable. */
+	onUpdateStaged?: ({ staged }: { staged: StagedUpdateInfo }) => void;
+	/**
+	 * Fired synchronously before quitAndInstall. On macOS the native updater
+	 * closes windows BEFORE emitting before-quit, so any close-interception
+	 * must be disarmed here, not in a before-quit handler.
+	 */
+	onBeforeQuitAndInstall?: () => void;
 	checkIntervalMs?: number;
 }): AutoUpdateController {
 	let preferences = readUpdatePreferences({ userDataPath });
@@ -163,6 +193,7 @@ export function createAutoUpdateController({
 	let listenersRegistered = false;
 	let checkPromise: Promise<UpdateState> | undefined;
 	let downloadPromise: Promise<UpdateState> | undefined;
+	let staged: StagedUpdateInfo | undefined;
 	let state: UpdateState = {
 		phase: "idle",
 		currentVersion: toReleaseVersion({ packageVersion: currentVersion }),
@@ -173,13 +204,80 @@ export function createAutoUpdateController({
 	};
 
 	const publishState = ({ nextState }: { nextState: UpdateState }): void => {
-		state = { ...nextState };
+		state = { ...nextState, staged };
 		sendToRenderer({ channel: "update-state-changed", data: state });
 	};
 
-	const publishError = ({ error }: { error: unknown }): UpdateState => {
+	/** True when the already-staged update makes downloading `candidate` useless. */
+	const stagedCovers = ({ candidate }: { candidate: string }): boolean => {
+		if (!staged) return false;
+		try {
+			return (
+				compareReleaseVersions({
+					left: staged.internalVersion,
+					right: candidate,
+				}) >= 0
+			);
+		} catch {
+			// Unparsable versions: only an exact match is provably redundant.
+			return (
+				staged.internalVersion === candidate || staged.version === candidate
+			);
+		}
+	};
+
+	/** Rebuilds the installable state from the staged update. */
+	const stagedReadyState = ({
+		stagedUpdate,
+	}: {
+		stagedUpdate: StagedUpdateInfo;
+	}): UpdateState => ({
+		...state,
+		phase: "ready",
+		version: stagedUpdate.version,
+		internalVersion: stagedUpdate.internalVersion,
+		releaseNotes: stagedUpdate.releaseNotes,
+		releaseDate: stagedUpdate.releaseDate,
+		downloadSize: stagedUpdate.downloadSize,
+		percent: 100,
+		automaticDownload: false,
+		message: "Update ready to install",
+		error: undefined,
+		lastCheckError: undefined,
+	});
+
+	const publishError = ({
+		error,
+		source,
+	}: {
+		error: unknown;
+		source?: "check" | "download";
+	}): UpdateState => {
 		const message = error instanceof Error ? error.message : String(error);
 		logger.error("[AutoUpdater] Error:", message);
+		if (staged) {
+			// The state machine may have progressed past the staged version to a
+			// newer offer or an in-flight download; a failed background check must
+			// not rewind that progress (it would also make downloadUpdate a no-op
+			// until the next successful hourly check).
+			const progressedPastStaged =
+				(state.phase === "available" || state.phase === "downloading") &&
+				state.internalVersion !== undefined &&
+				!stagedCovers({ candidate: state.internalVersion });
+			if (progressedPastStaged && source !== "download") {
+				publishState({ nextState: { ...state, lastCheckError: message } });
+				return state;
+			}
+			// The staged update on disk is still installable; surface the
+			// background failure without demoting the ready state.
+			publishState({
+				nextState: {
+					...stagedReadyState({ stagedUpdate: staged }),
+					lastCheckError: message,
+				},
+			});
+			return state;
+		}
 		publishState({
 			nextState: {
 				...state,
@@ -195,6 +293,16 @@ export function createAutoUpdateController({
 	const downloadUpdate = async (): Promise<UpdateState> => {
 		if (state.phase === "ready") return state;
 		if (downloadPromise) return downloadPromise;
+		const requested = state.internalVersion ?? state.version;
+		if (requested !== undefined && stagedCovers({ candidate: requested })) {
+			logger.log(
+				`[AutoUpdater] Skipping download; ${requested} is already staged`
+			);
+			if (staged) {
+				publishState({ nextState: stagedReadyState({ stagedUpdate: staged }) });
+			}
+			return state;
+		}
 
 		publishState({
 			nextState: {
@@ -208,7 +316,7 @@ export function createAutoUpdateController({
 		downloadPromise = updater
 			.downloadUpdate()
 			.then(() => state)
-			.catch((error: unknown) => publishError({ error }))
+			.catch((error: unknown) => publishError({ error, source: "download" }))
 			.finally(() => {
 				downloadPromise = undefined;
 			});
@@ -216,6 +324,17 @@ export function createAutoUpdateController({
 	};
 
 	const onUpdateAvailable = ({ info }: { info: UpdateInfoLike }): void => {
+		if (stagedCovers({ candidate: info.version })) {
+			// The hourly re-check reports the same (or an older) version that is
+			// already downloaded; re-downloading it would be pure waste.
+			logger.log(
+				`[AutoUpdater] Update ${info.version} is already staged; keeping ready state`
+			);
+			if (staged) {
+				publishState({ nextState: stagedReadyState({ stagedUpdate: staged }) });
+			}
+			return;
+		}
 		const downloadSize = resolveUpdateDownloadSize({ info });
 		const decision = resolveAutomaticUpdateDecision({
 			preferences,
@@ -248,6 +367,7 @@ export function createAutoUpdateController({
 						? "A large update is available"
 						: "An update is available",
 				error: undefined,
+				lastCheckError: undefined,
 			},
 		});
 		sendToRenderer({
@@ -275,6 +395,12 @@ export function createAutoUpdateController({
 		});
 		updater.on("update-not-available", () => {
 			logger.log("[AutoUpdater] QCut is up to date");
+			if (staged) {
+				// The staged download is still newer than the running app; keep it
+				// installable instead of reporting up-to-date.
+				publishState({ nextState: stagedReadyState({ stagedUpdate: staged }) });
+				return;
+			}
 			publishState({
 				nextState: {
 					...state,
@@ -303,21 +429,26 @@ export function createAutoUpdateController({
 		updater.on("update-downloaded", (...args: unknown[]) => {
 			const info = args[0] as UpdateInfoLike;
 			const version = toReleaseVersion({ packageVersion: info.version });
+			const alreadyStaged = staged?.internalVersion === info.version;
 			logger.log(`[AutoUpdater] Update ${version} is ready to install`);
+			staged = {
+				version,
+				internalVersion: info.version,
+				releaseNotes:
+					normalizeUpdateReleaseNotes({ releaseNotes: info.releaseNotes }) ||
+					state.releaseNotes,
+				releaseDate: info.releaseDate ?? state.releaseDate,
+				downloadSize: resolveUpdateDownloadSize({ info }) ?? state.downloadSize,
+			};
 			publishState({
 				nextState: {
-					...state,
-					phase: "ready",
-					version,
-					internalVersion: info.version,
-					percent: 100,
+					...stagedReadyState({ stagedUpdate: staged }),
 					transferred: state.total,
-					automaticDownload: false,
-					message: "Update ready to install",
-					error: undefined,
+					lastCheckError: undefined,
 				},
 			});
 			sendToRenderer({ channel: "update-downloaded", data: { version } });
+			if (!alreadyStaged) onUpdateStaged?.({ staged });
 		});
 		updater.on("error", (...args: unknown[]) => {
 			publishError({ error: args[0] });
@@ -326,18 +457,22 @@ export function createAutoUpdateController({
 
 	const checkForUpdates = async (): Promise<UpdateState> => {
 		if (checkPromise) return checkPromise;
-		publishState({
-			nextState: {
-				...state,
-				phase: "checking",
-				message: "Checking for updates",
-				error: undefined,
-			},
-		});
+		// With an update staged, checks run silently in the background: the
+		// ready state must stay visible (and installable) the whole time.
+		if (!staged) {
+			publishState({
+				nextState: {
+					...state,
+					phase: "checking",
+					message: "Checking for updates",
+					error: undefined,
+				},
+			});
+		}
 		checkPromise = updater
 			.checkForUpdates()
 			.then(() => state)
-			.catch((error: unknown) => publishError({ error }))
+			.catch((error: unknown) => publishError({ error, source: "check" }))
 			.finally(() => {
 				checkPromise = undefined;
 			});
@@ -372,9 +507,10 @@ export function createAutoUpdateController({
 		checkForUpdates,
 		downloadUpdate,
 		installUpdate: () => {
-			if (state.phase !== "ready") {
+			if (state.phase !== "ready" && !staged) {
 				return { success: false, message: "Update is not downloaded yet" };
 			}
+			onBeforeQuitAndInstall?.();
 			updater.quitAndInstall();
 			return { success: true, message: "Installing update" };
 		},

--- a/qcut/electron/main.ts
+++ b/qcut/electron/main.ts
@@ -9,8 +9,11 @@
 
 import {
 	app,
+	autoUpdater as nativeAutoUpdater,
 	BrowserWindow,
+	dialog,
 	ipcMain,
+	Notification,
 	protocol,
 	session,
 	screen,
@@ -31,6 +34,10 @@ import {
 	type AutoUpdaterLike,
 } from "./auto-update-controller.js";
 import { resolveAutoUpdateConfig } from "./auto-update-config.js";
+import {
+	createStagedUpdateVisibility,
+	type StagedUpdateVisibility,
+} from "./update-staged-visibility.js";
 import {
 	createCodexPluginUpdateController,
 	type CodexPluginUpdateController,
@@ -101,6 +108,7 @@ import { installEpipeGuard } from "./safe-console.js";
 installEpipeGuard();
 
 let updateController: AutoUpdateController | null = null;
+let stagedUpdateVisibility: StagedUpdateVisibility | null = null;
 let codexPluginUpdateController: CodexPluginUpdateController | null = null;
 let jianyingEnvelopeKeyController: JianyingEnvelopeKeyIPCController | null =
 	null;
@@ -399,6 +407,40 @@ function setupAutoUpdater(): void {
 				`[AutoUpdater] ${updateConfig.packagedConfigError}; using official fallback: ${updateConfig.configPath}`
 			);
 		}
+		stagedUpdateVisibility = createStagedUpdateVisibility({
+			platform: process.platform,
+			setDockBadge: ({ text }) => {
+				app.dock?.setBadge(text);
+			},
+			showNotification: ({ title, body }) => {
+				if (!Notification.isSupported()) return;
+				const notification = new Notification({ title, body });
+				notification.on("click", () => {
+					if (mainWindow && !mainWindow.isDestroyed()) {
+						mainWindow.show();
+					}
+				});
+				notification.show();
+			},
+			promptQuitAndInstall: async ({ version }) => {
+				const target =
+					mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
+				const options = {
+					type: "info" as const,
+					buttons: ["Quit and Install", "Keep Running"],
+					defaultId: 0,
+					cancelId: 1,
+					message: `QCut ${version} is ready to install.`,
+					detail:
+						"Install the update now, or keep QCut running in the background and install it the next time you quit.",
+				};
+				const { response } = target
+					? await dialog.showMessageBox(target, options)
+					: await dialog.showMessageBox(options);
+				return response === 0 ? "install" : "close";
+			},
+			logger,
+		});
 		updateController = createAutoUpdateController({
 			updater: updaterModule.autoUpdater,
 			currentVersion: app.getVersion(),
@@ -408,6 +450,14 @@ function setupAutoUpdater(): void {
 				if (mainWindow && !mainWindow.isDestroyed()) {
 					mainWindow.webContents.send(channel, data);
 				}
+			},
+			onUpdateStaged: ({ staged }) => {
+				stagedUpdateVisibility?.onUpdateStaged({ staged });
+			},
+			onBeforeQuitAndInstall: () => {
+				// macOS quitAndInstall closes windows BEFORE before-quit fires, so
+				// the close-prompt must be disarmed here or it hijacks the install.
+				stagedUpdateVisibility?.setQuitting();
 			},
 		});
 		updateController.start();
@@ -686,6 +736,24 @@ function createWindow(): void {
 	});
 
 	// Window event handlers
+	mainWindow.on("close", (event) => {
+		// macOS keeps QCut alive after the last window closes, so a staged
+		// update would otherwise wait forever for ShipIt. Offer to install now.
+		if (!stagedUpdateVisibility?.shouldInterceptClose()) return;
+		event.preventDefault();
+		void stagedUpdateVisibility.resolveClose().then((choice) => {
+			if (choice === "install") {
+				stagedUpdateVisibility?.setQuitting();
+				updateController?.installUpdate();
+				return;
+			}
+			if (mainWindow && !mainWindow.isDestroyed()) {
+				// The staged version is now marked as prompted, so this close
+				// passes straight through.
+				mainWindow.close();
+			}
+		});
+	});
 	mainWindow.on("closed", () => {
 		mainWindow = null;
 	});
@@ -1023,7 +1091,19 @@ if (!isCliKeyCommand && !isHeadlessRecorder) {
 // window-all-closed never quits the app on macOS, so the temp cleanup in
 // that handler historically never ran there and $TMPDIR/qcut-* grew without
 // bound. before-quit fires on every platform.
+// Emitted by the native macOS updater before it closes windows for an
+// install; before-quit fires only AFTER those closes, which is too late to
+// disarm the staged-update close prompt.
+if (process.platform === "darwin") {
+	nativeAutoUpdater.on("before-quit-for-update", () => {
+		stagedUpdateVisibility?.setQuitting();
+	});
+}
+
 app.on("before-quit", () => {
+	// A real quit is underway; the staged-update close prompt must not
+	// preventDefault the window teardown.
+	stagedUpdateVisibility?.setQuitting();
 	if (isHeadlessRecorder) return;
 	jianyingDraftExportController?.dispose();
 	jianyingDraftExportController = null;

--- a/qcut/electron/main.ts
+++ b/qcut/electron/main.ts
@@ -743,13 +743,20 @@ function createWindow(): void {
 		event.preventDefault();
 		void stagedUpdateVisibility.resolveClose().then((choice) => {
 			if (choice === "install") {
-				stagedUpdateVisibility?.setQuitting();
-				updateController?.installUpdate();
-				return;
+				// The controller's onBeforeQuitAndInstall hook disarms the prompt
+				// only when the install actually starts, so a failed start leaves
+				// future staged versions able to prompt again.
+				const result = updateController?.installUpdate();
+				if (result?.success) return;
+				logger.warn(
+					"[AutoUpdater] Quit-and-install did not start:",
+					result?.message ?? "update controller unavailable"
+				);
 			}
 			if (mainWindow && !mainWindow.isDestroyed()) {
 				// The staged version is now marked as prompted, so this close
-				// passes straight through.
+				// passes straight through — including when the install failed to
+				// start, so the window never silently stays open.
 				mainWindow.close();
 			}
 		});

--- a/qcut/electron/update-staged-visibility.ts
+++ b/qcut/electron/update-staged-visibility.ts
@@ -54,8 +54,21 @@ export function createStagedUpdateVisibility({
 			staged = nextStaged;
 			if (notifiedVersions.has(nextStaged.internalVersion)) return;
 			notifiedVersions.add(nextStaged.internalVersion);
+			// Each side effect fails independently: a dock-badge failure must not
+			// suppress the notification (the version is already marked notified).
+			if (platform === "darwin") {
+				try {
+					setDockBadge({ text: "1" });
+				} catch (error: unknown) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					logger.warn(
+						"[AutoUpdater] Staged-update dock badge failed:",
+						message
+					);
+				}
+			}
 			try {
-				if (platform === "darwin") setDockBadge({ text: "1" });
 				showNotification({
 					title: "QCut update ready",
 					body: `QCut ${nextStaged.version} will install the next time you quit the app.`,

--- a/qcut/electron/update-staged-visibility.ts
+++ b/qcut/electron/update-staged-visibility.ts
@@ -1,0 +1,98 @@
+import type { StagedUpdateInfo } from "./auto-update-controller.js";
+
+/**
+ * macOS-facing visibility for a staged (downloaded, waiting-for-restart)
+ * update. On macOS closing the last window keeps QCut alive, so ShipIt may
+ * never get a real quit; this module makes the pending install obvious:
+ * dock badge, one system notification per version, and a quit-and-install
+ * prompt when the user closes the main window.
+ */
+export interface StagedUpdateVisibilityDependencies {
+	platform: NodeJS.Platform;
+	setDockBadge: ({ text }: { text: string }) => void;
+	showNotification: ({ title, body }: { title: string; body: string }) => void;
+	promptQuitAndInstall: ({
+		version,
+	}: {
+		version: string;
+	}) => Promise<"install" | "close">;
+	logger: {
+		log(message?: unknown, ...optionalParams: unknown[]): void;
+		warn(message?: unknown, ...optionalParams: unknown[]): void;
+	};
+}
+
+export interface StagedUpdateVisibility {
+	/** Badge the dock and notify once for a newly staged update. */
+	onUpdateStaged({ staged }: { staged: StagedUpdateInfo }): void;
+	/** Suppresses the close prompt once a real quit is underway. */
+	setQuitting(): void;
+	/**
+	 * True when closing the main window should be intercepted to offer
+	 * quit-and-install. Each staged version prompts at most once.
+	 */
+	shouldInterceptClose(): boolean;
+	/** Shows the prompt for the currently staged version. */
+	resolveClose(): Promise<"install" | "close">;
+}
+
+export function createStagedUpdateVisibility({
+	platform,
+	setDockBadge,
+	showNotification,
+	promptQuitAndInstall,
+	logger,
+}: StagedUpdateVisibilityDependencies): StagedUpdateVisibility {
+	let staged: StagedUpdateInfo | undefined;
+	let quitting = false;
+	let promptInFlight = false;
+	const notifiedVersions = new Set<string>();
+	const promptedVersions = new Set<string>();
+
+	return {
+		onUpdateStaged: ({ staged: nextStaged }) => {
+			staged = nextStaged;
+			if (notifiedVersions.has(nextStaged.internalVersion)) return;
+			notifiedVersions.add(nextStaged.internalVersion);
+			try {
+				if (platform === "darwin") setDockBadge({ text: "1" });
+				showNotification({
+					title: "QCut update ready",
+					body: `QCut ${nextStaged.version} will install the next time you quit the app.`,
+				});
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.warn(
+					"[AutoUpdater] Staged-update notification failed:",
+					message
+				);
+			}
+		},
+		setQuitting: () => {
+			quitting = true;
+		},
+		shouldInterceptClose: () => {
+			if (platform !== "darwin" || quitting || promptInFlight) return false;
+			if (!staged) return false;
+			return !promptedVersions.has(staged.internalVersion);
+		},
+		resolveClose: async () => {
+			if (!staged) return "close";
+			promptInFlight = true;
+			promptedVersions.add(staged.internalVersion);
+			try {
+				const choice = await promptQuitAndInstall({ version: staged.version });
+				logger.log(
+					`[AutoUpdater] Close prompt for ${staged.version}: ${choice}`
+				);
+				return choice;
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.warn("[AutoUpdater] Close prompt failed:", message);
+				return "close";
+			} finally {
+				promptInFlight = false;
+			}
+		},
+	};
+}

--- a/qcut/electron/update-version.ts
+++ b/qcut/electron/update-version.ts
@@ -108,6 +108,47 @@ export function normalizeReleaseNotesVersion({
 	}
 }
 
+const PRERELEASE_CHANNEL_ORDER: Record<string, number> = {
+	alpha: 0,
+	beta: 1,
+	rc: 2,
+};
+
+/**
+ * Compares two QCut versions (package or release form). Returns a negative
+ * number when `left` is older, positive when newer, and 0 when equal.
+ * Throws when either version cannot be parsed as a QCut release version.
+ */
+export function compareReleaseVersions({
+	left,
+	right,
+}: {
+	left: string;
+	right: string;
+}): number {
+	const a = parseReleaseVersion({
+		version: toReleaseVersion({ packageVersion: left }),
+	});
+	const b = parseReleaseVersion({
+		version: toReleaseVersion({ packageVersion: right }),
+	});
+
+	const calendar =
+		a.year - b.year || a.month - b.month || a.day - b.day || a.build - b.build;
+	if (calendar !== 0) return calendar;
+
+	// A stable build is newer than any prerelease of the same build.
+	if (a.prerelease === null && b.prerelease === null) return 0;
+	if (a.prerelease === null) return 1;
+	if (b.prerelease === null) return -1;
+
+	const channelDelta =
+		(PRERELEASE_CHANNEL_ORDER[a.prerelease.channel] ?? -1) -
+		(PRERELEASE_CHANNEL_ORDER[b.prerelease.channel] ?? -1);
+	if (channelDelta !== 0) return channelDelta;
+	return a.prerelease.number - b.prerelease.number;
+}
+
 export function detectUpdateChannel({
 	version,
 }: {

--- a/qcut/packages/platform-core/src/index.ts
+++ b/qcut/packages/platform-core/src/index.ts
@@ -74,6 +74,7 @@ export type {
 	PlatformUpdatesAPI,
 	PlatformUpdatePhase,
 	PlatformAutomaticUpdateDecision,
+	PlatformStagedUpdateInfo,
 	PlatformUpdatePreferences,
 	PlatformUpdateState,
 	PlatformCodexPluginUpdatePhase,

--- a/qcut/packages/platform-core/src/types/integration-api.ts
+++ b/qcut/packages/platform-core/src/types/integration-api.ts
@@ -612,6 +612,14 @@ export interface PlatformUpdatePreferences {
 	maxAutomaticDownloadBytes: number;
 }
 
+export interface PlatformStagedUpdateInfo {
+	version: string;
+	internalVersion: string;
+	releaseNotes?: string;
+	releaseDate?: string;
+	downloadSize?: number;
+}
+
 export interface PlatformUpdateState {
 	phase: PlatformUpdatePhase;
 	currentVersion: string;
@@ -627,6 +635,10 @@ export interface PlatformUpdateState {
 	decision?: PlatformAutomaticUpdateDecision;
 	message?: string;
 	error?: string;
+	/** Downloaded update waiting for a restart; survives failed later checks. */
+	staged?: PlatformStagedUpdateInfo;
+	/** Most recent background check failure while an update is staged. */
+	lastCheckError?: string;
 }
 
 export type PlatformCodexPluginUpdatePhase =


### PR DESCRIPTION
## Problem

Field logs showed three failure modes in the auto-updater (QCut running 21+ hours on macOS):

1. **A downloaded update was erased by later failed checks** — v2903 was staged and ready, but when the hourly checks for 3001/3002 hit DNS/network errors, the single-phase state machine went `checking` → `error`, hiding the installable build sitting on disk.
2. **The same version was re-downloaded repeatedly** — logs show 2903 hitting "ready" at 17:23, 19:34, 20:54, 22:10, 00:18: every hourly check flipped `ready` → `available` → download again.
3. **macOS never installed** — closing the window keeps QCut alive, so ShipIt never saw a real quit and the staged update waited forever, invisibly.

## Fix

**Controller state model** ([auto-update-controller.ts](../blob/fix/auto-update-staged-state/qcut/electron/auto-update-controller.ts))
- New `staged` field (survives checks) + `lastCheckError` on `UpdateState`; additive fields on `PlatformUpdateState`, adapters pass through unchanged
- Check failures with a staged build fall back to `ready` + `lastCheckError` instead of `error`; background checks run silently (no `checking` flicker) while staged
- A failed check does **not** rewind past a newer `available`/`downloading` offer (kept manual download for a newer too-large build working); download failures fall back to the staged build
- `lastCheckError` clears on the next successful check
- `update-not-available` keeps the staged build installable instead of reporting up-to-date

**Download dedupe** ([update-version.ts](../blob/fix/auto-update-staged-state/qcut/electron/update-version.ts))
- `compareReleaseVersions` (calendar order, stable > prerelease, alpha < beta < rc)
- `stagedCovers` guards both `update-available` and `downloadUpdate`: same-or-older candidates never re-download; genuinely newer versions still do

**macOS visibility** ([update-staged-visibility.ts](../blob/fix/auto-update-staged-state/qcut/electron/update-staged-visibility.ts) + main.ts)
- Dock badge + one system notification per staged version (notification click focuses the window)
- Closing the last window with a staged update prompts "Quit and Install / Keep Running" — at most once per version, disarmed on real quits
- `onBeforeQuitAndInstall` hook disarms the prompt before `quitAndInstall` (on macOS the native updater closes windows **before** `before-quit` fires), with a native `before-quit-for-update` backstop

## Review

Ran a 3-lens adversarial review workflow (state-machine / lifecycle / test-races, 10 agents) over the diff; all 5 confirmed findings fixed in this PR, including a high-severity one where the close prompt would have hijacked the renderer's own "Restart" button and installed even after "Keep Running".

## Test plan
- [x] 41 tests green across the 7 update suites (12 controller tests incl. failed-check-preserves-staged, dedupe, newer-over-staged, available-survives-failed-check, download-failure fallback, disarm-before-install; 5 visibility tests incl. failed-prompt loop guard)
- [x] `bun check-types` clean
- [x] Biome clean

Not covered (follow-ups from the original analysis, out of scope here): exponential backoff/resume on network failures, split auto-check/auto-download preferences, error surfacing in the renderer notification, atomic release publishing, real ShipIt E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Downloaded updates now remain ready to install across background checks and temporary update errors.
  - Added update visibility through macOS dock badges and notifications.
  - Closing the app with a staged update can prompt users to install it immediately.
  - Update status now includes staged version details and recent check errors.

- **Bug Fixes**
  - Prevented duplicate downloads and preserved newer available updates.
  - Improved fallback behavior when downloads fail or updates become temporarily unavailable.
  - Added reliable release-version ordering across stable and prerelease versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->