### PR TITLE
feat(update): harden CLI and plugin update flow

### DIFF
--- a/qcut/electron/__tests__/app-update-cache.test.ts
+++ b/qcut/electron/__tests__/app-update-cache.test.ts
@@ -103,6 +103,39 @@ describe("app update cache", () => {
 		expect(fs.existsSync(installerPath)).toBe(false);
 	});
 
+	it("rejects asset names that are not direct filenames", async () => {
+		const content = Buffer.from("verified update payload");
+		const workingDirectory = createDirectory();
+		const cache = createDirectory();
+		for (const name of ["../escape.zip", "a/b.zip", "..", ".", ""]) {
+			const found = await findReusableInstaller({
+				asset: { ...assetFor({ content }), name },
+				copyToDirectory: workingDirectory,
+				directories: [cache],
+			});
+			expect(found).toBeUndefined();
+		}
+	});
+
+	it("never deletes through a traversal in the preserved path", () => {
+		const cache = createDirectory();
+		const outside = createDirectory();
+		const victim = path.join(outside, "victim.zip");
+		fs.writeFileSync(victim, "keep me");
+
+		discardPreservedInstaller({
+			preservedPath: path.join(
+				cache,
+				"..",
+				path.basename(outside),
+				"victim.zip"
+			),
+			directory: cache,
+		});
+
+		expect(fs.existsSync(victim)).toBe(true);
+	});
+
 	it("only discards files inside the CLI cache directory", () => {
 		const cache = createDirectory();
 		const foreign = createDirectory();

--- a/qcut/electron/__tests__/app-update-cache.test.ts
+++ b/qcut/electron/__tests__/app-update-cache.test.ts
@@ -160,8 +160,14 @@ describe("app update cache", () => {
 				env: {},
 			})
 		).toEqual([
-			"/Users/example/Library/Caches/qcut-updater/pending",
-			"/Users/example/Library/Caches/qcut-cli-updates",
+			path.join(
+				"/Users/example",
+				"Library",
+				"Caches",
+				"qcut-updater",
+				"pending"
+			),
+			path.join("/Users/example", "Library", "Caches", "qcut-cli-updates"),
 		]);
 		expect(
 			resolveCliUpdateCacheDirectory({

--- a/qcut/electron/__tests__/app-update-cache.test.ts
+++ b/qcut/electron/__tests__/app-update-cache.test.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	defaultUpdateCacheDirectories,
+	discardPreservedInstaller,
+	findReusableInstaller,
+	preserveInstallerFile,
+	resolveCliUpdateCacheDirectory,
+} from "../app-update-cache";
+
+const temporaryDirectories: string[] = [];
+
+function createDirectory(): string {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "qcut-cache-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function assetFor({ content }: { content: Buffer }) {
+	return {
+		name: "QCut-AI-Video-Editor-2026.8.702-arm64-mac.zip",
+		url: "https://github.com/Quriosity-agent/qcut/releases/download/v2026.08.07.2/QCut-AI-Video-Editor-2026.8.702-arm64-mac.zip",
+		size: content.byteLength,
+		digest: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+	};
+}
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		fs.rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("app update cache", () => {
+	it("copies a matching cached package into the private directory", async () => {
+		const content = Buffer.from("verified update payload");
+		const asset = assetFor({ content });
+		const pending = createDirectory();
+		const cache = createDirectory();
+		const workingDirectory = createDirectory();
+		fs.writeFileSync(path.join(cache, asset.name), content);
+
+		const found = await findReusableInstaller({
+			asset,
+			copyToDirectory: workingDirectory,
+			directories: [pending, cache],
+		});
+
+		// The verified installer is the private copy, never the shared cache
+		// path — a same-uid process must not be able to swap the bytes
+		// between verification and a privileged install.
+		expect(found?.installerPath).toBe(path.join(workingDirectory, asset.name));
+		expect(found?.sourcePath).toBe(path.join(cache, asset.name));
+		expect(fs.readFileSync(found?.installerPath as string)).toEqual(content);
+	});
+
+	it("skips size mismatches, digest mismatches, and missing directories", async () => {
+		const content = Buffer.from("verified update payload");
+		const asset = assetFor({ content });
+		const workingDirectory = createDirectory();
+		const wrongSize = createDirectory();
+		fs.writeFileSync(path.join(wrongSize, asset.name), Buffer.from("short"));
+		const wrongDigest = createDirectory();
+		fs.writeFileSync(
+			path.join(wrongDigest, asset.name),
+			Buffer.from("same-length payload!!!!")
+		);
+		expect(fs.statSync(path.join(wrongDigest, asset.name)).size).toBe(
+			asset.size
+		);
+
+		const found = await findReusableInstaller({
+			asset,
+			copyToDirectory: workingDirectory,
+			directories: [
+				wrongSize,
+				wrongDigest,
+				path.join(wrongSize, "does-not-exist"),
+			],
+		});
+
+		expect(found).toBeUndefined();
+		// Rejected candidates must not leave partial copies behind.
+		expect(fs.existsSync(path.join(workingDirectory, asset.name))).toBe(false);
+	});
+
+	it("preserves a downloaded installer for the next attempt", () => {
+		const source = createDirectory();
+		const cache = createDirectory();
+		const installerPath = path.join(source, "update.zip");
+		fs.writeFileSync(installerPath, "payload");
+
+		const preserved = preserveInstallerFile({
+			installerPath,
+			directory: path.join(cache, "qcut-cli-updates"),
+		});
+
+		expect(preserved).toBe(path.join(cache, "qcut-cli-updates", "update.zip"));
+		expect(fs.readFileSync(preserved as string, "utf8")).toBe("payload");
+		expect(fs.existsSync(installerPath)).toBe(false);
+	});
+
+	it("only discards files inside the CLI cache directory", () => {
+		const cache = createDirectory();
+		const foreign = createDirectory();
+		const owned = path.join(cache, "update.zip");
+		const notOwned = path.join(foreign, "update.zip");
+		fs.writeFileSync(owned, "ours");
+		fs.writeFileSync(notOwned, "theirs");
+
+		discardPreservedInstaller({ preservedPath: owned, directory: cache });
+		discardPreservedInstaller({ preservedPath: notOwned, directory: cache });
+
+		expect(fs.existsSync(owned)).toBe(false);
+		// The app's own electron-updater staging area must never be touched.
+		expect(fs.existsSync(notOwned)).toBe(true);
+	});
+
+	it("derives per-platform cache locations", () => {
+		expect(
+			defaultUpdateCacheDirectories({
+				platform: "darwin",
+				home: "/Users/example",
+				env: {},
+			})
+		).toEqual([
+			"/Users/example/Library/Caches/qcut-updater/pending",
+			"/Users/example/Library/Caches/qcut-cli-updates",
+		]);
+		expect(
+			resolveCliUpdateCacheDirectory({
+				platform: "linux",
+				home: "/home/example",
+				env: { XDG_CACHE_HOME: "/tmp/xdg" },
+			})
+		).toBe(path.join("/tmp/xdg", "qcut-cli-updates"));
+		const windows = defaultUpdateCacheDirectories({
+			platform: "win32",
+			home: "C:\\Users\\example",
+			env: { LOCALAPPDATA: "C:\\Users\\example\\AppData\\Local" },
+		});
+		expect(windows[0]).toContain("qcut-updater");
+		expect(windows[1]).toContain("qcut-cli-updates");
+	});
+});

--- a/qcut/electron/app-update-cache.ts
+++ b/qcut/electron/app-update-cache.ts
@@ -1,0 +1,193 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import {
+	copyFileSync,
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type { QCutReleaseAsset } from "./app-update-release.js";
+
+/**
+ * Locations that may already hold a fully-downloaded update package:
+ * the app's electron-updater staging cache (updaterCacheDirName in
+ * app-update.yml) and the CLI's own preserved-installer cache. Reusing a
+ * verified package there avoids re-downloading hundreds of megabytes.
+ */
+const ELECTRON_UPDATER_CACHE_NAME = "qcut-updater";
+const CLI_UPDATE_CACHE_NAME = "qcut-cli-updates";
+
+function platformCacheRoot({
+	platform,
+	home,
+	env,
+}: {
+	platform: NodeJS.Platform;
+	home: string;
+	env: NodeJS.ProcessEnv;
+}): string {
+	if (platform === "darwin") return join(home, "Library", "Caches");
+	if (platform === "win32") {
+		return env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+	}
+	return env.XDG_CACHE_HOME ?? join(home, ".cache");
+}
+
+export function resolveCliUpdateCacheDirectory({
+	platform = process.platform,
+	home = homedir(),
+	env = process.env,
+}: {
+	platform?: NodeJS.Platform;
+	home?: string;
+	env?: NodeJS.ProcessEnv;
+} = {}): string {
+	return join(
+		platformCacheRoot({ platform, home, env }),
+		CLI_UPDATE_CACHE_NAME
+	);
+}
+
+export function defaultUpdateCacheDirectories({
+	platform = process.platform,
+	home = homedir(),
+	env = process.env,
+}: {
+	platform?: NodeJS.Platform;
+	home?: string;
+	env?: NodeJS.ProcessEnv;
+} = {}): string[] {
+	const root = platformCacheRoot({ platform, home, env });
+	return [
+		join(root, ELECTRON_UPDATER_CACHE_NAME, "pending"),
+		join(root, CLI_UPDATE_CACHE_NAME),
+	];
+}
+
+function fileSha256({ filePath }: { filePath: string }): Promise<string> {
+	return new Promise((resolvePromise, rejectPromise) => {
+		const hash = createHash("sha256");
+		const stream = createReadStream(filePath);
+		stream.on("data", (chunk) => hash.update(chunk));
+		stream.on("error", rejectPromise);
+		stream.on("end", () => resolvePromise(hash.digest("hex")));
+	});
+}
+
+function digestMatches({
+	actual,
+	expected,
+}: {
+	actual: string;
+	expected: string;
+}): boolean {
+	const actualBytes = Buffer.from(actual, "hex");
+	const expectedBytes = Buffer.from(expected, "hex");
+	return (
+		actualBytes.length === expectedBytes.length &&
+		timingSafeEqual(actualBytes, expectedBytes)
+	);
+}
+
+export interface ReusableInstaller {
+	/** Private, verified copy inside the caller's working directory. */
+	installerPath: string;
+	/** Cache file the copy came from (for post-install cleanup). */
+	sourcePath: string;
+}
+
+/**
+ * Finds an already-downloaded copy of `asset` in the cache directories and,
+ * before trusting it, copies it into `copyToDirectory` (the caller's fresh
+ * 0700 mkdtemp) and verifies size + SHA-256 on that private copy. Verifying
+ * the same inode that gets installed closes the window where a same-uid
+ * process swaps the file at its predictable cache path between the hash and
+ * a privileged consumer (e.g. `sudo dpkg -i`). Candidates that cannot be
+ * read or fail verification are skipped silently — the caller falls back to
+ * a normal download.
+ */
+export async function findReusableInstaller({
+	asset,
+	copyToDirectory,
+	directories = defaultUpdateCacheDirectories(),
+}: {
+	asset: QCutReleaseAsset;
+	copyToDirectory: string;
+	directories?: string[];
+}): Promise<ReusableInstaller | undefined> {
+	const expectedDigest = asset.digest.slice("sha256:".length);
+	const privatePath = join(copyToDirectory, asset.name);
+	for (const directory of directories) {
+		const candidate = join(directory, asset.name);
+		try {
+			if (!existsSync(candidate)) continue;
+			if (statSync(candidate).size !== asset.size) continue;
+			copyFileSync(candidate, privatePath);
+			if (statSync(privatePath).size !== asset.size) {
+				rmSync(privatePath, { force: true });
+				continue;
+			}
+			const actualDigest = await fileSha256({ filePath: privatePath });
+			if (digestMatches({ actual: actualDigest, expected: expectedDigest })) {
+				return { installerPath: privatePath, sourcePath: candidate };
+			}
+			rmSync(privatePath, { force: true });
+		} catch {
+			// Unreadable or racing candidates fall through to the next source.
+			rmSync(privatePath, { force: true });
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Best-effort: moves a fully-downloaded installer into the CLI update cache
+ * so a failed install can retry without re-downloading. Returns the
+ * preserved path, or undefined when preservation itself fails.
+ */
+export function preserveInstallerFile({
+	installerPath,
+	directory = resolveCliUpdateCacheDirectory(),
+}: {
+	installerPath: string;
+	directory?: string;
+}): string | undefined {
+	try {
+		mkdirSync(directory, { recursive: true });
+		const preservedPath = join(directory, basename(installerPath));
+		rmSync(preservedPath, { force: true });
+		try {
+			renameSync(installerPath, preservedPath);
+		} catch {
+			// Rename fails across devices (tmpdir -> home); fall back to copy.
+			copyFileSync(installerPath, preservedPath);
+			rmSync(installerPath, { force: true });
+		}
+		return preservedPath;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Removes a previously preserved installer once it has served its purpose. */
+export function discardPreservedInstaller({
+	preservedPath,
+	directory = resolveCliUpdateCacheDirectory(),
+}: {
+	preservedPath: string;
+	directory?: string;
+}): void {
+	// Only ever delete files inside the CLI's own cache; reused packages from
+	// the app's electron-updater staging area belong to the app.
+	if (
+		!preservedPath.startsWith(`${directory}/`) &&
+		!preservedPath.startsWith(`${directory}\\`)
+	) {
+		return;
+	}
+	rmSync(preservedPath, { force: true });
+}

--- a/qcut/electron/app-update-cache.ts
+++ b/qcut/electron/app-update-cache.ts
@@ -9,7 +9,7 @@ import {
 	statSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import type { QCutReleaseAsset } from "./app-update-release.js";
 
 /**
@@ -68,6 +68,22 @@ export function defaultUpdateCacheDirectories({
 	];
 }
 
+/**
+ * Release asset names are validated upstream, but this module joins them
+ * into privileged install paths, so it re-rejects anything that is not a
+ * plain direct filename.
+ */
+function isDirectFileName({ name }: { name: string }): boolean {
+	return (
+		name.length > 0 &&
+		name !== "." &&
+		name !== ".." &&
+		!name.includes("/") &&
+		!name.includes("\\") &&
+		!name.includes("\0")
+	);
+}
+
 function fileSha256({ filePath }: { filePath: string }): Promise<string> {
 	return new Promise((resolvePromise, rejectPromise) => {
 		const hash = createHash("sha256");
@@ -119,6 +135,7 @@ export async function findReusableInstaller({
 	copyToDirectory: string;
 	directories?: string[];
 }): Promise<ReusableInstaller | undefined> {
+	if (!isDirectFileName({ name: asset.name })) return undefined;
 	const expectedDigest = asset.digest.slice("sha256:".length);
 	const privatePath = join(copyToDirectory, asset.name);
 	for (const directory of directories) {
@@ -181,12 +198,10 @@ export function discardPreservedInstaller({
 	preservedPath: string;
 	directory?: string;
 }): void {
-	// Only ever delete files inside the CLI's own cache; reused packages from
-	// the app's electron-updater staging area belong to the app.
-	if (
-		!preservedPath.startsWith(`${directory}/`) &&
-		!preservedPath.startsWith(`${directory}\\`)
-	) {
+	// Only ever delete direct children of the CLI's own cache; reused
+	// packages from the app's electron-updater staging area belong to the
+	// app, and a `directory/../outside` path must never reach rmSync.
+	if (resolve(preservedPath) !== resolve(directory, basename(preservedPath))) {
 		return;
 	}
 	rmSync(preservedPath, { force: true });

--- a/qcut/electron/native-pipeline/cli/cli-handlers-app-update.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-app-update.ts
@@ -1,6 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	discardPreservedInstaller,
+	findReusableInstaller,
+	preserveInstallerFile,
+} from "../../app-update-cache.js";
 import { discoverInstalledQCutApp } from "../../app-update-discovery.js";
 import { installQCutPackage } from "../../app-update-install.js";
 import {
@@ -21,6 +26,9 @@ export async function handleAppUpdate(
 ): Promise<CLIResult> {
 	const workingDirectory = mkdtempSync(join(tmpdir(), "qcut-update-"));
 	let preserveInstaller = false;
+	// Set only after this run fully downloads and digest-verifies a package;
+	// the failure path preserves that file for the next attempt.
+	let downloadedInstallerPath: string | undefined;
 	try {
 		const app = discoverInstalledQCutApp();
 		onProgress({
@@ -75,20 +83,41 @@ export async function handleAppUpdate(
 			};
 		}
 
-		const installerPath = join(workingDirectory, release.asset.name);
-		await downloadQCutReleaseAsset({
+		// A fully verified copy may already exist: the running app stages
+		// updates through electron-updater, and a previously failed CLI run
+		// preserves its download. Reusing one skips the multi-hundred-MB pull.
+		// The copy is re-verified inside this run's private tmpdir, so the
+		// installed bytes can no longer be swapped at the shared cache path.
+		let installerPath = join(workingDirectory, release.asset.name);
+		const reused = await findReusableInstaller({
 			asset: release.asset,
-			destinationPath: installerPath,
-			signal,
-			onProgress: ({ transferred, total }) => {
-				const percent = total > 0 ? Math.round((transferred / total) * 90) : 0;
-				onProgress({
-					stage: "download",
-					percent,
-					message: `Downloading QCut ${release.version}`,
-				});
-			},
+			copyToDirectory: workingDirectory,
 		});
+		if (reused) {
+			installerPath = reused.installerPath;
+			onProgress({
+				stage: "download",
+				percent: 90,
+				message: `Reusing the verified QCut ${release.version} package already on disk`,
+			});
+		} else {
+			const version = release.version;
+			await downloadQCutReleaseAsset({
+				asset: release.asset,
+				destinationPath: installerPath,
+				signal,
+				onProgress: ({ transferred, total }) => {
+					const percent =
+						total > 0 ? Math.round((transferred / total) * 90) : 0;
+					onProgress({
+						stage: "download",
+						percent,
+						message: `Downloading QCut ${version}`,
+					});
+				},
+			});
+			downloadedInstallerPath = installerPath;
+		}
 		onProgress({
 			stage: "install",
 			percent: 95,
@@ -101,6 +130,12 @@ export async function handleAppUpdate(
 			noLaunch: options.noLaunch,
 		});
 		preserveInstaller = installation.preserveInstaller;
+		if (reused) {
+			// The install ran from the private copy, so the cache original has
+			// served its purpose. Only CLI-preserved files are removed; staged
+			// packages owned by the app's own updater are left alone.
+			discardPreservedInstaller({ preservedPath: reused.sourcePath });
+		}
 		onProgress({
 			stage: "complete",
 			percent: 100,
@@ -116,11 +151,17 @@ export async function handleAppUpdate(
 			},
 		};
 	} catch (error: unknown) {
+		// Keep a fully downloaded, digest-verified package so the retry can
+		// skip the download (findReusableInstaller picks it up next run).
+		const preservedPath =
+			downloadedInstallerPath && existsSync(downloadedInstallerPath)
+				? preserveInstallerFile({ installerPath: downloadedInstallerPath })
+				: undefined;
 		return {
 			success: false,
 			error: `QCut update failed: ${
 				error instanceof Error ? error.message : String(error)
-			}`,
+			}${preservedPath ? ` (downloaded package kept at ${preservedPath}; rerun to reuse it)` : ""}`,
 		};
 	} finally {
 		if (!preserveInstaller) {

--- a/qcut/plugins/qcut/.claude-plugin/plugin.json
+++ b/qcut/plugins/qcut/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "qcut",
 	"displayName": "QCut",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Create media and control the QCut desktop video editor from Claude Code.",
 	"author": {
 		"name": "Quriosity Pty Ltd",

--- a/qcut/plugins/qcut/.codex-plugin/plugin.json
+++ b/qcut/plugins/qcut/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "qcut",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Create media and control the QCut desktop video editor from Codex.",
 	"author": {
 		"name": "Quriosity Pty Ltd",

--- a/qcut/plugins/qcut/scripts/qcut-setup.mjs
+++ b/qcut/plugins/qcut/scripts/qcut-setup.mjs
@@ -44,8 +44,19 @@ export async function getQCutSetupStatus({
 	fetchImpl = globalThis.fetch,
 } = {}) {
 	const editor = resolved ? inspectQCut({ resolved, env }) : null;
+	// Mirror updateQCutApp's asset preferences so the asset shown to the user
+	// is the one an update would actually install.
 	const latest = online
-		? await fetchLatestQCutRelease({ fetchImpl, platform, arch })
+		? await fetchLatestQCutRelease({
+				fetchImpl,
+				platform,
+				arch,
+				preferArchive: true,
+				preferDeb:
+					app.installed &&
+					app.platform === "linux" &&
+					!app.path.endsWith(".AppImage"),
+			})
 		: null;
 	const comparison = compareQCutVersions({
 		current: app.version,
@@ -390,17 +401,16 @@ async function main() {
 	if (command === "update") {
 		const result = await updateQCutApp({
 			confirmed: args.includes("--confirm"),
+			allowEditorQuit: args.includes("--allow-editor-quit"),
 		});
 		printJson({
 			payload: result,
 			stream: result.status === "ok" ? process.stdout : process.stderr,
 		});
-		process.exitCode =
-			result.status === "ok"
-				? 0
-				: result.code === "qcut:confirmation_required"
-					? 2
-					: 1;
+		const consentRequired =
+			result.code === "qcut:confirmation_required" ||
+			result.code === "qcut:editor_running";
+		process.exitCode = result.status === "ok" ? 0 : consentRequired ? 2 : 1;
 		return;
 	}
 	if (command === "open-media") {

--- a/qcut/plugins/qcut/scripts/qcut-setup.test.mjs
+++ b/qcut/plugins/qcut/scripts/qcut-setup.test.mjs
@@ -228,3 +228,39 @@ test("launches QCut and verifies the requested media page", async () => {
 		["editor:state:snapshot", "--include", "editor,project"],
 	]);
 });
+
+test("status shows the same asset the update path installs", async () => {
+	const { getQCutSetupStatus } = await import("./qcut-setup.mjs");
+	const release = {
+		tag_name: "v2026.07.22.3",
+		html_url:
+			"https://github.com/Quriosity-agent/qcut/releases/tag/v2026.07.22.3",
+		assets: [
+			...assets,
+			{
+				name: "QCut.AI.Video.Editor-2026.7.2203-arm64-mac.zip",
+				browser_download_url:
+					"https://github.com/Quriosity-agent/qcut/releases/download/v2026.07.22.3/QCut.AI.Video.Editor-2026.7.2203-arm64-mac.zip",
+				size: 460_000_000,
+			},
+		],
+	};
+	const status = await getQCutSetupStatus({
+		platform: "darwin",
+		arch: "arm64",
+		app: {
+			installed: true,
+			platform: "darwin",
+			arch: "arm64",
+			path: "/Applications/QCut AI Video Editor.app",
+			version: "2026.7.2103",
+		},
+		resolved: null,
+		fetchImpl: async () => ({ ok: true, json: async () => release }),
+	});
+
+	// The installer uses the signed -mac.zip package, so the asset shown for
+	// confirmation must be the zip, not the dmg.
+	assert.ok(status.data.latest.asset.name.endsWith("-mac.zip"));
+	assert.equal(status.data.updateAvailable, true);
+});

--- a/qcut/plugins/qcut/scripts/qcut-update.mjs
+++ b/qcut/plugins/qcut/scripts/qcut-update.mjs
@@ -26,7 +26,7 @@ import {
 	fetchLatestQCutRelease,
 	trustedReleaseUrl,
 } from "./qcut-release.mjs";
-import { resolveQCutCli, runQCutCommand } from "./qcut-runner.mjs";
+import { inspectQCut, resolveQCutCli, runQCutCommand } from "./qcut-runner.mjs";
 
 const QCUT_MAC_TEAM_ID = "JQ3Q27U24X";
 
@@ -36,6 +36,15 @@ function parseJsonOutput({ output }) {
 	} catch {
 		return null;
 	}
+}
+
+function isMacAppRunning({ spawnSyncImpl }) {
+	const result = spawnSyncImpl(
+		"/usr/bin/osascript",
+		["-e", `application id "${QCUT_BUNDLE_ID}" is running`],
+		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 5000 }
+	);
+	return result.status === 0 && String(result.stdout ?? "").trim() === "true";
 }
 
 function tryInstalledCliUpdater({ resolved, env, run }) {
@@ -322,12 +331,14 @@ function installBootstrapPackage({
 
 export async function updateQCutApp({
 	confirmed = false,
+	allowEditorQuit = false,
 	platform = process.platform,
 	arch = process.arch,
 	env = process.env,
 	app,
 	resolved,
 	run = runQCutCommand,
+	inspect = inspectQCut,
 	fetchRelease = fetchLatestQCutRelease,
 	download = downloadVerifiedInstaller,
 	install = installBootstrapPackage,
@@ -344,6 +355,29 @@ export async function updateQCutApp({
 	const currentApp = app ?? discoverQCutApp({ platform, arch, env });
 	const currentResolved =
 		resolved === undefined ? resolveQCutCli({ env }) : resolved;
+
+	// Updating quits a running editor, so a live session needs its own
+	// explicit consent on top of the update confirmation. Without a CLI the
+	// bootstrap path still force-quits the app on macOS, so fall back to
+	// asking the OS whether the app process is alive.
+	if (!allowEditorQuit) {
+		let editorRunning = false;
+		if (currentResolved) {
+			const editor = inspect({ resolved: currentResolved, env });
+			editorRunning = editor?.data?.editor?.running ?? false;
+		} else if (platform === "darwin" && currentApp.installed) {
+			editorRunning = isMacAppRunning({ spawnSyncImpl });
+		}
+		if (editorRunning) {
+			return {
+				status: "error",
+				code: "qcut:editor_running",
+				error:
+					"QCut is currently running. Warn the user that updating quits the editor (interrupting exports and unsaved work), then rerun with --allow-editor-quit after they agree.",
+				data: { requiredFlag: "--allow-editor-quit" },
+			};
+		}
+	}
 
 	const cliResult = tryInstalledCliUpdater({
 		resolved: currentResolved,

--- a/qcut/plugins/qcut/scripts/qcut-update.test.mjs
+++ b/qcut/plugins/qcut/scripts/qcut-update.test.mjs
@@ -77,6 +77,8 @@ test("does not download when the installed app is current", async () => {
 		confirmed: true,
 		app: { ...oldApp, version: latest.version },
 		resolved: null,
+		// Keep the editor-running probe off the real OS in unit tests.
+		spawnSyncImpl: () => ({ status: 0, stdout: "false\n" }),
 		fetchRelease: async () => latest,
 		download: async () => {
 			downloaded = true;
@@ -138,4 +140,89 @@ test("requests a Debian package when bootstrapping a Debian install", async () =
 
 	assert.equal(result.status, "ok");
 	assert.equal(releaseOptions.preferDeb, true);
+});
+
+test("blocks the update while the editor is running", async () => {
+	const result = await updateQCutApp({
+		confirmed: true,
+		app: oldApp,
+		resolved: { command: "qcut", prefixArgs: [] },
+		inspect: () => ({ status: "ok", data: { editor: { running: true } } }),
+		run: () => {
+			throw new Error("must not delegate to the CLI before consent");
+		},
+	});
+
+	assert.equal(result.status, "error");
+	assert.equal(result.code, "qcut:editor_running");
+	assert.equal(result.data.requiredFlag, "--allow-editor-quit");
+});
+
+test("proceeds past a running editor with explicit consent", async () => {
+	const result = await updateQCutApp({
+		confirmed: true,
+		allowEditorQuit: true,
+		app: oldApp,
+		resolved: { command: "qcut", prefixArgs: [] },
+		inspect: () => {
+			throw new Error("a consented update must not re-inspect the editor");
+		},
+		run: () => ({
+			status: 0,
+			stdout: JSON.stringify({ status: "ok", data: { updated: true } }),
+		}),
+	});
+
+	assert.equal(result.status, "ok");
+	assert.equal(result.data.source, "qcut-cli");
+});
+
+test("updates normally when the editor is not running", async () => {
+	const result = await updateQCutApp({
+		confirmed: true,
+		app: oldApp,
+		resolved: { command: "qcut", prefixArgs: [] },
+		inspect: () => ({ status: "ok", data: { editor: { running: false } } }),
+		run: () => ({
+			status: 0,
+			stdout: JSON.stringify({ status: "ok", data: { updated: true } }),
+		}),
+	});
+
+	assert.equal(result.status, "ok");
+	assert.equal(result.data.source, "qcut-cli");
+});
+
+test("blocks the bootstrap path while the app runs and no CLI resolves", async () => {
+	const result = await updateQCutApp({
+		confirmed: true,
+		platform: "darwin",
+		app: oldApp,
+		resolved: null,
+		spawnSyncImpl: () => ({ status: 0, stdout: "true\n" }),
+		fetchRelease: () => {
+			throw new Error("must not reach the bootstrap before consent");
+		},
+	});
+
+	assert.equal(result.status, "error");
+	assert.equal(result.code, "qcut:editor_running");
+});
+
+test("bootstrap proceeds when the app is not running", async () => {
+	const result = await updateQCutApp({
+		confirmed: true,
+		platform: "darwin",
+		app: oldApp,
+		resolved: null,
+		spawnSyncImpl: () => ({ status: 0, stdout: "false\n" }),
+		fetchRelease: async () => ({
+			checked: true,
+			version: oldApp.version,
+			asset: latest.asset,
+		}),
+	});
+
+	assert.equal(result.status, "ok");
+	assert.equal(result.data.updated, false);
 });

--- a/qcut/plugins/qcut/skills/qcut-cli/SKILL.md
+++ b/qcut/plugins/qcut/skills/qcut-cli/SKILL.md
@@ -30,10 +30,19 @@ asset name, and download size from `status`. After explicit confirmation, run:
 node <plugin-root>/scripts/qcut-setup.mjs update --confirm
 ```
 
+If `status` reports `cli.editorRunning: true` (or the update returns
+`qcut:editor_running`), warn the user that updating quits the running QCut
+editor — interrupting exports and unsaved work — and only after they agree add
+`--allow-editor-quit`:
+
+```bash
+node <plugin-root>/scripts/qcut-setup.mjs update --confirm --allow-editor-quit
+```
+
 The helper delegates to `qcut update --yes` when the installed CLI supports it
 and uses the plugin's verified bootstrap path for older QCut releases. Never add
-`--confirm` without consent. Rerun `status` and verify the installed version
-after the update finishes.
+`--confirm` or `--allow-editor-quit` without consent. Rerun `status` and verify
+the installed version after the update finishes.
 
 Then run this before the first QCut command in the task:
 


### PR DESCRIPTION
## Context

Verified the agent-driven update path end to end on this machine: `qcut-setup.mjs status` → `update --confirm` took the installed app from 2026.8.501 to 2026.8.702 (download, SHA-256 verify, codesign/Gatekeeper check, replace, relaunch) with zero manual steps. The flow works; this PR fixes the five rough edges that surfaced, plus two security findings from an adversarial review of the fix itself.

## Changes

**Confirm what you install** — `getQCutSetupStatus` now requests the release asset with the same `preferArchive`/`preferDeb` preferences as `updateQCutApp`, so the name/size shown for confirmation is the signed `-mac.zip` the installer actually uses, not the dmg.

**Consent before quitting a live editor** — `updateQCutApp` returns `qcut:editor_running` (exit 2) unless `--allow-editor-quit` is passed. The guard covers both paths: CLI delegation (via `editor:health`) and the no-CLI bootstrap (via an osascript process probe — previously the bootstrap force-quit a running editor with only `--confirm`, interrupting exports). [SKILL.md](qcut/plugins/qcut/skills/qcut-cli/SKILL.md) instructs the agent to warn the user first and never add the flag without consent.

**Reuse already-downloaded packages** — `qcut update` probes the app's electron-updater staging cache (`~/Library/Caches/qcut-updater/pending`) and the CLI's own cache before downloading ~460MB again. This directly serves the field case where the app had auto-downloaded the same version repeatedly overnight.

**TOCTOU-safe reuse** — the cached candidate is copied into the run's private 0700 tmpdir and size + streamed SHA-256 are verified **on that private copy**, so verified bytes = installed bytes. Without this, a same-uid process could swap the file at its predictable cache path between the user-context hash and a privileged consumer (`sudo dpkg -i` on the Linux deb path has no post-hash re-verification). Confirmed by adversarial review with a concrete escalation scenario; the copy design closes it for all platforms.

**Failed installs keep their download** — a fully verified download whose install throws is preserved into the CLI cache (path reported in the error); the next attempt reuses it instead of re-downloading. Success discards only CLI-owned preserved files — the app updater's staged packages are never touched.

Also verified (no change needed): with no repo checkout and nothing on PATH, the plugin resolves the CLI from the installed app bundle via `ELECTRON_RUN_AS_NODE` + asar, so the pure-end-user path works.

Plugin version 1.2.0 → 1.3.0 (both manifests, parity test green).

## Review

2-lens adversarial workflow (security / control-flow, 6 agents) over the diff: 4 confirmed findings (TOCTOU-to-root on deb reuse, bootstrap guard bypass ×2, discard-vs-preserveInstaller contract) — all fixed in this PR; 0 refuted survivors.

## Test plan
- [x] 39 plugin tests (`node --test`) incl. new: status/install asset parity, editor-running guard on both paths, consent flag passthrough
- [x] 18 electron vitest incl. new app-update-cache suite: private-copy verification, mismatch rejection + no partial copies, preserve/discard ownership, per-platform cache paths
- [x] `bun check-types` + biome clean
- [x] Live smoke: `qcut update --check` reports up-to-date on 2026.8.702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates reuse verified installer packages when available, reducing unnecessary downloads.
  * Failed updates preserve completed installers for retry.
  * Update checks select the correct platform-specific installation package.
  * Updates detect when the editor is running and require explicit consent before quitting it.
  * Added `--allow-editor-quit` support for command-line updates.
  * Updated the QCut plugin to version 1.3.0.

* **Bug Fixes**
  * Improved handling of invalid, missing, or incomplete installer files.
  * Fixed update status reporting for macOS installation assets.

* **Tests**
  * Added coverage for installer reuse, preservation, platform behavior, and editor-running update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->